### PR TITLE
fix increase_nonce

### DIFF
--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -122,7 +122,7 @@ pub fn increase_nonce(nonce: &mut [u8]) {
 
 #[cfg(not(feature = "sodium"))]
 pub fn increase_nonce(nonce: &mut [u8]) {
-    let mut prev: u16 = 0;
+    let mut prev: u16 = 1;
     for i in nonce {
         prev += *i as u16;
         *i = prev as u8;


### PR DESCRIPTION
The old implementation dose nothing to the nonce, because `prev` is 0.
See also https://github.com/jedisct1/libsodium/blob/569778b517496861a3880e0e690973bf08a52e08/src/libsodium/sodium/utils.c#L239