### PR TITLE
Don't pass around Copy types as references

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -244,8 +244,8 @@ impl ServerConfig {
     }
 
     /// Get timeout
-    pub fn timeout(&self) -> &Option<Duration> {
-        &self.timeout
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
     }
 
     /// Get plugin

--- a/src/crypto/cipher.rs
+++ b/src/crypto/cipher.rs
@@ -156,8 +156,8 @@ pub enum CipherCategory {
 
 impl CipherType {
     /// Symmetric crypto key size
-    pub fn key_size(&self) -> usize {
-        match *self {
+    pub fn key_size(self) -> usize {
+        match self {
             CipherType::Table | CipherType::Plain => 0,
 
             CipherType::Aes128Cfb1 => symm::Cipher::aes_128_cfb1().key_len(),
@@ -187,7 +187,7 @@ impl CipherType {
         }
     }
 
-    fn classic_bytes_to_key(&self, key: &[u8]) -> Bytes {
+    fn classic_bytes_to_key(self, key: &[u8]) -> Bytes {
         let iv_len = self.iv_size();
         let key_len = self.key_size();
 
@@ -219,13 +219,13 @@ impl CipherType {
     }
 
     /// Extends key to match the required key length
-    pub fn bytes_to_key(&self, key: &[u8]) -> Bytes {
+    pub fn bytes_to_key(self, key: &[u8]) -> Bytes {
         self.classic_bytes_to_key(key)
     }
 
     /// Symmetric crypto initialize vector size
-    pub fn iv_size(&self) -> usize {
-        match *self {
+    pub fn iv_size(self) -> usize {
+        match self {
             CipherType::Table | CipherType::Plain => 0,
 
             CipherType::Aes128Cfb1 => symm::Cipher::aes_128_cfb1()
@@ -282,14 +282,14 @@ impl CipherType {
     }
 
     /// Generate a random initialize vector for this cipher
-    pub fn gen_init_vec(&self) -> Bytes {
+    pub fn gen_init_vec(self) -> Bytes {
         let iv_len = self.iv_size();
         CipherType::gen_random_bytes(iv_len)
     }
 
     /// Get category of cipher
-    pub fn category(&self) -> CipherCategory {
-        match *self {
+    pub fn category(self) -> CipherCategory {
+        match self {
             CipherType::Aes128Gcm | CipherType::Aes256Gcm | CipherType::ChaCha20IetfPoly1305 => CipherCategory::Aead,
 
             #[cfg(feature = "sodium")]
@@ -303,10 +303,10 @@ impl CipherType {
     }
 
     /// Get tag size for AEAD Ciphers
-    pub fn tag_size(&self) -> usize {
+    pub fn tag_size(self) -> usize {
         assert!(self.category() == CipherCategory::Aead);
 
-        match *self {
+        match self {
             CipherType::Aes128Gcm => AES_128_GCM.tag_len(),
             CipherType::Aes256Gcm => AES_256_GCM.tag_len(),
             CipherType::ChaCha20IetfPoly1305 => CHACHA20_POLY1305.tag_len(),
@@ -321,13 +321,13 @@ impl CipherType {
     }
 
     /// Get nonce size for AEAD ciphers
-    pub fn salt_size(&self) -> usize {
+    pub fn salt_size(self) -> usize {
         assert!(self.category() == CipherCategory::Aead);
         self.key_size()
     }
 
     /// Get salt for AEAD ciphers
-    pub fn gen_salt(&self) -> Bytes {
+    pub fn gen_salt(self) -> Bytes {
         CipherType::gen_random_bytes(self.salt_size())
     }
 }

--- a/src/relay/socks5.rs
+++ b/src/relay/socks5.rs
@@ -70,8 +70,8 @@ pub enum Command {
 impl Command {
     #[inline]
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    fn as_u8(&self) -> u8 {
-        match *self {
+    fn as_u8(self) -> u8 {
+        match self {
             Command::TcpConnect   => consts::SOCKS5_CMD_TCP_CONNECT,
             Command::TcpBind      => consts::SOCKS5_CMD_TCP_BIND,
             Command::UdpAssociate => consts::SOCKS5_CMD_UDP_ASSOCIATE,
@@ -109,8 +109,8 @@ pub enum Reply {
 impl Reply {
     #[inline]
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    fn as_u8(&self) -> u8 {
-        match *self {
+    fn as_u8(self) -> u8 {
+        match self {
             Reply::Succeeded               => consts::SOCKS5_REPLY_SUCCEEDED,
             Reply::GeneralFailure          => consts::SOCKS5_REPLY_GENERAL_FAILURE,
             Reply::ConnectionNotAllowed    => consts::SOCKS5_REPLY_CONNECTION_NOT_ALLOWED,

--- a/src/relay/tcprelay/mod.rs
+++ b/src/relay/tcprelay/mod.rs
@@ -230,7 +230,7 @@ fn connect_proxy_server(
     config: Arc<Config>,
     svr_cfg: Arc<ServerConfig>,
 ) -> impl Future<Item = TcpStream, Error = io::Error> + Send {
-    let timeout = *svr_cfg.timeout();
+    let timeout = svr_cfg.timeout();
     trace!("Connecting to proxy {:?}, timeout: {:?}", svr_cfg.addr(), timeout);
     match *svr_cfg.addr() {
         ServerAddr::SocketAddr(ref addr) => {
@@ -261,7 +261,7 @@ pub fn proxy_server_handshake(
     ),
     Error = io::Error,
 > + Send {
-    let timeout = *svr_cfg.timeout();
+    let timeout = svr_cfg.timeout();
     proxy_handshake(remote_stream, svr_cfg).and_then(move |(r_fut, w_fut)| {
         let w_fut = w_fut.and_then(move |enc_w| {
             // Send relay address to remote
@@ -294,7 +294,7 @@ pub fn proxy_handshake(
     Error = io::Error,
 > + Send {
     futures::lazy(|| Ok(remote_stream.split())).and_then(move |(r, w)| {
-        let timeout = svr_cfg.timeout().clone();
+        let timeout = svr_cfg.timeout();
 
         let svr_cfg_cloned = svr_cfg.clone();
 

--- a/src/relay/tcprelay/server.rs
+++ b/src/relay/tcprelay/server.rs
@@ -64,7 +64,7 @@ impl TcpRelayClientHandshake {
         futures::lazy(move || s.peer_addr().map(|p| (s, p))).and_then(|(s, peer_addr)| {
             debug!("Handshaking with peer {}", peer_addr);
 
-            let timeout = *svr_cfg.timeout();
+            let timeout = svr_cfg.timeout();
             proxy_handshake(s, svr_cfg).and_then(move |(r_fut, w_fut)| {
                 r_fut
                     .and_then(move |r| {
@@ -189,7 +189,7 @@ fn handle_client(
     config: Arc<Config>,
     socket: TcpStream,
 ) -> impl Future<Item = (), Error = ()> + Send {
-    if let Err(err) = socket.set_keepalive(*server_cfg.timeout()) {
+    if let Err(err) = socket.set_keepalive(server_cfg.timeout()) {
         error!("Failed to set keep alive: {:?}", err);
     }
 

--- a/src/relay/tcprelay/socks5_local.rs
+++ b/src/relay/tcprelay/socks5_local.rs
@@ -39,7 +39,7 @@ fn handle_socks5_connect(
 ) -> impl Future<Item = (), Error = io::Error> + Send {
     let cloned_addr = addr.clone();
     let cloned_svr_cfg = svr_cfg.clone();
-    let timeout = *svr_cfg.timeout();
+    let timeout = svr_cfg.timeout();
     super::connect_proxy_server(config.clone(), svr_cfg)
         .then(move |res| {
             let (header, r) = match res {
@@ -77,7 +77,7 @@ fn handle_socks5_connect(
         })
         .and_then(move |(svr_s, w)| {
             let svr_cfg = cloned_svr_cfg;
-            let timeout = *svr_cfg.timeout();
+            let timeout = svr_cfg.timeout();
             super::proxy_server_handshake(svr_s, svr_cfg, addr).and_then(move |(svr_r, svr_w)| {
                 let cloned_timeout = timeout;
                 let rhalf = svr_r.and_then(move |svr_r| svr_r.copy_timeout_opt(w, timeout));
@@ -94,7 +94,7 @@ fn handle_socks5_client(
     conf: Arc<ServerConfig>,
     udp_conf: UdpConfig,
 ) -> io::Result<()> {
-    if let Err(err) = s.set_keepalive(*conf.timeout()) {
+    if let Err(err) = s.set_keepalive(conf.timeout()) {
         error!("Failed to set keep alive: {:?}", err);
     }
 

--- a/src/relay/udprelay/server.rs
+++ b/src/relay/udprelay/server.rs
@@ -54,7 +54,7 @@ fn listen(config: Arc<Config>, svr_cfg: Arc<ServerConfig>) -> impl Future<Item =
             let svr_cfg_cloned = svr_cfg.clone();
             let socket = socket.clone();
             let config = config.clone();
-            let timeout = *svr_cfg.timeout();
+            let timeout = svr_cfg.timeout();
             let rel = futures::lazy(move || decrypt_payload(svr_cfg.method(), svr_cfg.key(), &pkt))
                 .and_then(move |payload| {
                     // Read Address in the front (ShadowSocks protocol)


### PR DESCRIPTION
I hope this does not come off as me complaining about style, that is not my intention :)

I just opened the code in my IDE that runs the Clippy linter on everything by default, and I noticed a few things it mentioned. Passing `Copy` types around by reference is not needed, and discouraged by Clippy since it can lead to less optimal code being generated. This PR makes the `Copy` types be sent by value instead.