### PR TITLE
Fix .travis.yml to actually build on beta and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: rust
 matrix:
-    - rust: stable
-    - rust: beta
-    - rust: nightly
-      env: BUILD_WITH_FEATURE="--features miscreant"
+    include:
+        - rust: stable
+        - rust: beta
+        - rust: nightly
+          env: BUILD_WITH_FEATURE="--features miscreant"
 
 cache: cargo
 


### PR DESCRIPTION
It looks like, from the config, that you want the CI to run on all three release channel. However, it looks like Travis actually only runs on stable currently. This should hopefully fix that.