### PR TITLE
Feature gate RC4 cipher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ lto = true
 [features]
 default = ["sodium"]
 sodium = ["libsodium-ffi"]
+rc4 = []
 
 [dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/bin/ssdns.rs"
 lto = true
 
 [features]
-default = ["sodium"]
+default = ["sodium", "rc4"]
 sodium = ["libsodium-ffi"]
 rc4 = []
 

--- a/src/crypto/cipher.rs
+++ b/src/crypto/cipher.rs
@@ -78,7 +78,9 @@ const CIPHER_AES_256_CFB_1: &str = "aes-256-cfb1";
 const CIPHER_AES_256_CFB_8: &str = "aes-256-cfb8";
 const CIPHER_AES_256_CFB_128: &str = "aes-256-cfb128";
 
+#[cfg(feature = "rc4")]
 const CIPHER_RC4: &str = "rc4";
+#[cfg(feature = "rc4")]
 const CIPHER_RC4_MD5: &str = "rc4-md5";
 
 const CIPHER_TABLE: &str = "table";
@@ -120,7 +122,9 @@ pub enum CipherType {
     Aes256Cfb8,
     Aes256Cfb128,
 
+    #[cfg(feature = "rc4")]
     Rc4,
+    #[cfg(feature = "rc4")]
     Rc4Md5,
 
     #[cfg(feature = "sodium")]
@@ -167,6 +171,7 @@ impl CipherType {
             CipherType::Aes256Cfb8 => symm::Cipher::aes_256_cfb8().key_len(),
             CipherType::Aes256Cfb | CipherType::Aes256Cfb128 => symm::Cipher::aes_256_cfb128().key_len(),
 
+            #[cfg(feature = "rc4")]
             CipherType::Rc4 | CipherType::Rc4Md5 => symm::Cipher::rc4().key_len(),
 
             #[cfg(feature = "sodium")]
@@ -247,7 +252,9 @@ impl CipherType {
                 .iv_len()
                 .expect("iv_len should not be None"),
 
+            #[cfg(feature = "rc4")]
             CipherType::Rc4 => symm::Cipher::rc4().iv_len().expect("iv_len should not be None"),
+            #[cfg(feature = "rc4")]
             CipherType::Rc4Md5 => 16,
 
             #[cfg(feature = "sodium")]
@@ -349,7 +356,9 @@ impl FromStr for CipherType {
             CIPHER_AES_256_CFB_8 => Ok(CipherType::Aes256Cfb8),
             CIPHER_AES_256_CFB_128 => Ok(CipherType::Aes256Cfb128),
 
+            #[cfg(feature = "rc4")]
             CIPHER_RC4 => Ok(CipherType::Rc4),
+            #[cfg(feature = "rc4")]
             CIPHER_RC4_MD5 => Ok(CipherType::Rc4Md5),
 
             #[cfg(feature = "sodium")]
@@ -393,7 +402,9 @@ impl Display for CipherType {
             CipherType::Aes256Cfb8 => write!(f, "{}", CIPHER_AES_256_CFB_8),
             CipherType::Aes256Cfb128 => write!(f, "{}", CIPHER_AES_256_CFB_128),
 
+            #[cfg(feature = "rc4")]
             CipherType::Rc4 => write!(f, "{}", CIPHER_RC4),
+            #[cfg(feature = "rc4")]
             CipherType::Rc4Md5 => write!(f, "{}", CIPHER_RC4_MD5),
 
             #[cfg(feature = "sodium")]
@@ -439,6 +450,7 @@ mod test_cipher {
         assert!(message.as_bytes() == &decrypted_msg[..]);
     }
 
+    #[cfg(feature = "rc4")]
     #[test]
     fn test_rc4_md5_key_iv() {
         let ty = CipherType::Rc4Md5;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -15,6 +15,7 @@ pub mod cipher;
 pub mod digest;
 pub mod dummy;
 pub mod openssl;
+#[cfg(feature = "rc4")]
 pub mod rc4_md5;
 pub mod ring;
 #[cfg(feature = "miscreant")]

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -26,6 +26,7 @@ impl OpenSSLCrypto {
             CipherType::Aes256Cfb1 => symm::Cipher::aes_256_cfb1(),
             CipherType::Aes256Cfb128 => symm::Cipher::aes_256_cfb128(),
 
+            #[cfg(feature = "rc4")]
             CipherType::Rc4 => symm::Cipher::rc4(),
             _ => panic!("Cipher type {:?} does not supported by OpenSSLCrypt yet", cipher_type),
         };

--- a/src/crypto/stream.rs
+++ b/src/crypto/stream.rs
@@ -2,11 +2,12 @@
 
 #[cfg(feature = "sodium")]
 use crypto::sodium;
+#[cfg(feature = "rc4")]
+use crypto::rc4_md5;
 use crypto::{
     cipher::{CipherCategory, CipherResult, CipherType},
     dummy,
     openssl,
-    rc4_md5,
     table,
     CryptoMode,
 };
@@ -85,6 +86,7 @@ macro_rules! define_stream_ciphers {
 define_stream_ciphers! {
     pub TableCipher => table::TableCipher,
     pub DummyCipher => dummy::DummyCipher,
+    #[cfg(feature = "rc4")]
     pub Rc4Md5Cipher => rc4_md5::Rc4Md5Cipher,
     pub OpenSSLCipher => openssl::OpenSSLCipher,
     #[cfg(feature = "sodium")]
@@ -107,6 +109,7 @@ pub fn new_stream(t: CipherType, key: &[u8], iv: &[u8], mode: CryptoMode) -> Str
             StreamCipherVariant::new(sodium::SodiumStreamCipher::new(t, key, iv))
         }
 
+        #[cfg(feature = "rc4")]
         CipherType::Rc4Md5 => StreamCipherVariant::new(rc4_md5::Rc4Md5Cipher::new(key, iv, mode)),
 
         _ => StreamCipherVariant::new(openssl::OpenSSLCipher::new(t, key, iv, mode)),


### PR DESCRIPTION
Hi. Would it be OK to feature gate the RC4 cipher? This crypto is considered quite broken, and we are trying to link towards our a stripped down version of OpenSSL without RC4 support. We can't do that while this crate is using RC4 functions however.

I have enabled this feature by default, so merging this PR should not cause any real change to the project as is, but for those who want to get rid of RC4 they can now build with `--no-default-features` if they want to.