### PR TITLE
Fix unused warning, simplify assignment

### DIFF
--- a/src/crypto/cipher.rs
+++ b/src/crypto/cipher.rs
@@ -102,6 +102,7 @@ const CIPHER_PLAIN: &str = "plain";
 const CIPHER_AES_128_GCM: &str = "aes-128-gcm";
 const CIPHER_AES_256_GCM: &str = "aes-256-gcm";
 const CIPHER_CHACHA20_IETF_POLY1305: &str = "chacha20-ietf-poly1305";
+#[cfg(feature = "sodium")]
 const CIPHER_XCHACHA20_IETF_POLY1305: &str = "xchacha20-ietf-poly1305";
 
 /// ShadowSocks cipher type

--- a/src/relay/dns_resolver.rs
+++ b/src/relay/dns_resolver.rs
@@ -25,7 +25,7 @@ lazy_static! {
 /// Set address for global DNS resolver
 /// Must be called before servers are actually run
 pub fn set_dns_config(addr: ResolverConfig) {
-    *(&mut *GLOBAL_DNS_ADDRESS.lock()) = Some(addr);
+    *GLOBAL_DNS_ADDRESS.lock() = Some(addr);
 }
 
 fn get_dns_address() -> Option<ResolverConfig> {


### PR DESCRIPTION
When compiling without the `sodium` feature I get a compile warning that a constant is unused. So I added conditional compilation to that constant.

Clippy also showed me that an assignment could be simplified.