### PR TITLE
Misc simplification

### DIFF
--- a/src/bin/ssurl.rs
+++ b/src/bin/ssurl.rs
@@ -15,8 +15,8 @@ use shadowsocks::{
     VERSION,
 };
 
-const BLACK: &'static str = "\x1b[40m  \x1b[0m";
-const WHITE: &'static str = "\x1b[47m  \x1b[0m";
+const BLACK: &str = "\x1b[40m  \x1b[0m";
+const WHITE: &str = "\x1b[47m  \x1b[0m";
 
 fn print_qrcode(encoded: &str) {
     let qrcode = QrCode::new(encoded.as_bytes()).unwrap();
@@ -24,7 +24,7 @@ fn print_qrcode(encoded: &str) {
     for _ in 0..qrcode.width() + 2 {
         print!("{}", WHITE);
     }
-    println!("");
+    println!();
 
     for y in 0..qrcode.width() {
         print!("{}", WHITE);
@@ -42,7 +42,7 @@ fn print_qrcode(encoded: &str) {
     for _ in 0..qrcode.width() + 2 {
         print!("{}", WHITE);
     }
-    println!("");
+    println!();
 }
 
 fn encode(filename: &str, need_qrcode: bool) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,12 +220,12 @@ impl ServerConfig {
         let enc_key = method.bytes_to_key(pwd.as_bytes());
         trace!("Initialize config with pwd: {:?}, key: {:?}", pwd, enc_key);
         ServerConfig {
-            addr: addr,
+            addr,
             password: pwd,
-            method: method,
-            timeout: timeout,
-            enc_key: enc_key,
-            plugin: plugin,
+            method,
+            timeout,
+            enc_key,
+            plugin,
             udp_timeout: None,
             plugin_addr: None,
         }
@@ -566,11 +566,7 @@ pub struct Error {
 
 impl Error {
     pub fn new(kind: ErrorKind, desc: &'static str, detail: Option<String>) -> Error {
-        Error {
-            kind: kind,
-            desc: desc,
-            detail: detail,
-        }
+        Error { kind, desc, detail }
     }
 }
 
@@ -608,7 +604,7 @@ impl Config {
             mode: Mode::TcpOnly,
             no_delay: false,
             manager_address: None,
-            config_type: config_type,
+            config_type,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,8 +64,7 @@ use serde_urlencoded;
 use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig};
 use url::{self, Url};
 
-use crate::crypto::cipher::CipherType;
-use crate::plugin::PluginConfig;
+use crate::{crypto::cipher::CipherType, plugin::PluginConfig};
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct SSConfig {
@@ -689,7 +688,6 @@ impl Config {
                 let udp_timeout = config.udp_timeout.map(Duration::from_secs);
 
                 let mut nsvr = ServerConfig::new(addr, pwd, method, timeout, plugin);
-
 
                 nsvr.udp_timeout = udp_timeout;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,9 +9,7 @@ use std::{
 use lru_cache::LruCache;
 use trust_dns_resolver::AsyncResolver;
 
-use crate::config::Config;
-use crate::plugin::Plugin;
-use crate::relay::dns_resolver::create_resolver;
+use crate::{config::Config, plugin::Plugin, relay::dns_resolver::create_resolver};
 
 type DnsQueryCache = LruCache<u16, (SocketAddr, Instant)>;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,7 @@ impl Context {
     pub fn new(config: Config) -> Context {
         let resolver = create_resolver(config.get_dns_config());
         Context {
-            config: config,
+            config,
             dns_resolver: Arc::new(resolver),
             dns_query_cache: None,
             plugins: Arc::new(Vec::new()),
@@ -37,7 +37,7 @@ impl Context {
     pub fn new_dns(config: Config) -> Context {
         let resolver = create_resolver(config.get_dns_config());
         Context {
-            config: config,
+            config,
             dns_resolver: Arc::new(resolver),
             dns_query_cache: Some(Arc::new(Mutex::new(LruCache::new(1024)))),
             plugins: Arc::new(Vec::new()),

--- a/src/crypto/aead.rs
+++ b/src/crypto/aead.rs
@@ -77,7 +77,7 @@ pub fn new_aead_decryptor(t: CipherType, key: &[u8], nonce: &[u8]) -> BoxAeadDec
     }
 }
 
-const SUBKEY_INFO: &'static [u8] = b"ss-subkey";
+const SUBKEY_INFO: &[u8] = b"ss-subkey";
 
 /// Make Session key
 ///

--- a/src/crypto/cipher.rs
+++ b/src/crypto/cipher.rs
@@ -8,8 +8,8 @@ use std::{
     str::{self, FromStr},
 };
 
-use bytes::{BufMut, Bytes, BytesMut};
 use crate::crypto::digest::{self, Digest, DigestType};
+use bytes::{BufMut, Bytes, BytesMut};
 use openssl::symm;
 use rand::{self, RngCore};
 use ring::aead::{AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305};

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,12 +1,12 @@
 //! Crypto methods for shadowsocks
 
-use std::convert::From;
-use crate::openssl::symm;
 pub use self::{
     aead::{new_aead_decryptor, new_aead_encryptor, AeadDecryptor, AeadEncryptor, BoxAeadDecryptor, BoxAeadEncryptor},
     cipher::{CipherCategory, CipherResult, CipherType},
     stream::{new_stream, BoxStreamCipher, StreamCipher},
 };
+use crate::openssl::symm;
+use std::convert::From;
 
 pub mod aead;
 pub mod cipher;

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -48,10 +48,10 @@ impl RingAeadCipher {
         let skey = make_skey(t, key, salt);
         let cipher = RingAeadCipher::new_variant(t, &skey, &nonce, is_seal);
         RingAeadCipher {
-            cipher: cipher,
+            cipher,
             cipher_type: t,
             key: skey,
-            nonce: nonce,
+            nonce,
         }
     }
 

--- a/src/crypto/sodium.rs
+++ b/src/crypto/sodium.rs
@@ -184,7 +184,7 @@ impl SodiumAeadCipher {
         SodiumAeadCipher {
             cipher_type: t,
             key: skey,
-            nonce: nonce,
+            nonce,
         }
     }
 

--- a/src/crypto/table.rs
+++ b/src/crypto/table.rs
@@ -30,8 +30,8 @@ impl TableCipher {
         let a = bufr.read_u64::<LittleEndian>().unwrap();
 
         let mut table = [0u64; TABLE_SIZE];
-        for i in 0..TABLE_SIZE {
-            table[i] = i as u64;
+        for (i, element) in table.iter_mut().enumerate() {
+            *element = i as u64;
         }
 
         for i in 1..1024 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ extern crate typenum;
 extern crate url;
 
 /// ShadowSocks version
-pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub use self::{
     config::{ClientConfig, Config, ConfigType, Mode, ServerAddr, ServerConfig},

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -8,8 +8,7 @@ use tokio_io::IoFuture;
 
 use futures::{self, stream::futures_unordered, Future, Stream};
 
-use crate::plugin::Plugin;
-use crate::relay::boxed_future;
+use crate::{plugin::Plugin, relay::boxed_future};
 
 #[cfg(unix)]
 pub fn monitor_signal() -> impl Future<Item = (), Error = io::Error> + Send {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -41,15 +41,7 @@ pub enum PluginMode {
 /// Plugin holder
 #[derive(Debug)]
 pub struct Plugin {
-    addr: ServerAddr,
     process: Popen,
-}
-
-impl Plugin {
-    /// Get address of the plugin
-    pub fn addr(&self) -> &ServerAddr {
-        &self.addr
-    }
 }
 
 impl Drop for Plugin {
@@ -74,12 +66,9 @@ pub fn launch_plugin(config: &mut Config, mode: PluginMode) -> io::Result<Vec<Pl
                 Err(err) => {
                     panic!("Failed to start plugin \"{}\", err: {}", c.plugin, err);
                 }
-                Ok(p) => {
+                Ok(process) => {
                     let svr_addr = ServerAddr::SocketAddr(local_addr);
-                    plugins.push(Plugin {
-                        addr: svr_addr.clone(),
-                        process: p,
-                    });
+                    plugins.push(Plugin { process });
 
                     // Replace addr with plugin
                     svr_addr

--- a/src/relay/dns.rs
+++ b/src/relay/dns.rs
@@ -4,9 +4,11 @@ use std::io;
 
 use futures::{self, Future};
 
-use crate::config::Config;
-use crate::context::{Context, SharedContext};
-use crate::relay::udprelay::dns::run as run_udp;
+use crate::{
+    config::Config,
+    context::{Context, SharedContext},
+    relay::udprelay::dns::run as run_udp,
+};
 
 /// DNS Relay server running under local environment.
 pub fn run(config: Config) -> impl Future<Item = (), Error = io::Error> + Send {

--- a/src/relay/loadbalancing/server/roundrobin.rs
+++ b/src/relay/loadbalancing/server/roundrobin.rs
@@ -2,8 +2,10 @@
 
 use std::sync::Arc;
 
-use crate::config::{Config, ServerConfig};
-use crate::relay::loadbalancing::server::LoadBalancer;
+use crate::{
+    config::{Config, ServerConfig},
+    relay::loadbalancing::server::LoadBalancer,
+};
 
 #[derive(Clone)]
 pub struct RoundRobin {

--- a/src/relay/socks5.rs
+++ b/src/relay/socks5.rs
@@ -28,7 +28,7 @@ pub use self::consts::{
 
 use super::utils::{write_bytes, WriteBytes};
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 mod consts {
     pub const SOCKS5_VERSION:                          u8 = 0x05;
 
@@ -69,7 +69,7 @@ pub enum Command {
 
 impl Command {
     #[inline]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn as_u8(self) -> u8 {
         match self {
             Command::TcpConnect   => consts::SOCKS5_CMD_TCP_CONNECT,
@@ -79,7 +79,7 @@ impl Command {
     }
 
     #[inline]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn from_u8(code: u8) -> Option<Command> {
         match code {
             consts::SOCKS5_CMD_TCP_CONNECT   => Some(Command::TcpConnect),
@@ -108,7 +108,7 @@ pub enum Reply {
 
 impl Reply {
     #[inline]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn as_u8(self) -> u8 {
         match self {
             Reply::Succeeded               => consts::SOCKS5_REPLY_SUCCEEDED,
@@ -125,7 +125,7 @@ impl Reply {
     }
 
     #[inline]
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn from_u8(code: u8) -> Reply {
         match code {
             consts::SOCKS5_REPLY_SUCCEEDED                  => Reply::Succeeded,
@@ -143,7 +143,7 @@ impl Reply {
 }
 
 impl fmt::Display for Reply {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Reply::Succeeded               => write!(f, "Succeeded"),
@@ -172,7 +172,7 @@ pub struct Error {
 impl Error {
     pub fn new(reply: Reply, message: &str) -> Error {
         Error {
-            reply: reply,
+            reply,
             message: message.to_string(),
         }
     }
@@ -586,10 +586,7 @@ impl TcpRequestHeader {
             })
             .and_then(|(r, command)| {
                 Address::read_from(r).map(move |(conn, address)| {
-                    let header = TcpRequestHeader {
-                        command: command,
-                        address: address,
-                    };
+                    let header = TcpRequestHeader { command, address };
 
                     (conn, header)
                 })
@@ -641,10 +638,7 @@ pub struct TcpResponseHeader {
 impl TcpResponseHeader {
     /// Creates a response header
     pub fn new(reply: Reply, address: Address) -> TcpResponseHeader {
-        TcpResponseHeader {
-            reply: reply,
-            address: address,
-        }
+        TcpResponseHeader { reply, address }
     }
 
     /// Read from a reader
@@ -668,7 +662,7 @@ impl TcpResponseHeader {
                 Address::read_from(r).map(move |(r, address)| {
                     let rep = TcpResponseHeader {
                         reply: Reply::from_u8(reply_code),
-                        address: address,
+                        address,
                     };
 
                     (r, rep)
@@ -714,7 +708,7 @@ pub struct HandshakeRequest {
 impl HandshakeRequest {
     /// Creates a handshake request
     pub fn new(methods: Vec<u8>) -> HandshakeRequest {
-        HandshakeRequest { methods: methods }
+        HandshakeRequest { methods }
     }
 
     /// Read from a reader
@@ -734,7 +728,7 @@ impl HandshakeRequest {
                 Ok((r, nmet))
             })
             .and_then(|(r, nmet)| read_exact(r, vec![0u8; nmet as usize]))
-            .and_then(|(r, methods)| Ok((r, HandshakeRequest { methods: methods })))
+            .and_then(|(r, methods)| Ok((r, HandshakeRequest { methods })))
     }
 
     /// Write to a writer
@@ -834,10 +828,7 @@ pub struct UdpAssociateHeader {
 impl UdpAssociateHeader {
     /// Creates a header
     pub fn new(frag: u8, address: Address) -> UdpAssociateHeader {
-        UdpAssociateHeader {
-            frag: frag,
-            address: address,
-        }
+        UdpAssociateHeader { frag, address }
     }
 
     /// Read from a reader

--- a/src/relay/tcprelay/context.rs
+++ b/src/relay/tcprelay/context.rs
@@ -40,9 +40,9 @@ impl TcpServerContext {
         let ctx = TcpServerContext {
             tx: AtomicUsize::new(0),
             rx: AtomicUsize::new(0),
-            context: context,
+            context,
             stop_flag: stop_flag.clone(),
-            svr_cfg: svr_cfg,
+            svr_cfg,
         };
 
         let ctx = Arc::new(ctx);

--- a/src/relay/tcprelay/context.rs
+++ b/src/relay/tcprelay/context.rs
@@ -10,9 +10,11 @@ use std::{
     time::Duration,
 };
 
-use crate::config::{ServerAddr, ServerConfig};
-use crate::context::SharedContext;
-use crate::relay::{boxed_future, dns_resolver::resolve};
+use crate::{
+    config::{ServerAddr, ServerConfig},
+    context::SharedContext,
+    relay::{boxed_future, dns_resolver::resolve},
+};
 
 use futures::{future, Future, Stream};
 use tokio::{self, net::UdpSocket, timer::Interval};

--- a/src/relay/tcprelay/crypto_io.rs
+++ b/src/relay/tcprelay/crypto_io.rs
@@ -135,7 +135,7 @@ where
         let buffer_size = w.buffer_size(&DUMMY_BUFFER);
         EncryptedWriteAll::Writing {
             writer: w,
-            buf: buf,
+            buf,
             pos: 0,
             enc_buf: BytesMut::with_capacity(buffer_size),
             encrypted: false,

--- a/src/relay/tcprelay/mod.rs
+++ b/src/relay/tcprelay/mod.rs
@@ -502,7 +502,7 @@ impl<R: Read> Future for IgnoreUntilEnd<R> {
 
 /// Ignore all data from the reader
 pub fn ignore_until_end<R: Read>(r: R) -> IgnoreUntilEnd<R> {
-    IgnoreUntilEnd::Pending { r: r, amt: 0 }
+    IgnoreUntilEnd::Pending { r, amt: 0 }
 }
 
 pub enum TimeoutFuture<T, F>

--- a/src/relay/tcprelay/mod.rs
+++ b/src/relay/tcprelay/mod.rs
@@ -9,10 +9,12 @@ use std::{
     time::Duration,
 };
 
-use crate::config::{ConfigType, ServerAddr, ServerConfig};
-use crate::context::SharedContext;
-use crate::crypto::CipherCategory;
-use crate::relay::{boxed_future, dns_resolver::resolve, socks5::Address};
+use crate::{
+    config::{ConfigType, ServerAddr, ServerConfig},
+    context::SharedContext,
+    crypto::CipherCategory,
+    relay::{boxed_future, dns_resolver::resolve, socks5::Address},
+};
 
 use tokio::{
     net::{tcp::ConnectFuture, TcpStream},

--- a/src/relay/tcprelay/server.rs
+++ b/src/relay/tcprelay/server.rs
@@ -83,11 +83,11 @@ impl TcpRelayClientHandshake {
                         try_timeout(fut, timeout)
                     })
                     .map(move |(r, addr)| TcpRelayClientPending {
-                        r: r,
-                        addr: addr,
+                        r,
+                        addr,
                         w: w_fut,
-                        timeout: timeout,
-                        svr_context: svr_context,
+                        timeout,
+                        svr_context,
                     })
             })
         })
@@ -160,7 +160,7 @@ where
             TcpRelayClientConnected {
                 server: stream.split(),
                 client: client_pair,
-                timeout: timeout,
+                timeout,
             }
         })
     }
@@ -218,10 +218,7 @@ fn handle_client(svr_context: SharedTcpServerContext, socket: TcpStream) -> impl
         trace!("Got connection, addr: {}", addr);
         trace!("Picked proxy server: {:?}", svr_context.svr_cfg());
 
-        let client = TcpRelayClientHandshake {
-            s: socket,
-            svr_context: svr_context,
-        };
+        let client = TcpRelayClientHandshake { s: socket, svr_context };
 
         client
             .handshake()

--- a/src/relay/tcprelay/socks5_local.rs
+++ b/src/relay/tcprelay/socks5_local.rs
@@ -13,8 +13,7 @@ use tokio_io::{
     AsyncRead,
 };
 
-use crate::config::ServerConfig;
-use crate::context::SharedContext;
+use crate::{config::ServerConfig, context::SharedContext};
 
 use crate::relay::{
     boxed_future,

--- a/src/relay/tcprelay/stream.rs
+++ b/src/relay/tcprelay/stream.rs
@@ -5,8 +5,8 @@ use std::{
     io::{self, BufRead, Read},
 };
 
-use bytes::{BufMut, BytesMut};
 use crate::crypto::{new_stream, BoxStreamCipher, CipherType, CryptoMode, StreamCipher};
+use bytes::{BufMut, BytesMut};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::{DecryptedRead, EncryptedWrite, BUFFER_SIZE};

--- a/src/relay/tcprelay/stream.rs
+++ b/src/relay/tcprelay/stream.rs
@@ -35,7 +35,7 @@ where
         DecryptedReader {
             reader: r,
             buffer: BytesMut::with_capacity(buffer_size),
-            cipher: cipher,
+            cipher,
             pos: 0,
             sent_final: false,
         }

--- a/src/relay/tcprelay/utils.rs
+++ b/src/relay/tcprelay/utils.rs
@@ -50,7 +50,7 @@ where
         CopyTimeout {
             r: Some(r),
             w: Some(w),
-            timeout: timeout,
+            timeout,
             amt: 0,
             timer: None,
             buf: [0u8; BUFFER_SIZE],

--- a/src/relay/udprelay/dns.rs
+++ b/src/relay/udprelay/dns.rs
@@ -18,9 +18,11 @@ use super::{
     SendDgramRc,
     SharedUdpSocket,
 };
-use crate::config::{ServerAddr, ServerConfig};
-use crate::context::SharedContext;
-use crate::relay::{boxed_future, dns_resolver::resolve, socks5::Address};
+use crate::{
+    config::{ServerAddr, ServerConfig},
+    context::SharedContext,
+    relay::{boxed_future, dns_resolver::resolve, socks5::Address},
+};
 
 struct PrettyRRData<'a> {
     data: &'a RRData<'a>,

--- a/src/relay/udprelay/dns.rs
+++ b/src/relay/udprelay/dns.rs
@@ -84,7 +84,7 @@ struct PrettyPacket<'a> {
 
 impl<'a> PrettyPacket<'a> {
     pub fn new(pkt: &'a Packet<'a>) -> PrettyPacket<'a> {
-        PrettyPacket { pkt: pkt }
+        PrettyPacket { pkt }
     }
 }
 

--- a/src/relay/udprelay/local.rs
+++ b/src/relay/udprelay/local.rs
@@ -11,13 +11,15 @@ use futures::{self, Future, Stream};
 
 use tokio::{self, net::UdpSocket, util::FutureExt};
 
-use crate::config::{ServerAddr, ServerConfig};
-use crate::context::SharedContext;
-use crate::relay::{
-    boxed_future,
-    dns_resolver::resolve,
-    loadbalancing::server::{LoadBalancer, RoundRobin},
-    socks5::{Address, UdpAssociateHeader},
+use crate::{
+    config::{ServerAddr, ServerConfig},
+    context::SharedContext,
+    relay::{
+        boxed_future,
+        dns_resolver::resolve,
+        loadbalancing::server::{LoadBalancer, RoundRobin},
+        socks5::{Address, UdpAssociateHeader},
+    },
 };
 
 use super::{

--- a/src/relay/udprelay/mod.rs
+++ b/src/relay/udprelay/mod.rs
@@ -73,7 +73,7 @@ impl PacketStream {
     /// Creates a new `PacketStream`
     pub fn new(udp: SharedUdpSocket) -> PacketStream {
         PacketStream {
-            udp: udp,
+            udp,
             buf: [0u8; MAXIMUM_UDP_PAYLOAD_SIZE],
         }
     }
@@ -106,11 +106,7 @@ pub struct SendDgramRc<B: AsRef<[u8]>> {
 impl<B: AsRef<[u8]>> SendDgramRc<B> {
     pub fn new(udp: SharedUdpSocket, buf: B, addr: SocketAddr) -> SendDgramRc<B> {
         SendDgramRc {
-            stat: SendDgramStat::Pending {
-                udp: udp,
-                buf: buf,
-                addr: addr,
-            },
+            stat: SendDgramStat::Pending { udp, buf, addr },
         }
     }
 }

--- a/src/relay/udprelay/server.rs
+++ b/src/relay/udprelay/server.rs
@@ -11,9 +11,11 @@ use futures::{self, stream::futures_unordered, Future, Stream};
 
 use tokio::{self, net::UdpSocket, util::FutureExt};
 
-use crate::config::ServerConfig;
-use crate::context::SharedContext;
-use crate::relay::{boxed_future, dns_resolver::resolve, socks5::Address};
+use crate::{
+    config::ServerConfig,
+    context::SharedContext,
+    relay::{boxed_future, dns_resolver::resolve, socks5::Address},
+};
 
 use super::{
     crypto_io::{decrypt_payload, encrypt_payload},


### PR DESCRIPTION
This started out with seeing that `Plugin.addr` seemed unused. So I removed it and wanted to send a PR. To get some feedback if it was indeed unused, or if I had missed something about it.

Then I also saw that rustfmt suggested some changes. So I applied that. And then I saw Clippy had a few things to suggest. So I went ahead and applied some of the suggestions it had.

This PR should not change any behavior or exposed API. Except the `Plugin::addr()` method which is now gone.