### PR TITLE
Apply cargo fix --edition and upgrade to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/zonyitoo/shadowsocks-rust"
 documentation = "https://docs.rs/shadowsocks-rust"
 keywords = ["shadowsocks", "proxy", "socks", "socks5", "firewall"]
 license = "MIT"
+edition = "2018"
 
 [lib]
 name = "shadowsocks"

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,8 +64,8 @@ use serde_urlencoded;
 use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig};
 use url::{self, Url};
 
-use crypto::cipher::CipherType;
-use plugin::PluginConfig;
+use crate::crypto::cipher::CipherType;
+use crate::plugin::PluginConfig;
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct SSConfig {

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,8 +9,8 @@ use std::{
 use lru_cache::LruCache;
 use trust_dns_resolver::AsyncResolver;
 
-use config::Config;
-use relay::dns_resolver::create_resolver;
+use crate::config::Config;
+use crate::relay::dns_resolver::create_resolver;
 
 type DnsQueryCache = LruCache<u16, (SocketAddr, Instant)>;
 

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -4,7 +4,7 @@ use crate::crypto::cipher::{CipherCategory, CipherResult, CipherType};
 
 use crate::crypto::ring::RingAeadCipher;
 #[cfg(feature = "miscreant")]
-use crypto::siv::MiscreantCipher;
+use crate::crypto::siv::MiscreantCipher;
 #[cfg(feature = "sodium")]
 use crate::crypto::sodium::SodiumAeadCipher;
 

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -1,12 +1,12 @@
 //! Aead Ciphers
 
-use crypto::cipher::{CipherCategory, CipherResult, CipherType};
+use crate::crypto::cipher::{CipherCategory, CipherResult, CipherType};
 
-use crypto::ring::RingAeadCipher;
+use crate::crypto::ring::RingAeadCipher;
 #[cfg(feature = "miscreant")]
 use crypto::siv::MiscreantCipher;
 #[cfg(feature = "sodium")]
-use crypto::sodium::SodiumAeadCipher;
+use crate::crypto::sodium::SodiumAeadCipher;
 
 use bytes::{Bytes, BytesMut};
 use ring::{digest::SHA1, hkdf, hmac::SigningKey};

--- a/src/crypto/cipher.rs
+++ b/src/crypto/cipher.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use bytes::{BufMut, Bytes, BytesMut};
-use crypto::digest::{self, Digest, DigestType};
+use crate::crypto::digest::{self, Digest, DigestType};
 use openssl::symm;
 use rand::{self, RngCore};
 use ring::aead::{AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305};
@@ -433,7 +433,7 @@ impl Display for CipherType {
 
 #[cfg(test)]
 mod test_cipher {
-    use crypto::{new_stream, CipherType, CryptoMode, StreamCipher};
+    use crate::crypto::{new_stream, CipherType, CryptoMode, StreamCipher};
 
     #[test]
     fn test_get_cipher() {

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,9 +1,7 @@
 //! Crypto methods for shadowsocks
 
 use std::convert::From;
-
-use openssl::symm;
-
+use crate::openssl::symm;
 pub use self::{
     aead::{new_aead_decryptor, new_aead_encryptor, AeadDecryptor, AeadEncryptor, BoxAeadDecryptor, BoxAeadEncryptor},
     cipher::{CipherCategory, CipherResult, CipherType},

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -2,9 +2,9 @@
 
 use std::convert::From;
 
-use crypto::{cipher, CipherResult, CipherType, StreamCipher};
+use crate::crypto::{cipher, CipherResult, CipherType, StreamCipher};
 
-use crypto::CryptoMode;
+use crate::crypto::CryptoMode;
 
 use bytes::{BufMut, BytesMut};
 use openssl::symm;

--- a/src/crypto/rc4_md5.rs
+++ b/src/crypto/rc4_md5.rs
@@ -1,6 +1,6 @@
 //! Rc4Md5 cipher definition
 
-use crypto::{
+use crate::crypto::{
     digest::{self, Digest, DigestType},
     openssl::OpenSSLCrypto,
     CipherResult,
@@ -49,7 +49,7 @@ unsafe impl Send for Rc4Md5Cipher {}
 #[cfg(test)]
 mod test {
     use super::*;
-    use crypto::{CipherType, CryptoMode, StreamCipher};
+    use crate::crypto::{CipherType, CryptoMode, StreamCipher};
 
     #[test]
     fn test_rc4_md5_cipher() {

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -4,7 +4,7 @@ use std::{mem, ptr};
 
 use ring::aead::{open_in_place, seal_in_place, OpeningKey, SealingKey, AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305};
 
-use crypto::{
+use crate::crypto::{
     aead::{increase_nonce, make_skey},
     cipher::Error,
     AeadDecryptor,
@@ -154,7 +154,7 @@ impl AeadDecryptor for RingAeadCipher {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crypto::CipherType;
+    use crate::crypto::CipherType;
 
     fn test_ring_aead(ct: CipherType) {
         let key = ct.bytes_to_key(b"PassWORD");

--- a/src/crypto/siv.rs
+++ b/src/crypto/siv.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 use miscreant::aead::{Aes128PmacSiv, Aes256PmacSiv, Algorithm};
 
-use crypto::{
+use crate::crypto::{
     aead::{increase_nonce, make_skey},
     cipher::Error,
     AeadDecryptor,
@@ -135,7 +135,6 @@ impl AeadDecryptor for MiscreantCipher {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crypto::{AeadDecryptor, AeadEncryptor, CipherType};
 
     fn test_miscreant(ct: CipherType) {
         let key = ct.bytes_to_key(b"PassWORD");

--- a/src/crypto/sodium.rs
+++ b/src/crypto/sodium.rs
@@ -18,7 +18,7 @@ use libsodium_ffi::{
     sodium_init,
 };
 
-use crypto::{
+use crate::crypto::{
     aead::{increase_nonce, make_skey},
     cipher::Error,
     AeadDecryptor,
@@ -266,7 +266,7 @@ impl AeadDecryptor for SodiumAeadCipher {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crypto::{CipherType, StreamCipher};
+    use crate::crypto::{CipherType, StreamCipher};
 
     fn test_sodium(ct: CipherType) {
         let key = ct.bytes_to_key(b"PassWORD");

--- a/src/crypto/stream.rs
+++ b/src/crypto/stream.rs
@@ -3,10 +3,10 @@
 use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "rc4")]
-use crypto::rc4_md5;
+use crate::crypto::rc4_md5;
 #[cfg(feature = "sodium")]
-use crypto::sodium;
-use crypto::{
+use crate::crypto::sodium;
+use crate::crypto::{
     cipher::{CipherCategory, CipherResult, CipherType},
     dummy,
     openssl,

--- a/src/crypto/table.rs
+++ b/src/crypto/table.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use crypto::{
+use crate::crypto::{
     digest::{self, Digest, DigestType},
     CipherResult,
     CryptoMode,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -8,8 +8,8 @@ use tokio_io::IoFuture;
 
 use futures::{self, stream::futures_unordered, Future, Stream};
 
-use plugin::Plugin;
-use relay::boxed_future;
+use crate::plugin::Plugin;
+use crate::relay::boxed_future;
 
 #[cfg(unix)]
 pub fn monitor_signal(plugins: Vec<Plugin>) -> impl Future<Item = (), Error = io::Error> + Send {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -19,7 +19,7 @@ use std::{
 
 use subprocess::{Popen, Result as PopenResult};
 
-use config::{Config, ServerAddr};
+use crate::config::{Config, ServerAddr};
 
 mod obfs_proxy;
 mod ss_plugin;

--- a/src/plugin/obfs_proxy.rs
+++ b/src/plugin/obfs_proxy.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use subprocess::{Exec, Popen, Result as PopenResult};
 
-use config::ServerAddr;
+use crate::config::ServerAddr;
 
 use super::{PluginConfig, PluginMode};
 

--- a/src/plugin/ss_plugin.rs
+++ b/src/plugin/ss_plugin.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use subprocess::{Exec, NullFile, Popen, Result as PopenResult};
 
-use config::ServerAddr;
+use crate::config::ServerAddr;
 
 use super::{PluginConfig, PluginMode};
 

--- a/src/relay/dns.rs
+++ b/src/relay/dns.rs
@@ -4,9 +4,9 @@ use std::io;
 
 use futures::{self, Future};
 
-use config::Config;
-use context::{Context, SharedContext};
-use relay::udprelay::dns::run as run_udp;
+use crate::config::Config;
+use crate::context::{Context, SharedContext};
+use crate::relay::udprelay::dns::run as run_udp;
 
 /// DNS Relay server running under local environment.
 pub fn run(config: Config) -> impl Future<Item = (), Error = io::Error> + Send {

--- a/src/relay/dns_resolver.rs
+++ b/src/relay/dns_resolver.rs
@@ -9,7 +9,7 @@ use futures::Future;
 use tokio;
 use trust_dns_resolver::{config::ResolverConfig, AsyncResolver};
 
-use context::SharedContext;
+use crate::context::SharedContext;
 
 pub fn create_resolver(dns: Option<ResolverConfig>) -> AsyncResolver {
     let (resolver, bg) = {

--- a/src/relay/loadbalancing/server/mod.rs
+++ b/src/relay/loadbalancing/server/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 pub use self::roundrobin::RoundRobin;
 
-use config::ServerConfig;
+use crate::config::ServerConfig;
 
 pub mod roundrobin;
 

--- a/src/relay/loadbalancing/server/roundrobin.rs
+++ b/src/relay/loadbalancing/server/roundrobin.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
-use config::{Config, ServerConfig};
-use relay::loadbalancing::server::LoadBalancer;
+use crate::config::{Config, ServerConfig};
+use crate::relay::loadbalancing::server::LoadBalancer;
 
 #[derive(Clone)]
 pub struct RoundRobin {

--- a/src/relay/local.rs
+++ b/src/relay/local.rs
@@ -4,10 +4,10 @@ use std::io;
 
 use futures::{stream::futures_unordered, Future, Stream};
 
-use config::Config;
-use context::{Context, SharedContext};
-use plugin::{launch_plugin, PluginMode};
-use relay::{boxed_future, tcprelay::local::run as run_tcp, udprelay::local::run as run_udp};
+use crate::config::Config;
+use crate::context::{Context, SharedContext};
+use crate::plugin::{launch_plugin, PluginMode};
+use crate::relay::{boxed_future, tcprelay::local::run as run_tcp, udprelay::local::run as run_udp};
 
 /// Relay server running under local environment.
 ///
@@ -52,7 +52,7 @@ pub fn run(config: Config) -> impl Future<Item = (), Error = io::Error> + Send {
 
         // Hold it here, kill all plugins when `tokio::run` is finished
         let plugins = launch_plugin(context.config_mut(), PluginMode::Client).expect("Failed to launch plugins");
-        let mon = ::monitor::monitor_signal(plugins);
+        let mon = crate::monitor::monitor_signal(plugins);
 
         let tcp_fut = run_tcp(SharedContext::new(context));
 

--- a/src/relay/server.rs
+++ b/src/relay/server.rs
@@ -4,10 +4,10 @@ use std::io;
 
 use futures::{stream::futures_unordered, Future, Stream};
 
-use config::Config;
-use context::{Context, SharedContext};
-use plugin::{launch_plugin, PluginMode};
-use relay::{boxed_future, tcprelay::server::run as run_tcp, udprelay::server::run as run_udp};
+use crate::config::Config;
+use crate::context::{Context, SharedContext};
+use crate::plugin::{launch_plugin, PluginMode};
+use crate::relay::{boxed_future, tcprelay::server::run as run_tcp, udprelay::server::run as run_udp};
 
 /// Relay server running on server side.
 ///
@@ -53,7 +53,7 @@ pub fn run(config: Config) -> impl Future<Item = (), Error = io::Error> + Send {
         if context.config().mode.enable_tcp() {
             // Hold it here, kill all plugins when `tokio::run` is finished
             let plugins = launch_plugin(context.config_mut(), PluginMode::Server).expect("Failed to launch plugins");
-            let mon = ::monitor::monitor_signal(plugins);
+            let mon = crate::monitor::monitor_signal(plugins);
 
             let tcp_fut = run_tcp(SharedContext::new(context));
 

--- a/src/relay/tcprelay/aead.rs
+++ b/src/relay/tcprelay/aead.rs
@@ -42,7 +42,7 @@ use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, BytesMut};
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use crypto::{self, BoxAeadDecryptor, BoxAeadEncryptor, CipherType};
+use crate::crypto::{self, BoxAeadDecryptor, BoxAeadEncryptor, CipherType};
 
 use super::{DecryptedRead, EncryptedWrite, BUFFER_SIZE};
 

--- a/src/relay/tcprelay/client.rs
+++ b/src/relay/tcprelay/client.rs
@@ -10,7 +10,7 @@ use tokio_io::{io::flush, AsyncRead, AsyncWrite};
 
 use futures::{self, Async, Future, Poll};
 
-use relay::socks5::{
+use crate::relay::socks5::{
     self,
     Address,
     Command,

--- a/src/relay/tcprelay/context.rs
+++ b/src/relay/tcprelay/context.rs
@@ -10,9 +10,9 @@ use std::{
     time::Duration,
 };
 
-use config::{ServerAddr, ServerConfig};
-use context::SharedContext;
-use relay::{boxed_future, dns_resolver::resolve};
+use crate::config::{ServerAddr, ServerConfig};
+use crate::context::SharedContext;
+use crate::relay::{boxed_future, dns_resolver::resolve};
 
 use futures::{future, Future, Stream};
 use tokio::{self, net::UdpSocket, timer::Interval};

--- a/src/relay/tcprelay/local.rs
+++ b/src/relay/tcprelay/local.rs
@@ -5,7 +5,7 @@ use std::io;
 use futures::Future;
 
 use super::socks5_local;
-use context::SharedContext;
+use crate::context::SharedContext;
 
 /// Starts a TCP local server
 pub fn run(context: SharedContext) -> impl Future<Item = (), Error = io::Error> + Send {

--- a/src/relay/tcprelay/mod.rs
+++ b/src/relay/tcprelay/mod.rs
@@ -9,10 +9,10 @@ use std::{
     time::Duration,
 };
 
-use config::{ConfigType, ServerAddr, ServerConfig};
-use context::SharedContext;
-use crypto::CipherCategory;
-use relay::{boxed_future, dns_resolver::resolve, socks5::Address};
+use crate::config::{ConfigType, ServerAddr, ServerConfig};
+use crate::context::SharedContext;
+use crate::crypto::CipherCategory;
+use crate::relay::{boxed_future, dns_resolver::resolve, socks5::Address};
 
 use tokio::{
     net::{tcp::ConnectFuture, TcpStream},

--- a/src/relay/tcprelay/server.rs
+++ b/src/relay/tcprelay/server.rs
@@ -7,14 +7,14 @@ use std::{
     time::Duration,
 };
 
-use relay::{
+use crate::relay::{
     boxed_future,
     dns_resolver::resolve,
     socks5::Address,
     tcprelay::crypto_io::{DecryptedRead, EncryptedWrite},
 };
 
-use context::SharedContext;
+use crate::context::SharedContext;
 
 use futures::{
     self,

--- a/src/relay/tcprelay/socks5_local.rs
+++ b/src/relay/tcprelay/socks5_local.rs
@@ -13,10 +13,10 @@ use tokio_io::{
     AsyncRead,
 };
 
-use config::ServerConfig;
-use context::SharedContext;
+use crate::config::ServerConfig;
+use crate::context::SharedContext;
 
-use relay::{
+use crate::relay::{
     boxed_future,
     loadbalancing::server::{LoadBalancer, RoundRobin},
     socks5::{self, Address, HandshakeRequest, HandshakeResponse, TcpRequestHeader, TcpResponseHeader},
@@ -51,7 +51,7 @@ fn handle_socks5_connect(
                     (header, Ok(svr_s))
                 }
                 Err(err) => {
-                    use relay::socks5::Reply;
+                    use crate::relay::socks5::Reply;
                     use std::io::ErrorKind;
 
                     error!("Failed to connect remote server, err: {}", err);

--- a/src/relay/tcprelay/stream.rs
+++ b/src/relay/tcprelay/stream.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::{BufMut, BytesMut};
-use crypto::{new_stream, BoxStreamCipher, CipherType, CryptoMode, StreamCipher};
+use crate::crypto::{new_stream, BoxStreamCipher, CipherType, CryptoMode, StreamCipher};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::{DecryptedRead, EncryptedWrite, BUFFER_SIZE};

--- a/src/relay/udprelay/crypto_io.rs
+++ b/src/relay/udprelay/crypto_io.rs
@@ -22,7 +22,7 @@
 
 use std::io;
 
-use crypto::{self, CipherCategory, CipherType, CryptoMode, StreamCipher};
+use crate::crypto::{self, CipherCategory, CipherType, CryptoMode, StreamCipher};
 
 /// Encrypt payload into ShadowSocks UDP encrypted packet
 pub fn encrypt_payload(t: CipherType, key: &[u8], payload: &[u8]) -> io::Result<Vec<u8>> {

--- a/src/relay/udprelay/dns.rs
+++ b/src/relay/udprelay/dns.rs
@@ -18,9 +18,9 @@ use super::{
     SendDgramRc,
     SharedUdpSocket,
 };
-use config::{ServerAddr, ServerConfig};
-use context::SharedContext;
-use relay::{boxed_future, dns_resolver::resolve, socks5::Address};
+use crate::config::{ServerAddr, ServerConfig};
+use crate::context::SharedContext;
+use crate::relay::{boxed_future, dns_resolver::resolve, socks5::Address};
 
 struct PrettyRRData<'a> {
     data: &'a RRData<'a>,

--- a/src/relay/udprelay/local.rs
+++ b/src/relay/udprelay/local.rs
@@ -11,9 +11,9 @@ use futures::{self, Future, Stream};
 
 use tokio::{self, net::UdpSocket, util::FutureExt};
 
-use config::{ServerAddr, ServerConfig};
-use context::SharedContext;
-use relay::{
+use crate::config::{ServerAddr, ServerConfig};
+use crate::context::SharedContext;
+use crate::relay::{
     boxed_future,
     dns_resolver::resolve,
     loadbalancing::server::{LoadBalancer, RoundRobin},

--- a/src/relay/udprelay/server.rs
+++ b/src/relay/udprelay/server.rs
@@ -11,9 +11,9 @@ use futures::{self, stream::futures_unordered, Future, Stream};
 
 use tokio::{self, net::UdpSocket, util::FutureExt};
 
-use config::ServerConfig;
-use context::SharedContext;
-use relay::{boxed_future, dns_resolver::resolve, socks5::Address};
+use crate::config::ServerConfig;
+use crate::context::SharedContext;
+use crate::relay::{boxed_future, dns_resolver::resolve, socks5::Address};
 
 use super::{
     crypto_io::{decrypt_payload, encrypt_payload},


### PR DESCRIPTION
Upgrading to Rust 2018 gives us access to NLL and other new features. As well as the async ecosystem whenever it's stabilized. The earlier one jumps to 2018 the smaller the hurdle likely.

After this it's also possible to get rid of basically all `extern crate` statements. But I did not want to make this PR too complex, so refrained from that here and now.