### PR TITLE
Remove extern crate statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1240,7 +1243,6 @@ dependencies = [
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,7 @@ digest = "0.7"
 typenum = "1.10"
 qrcode = { version = "0.7", default-features = false }
 serde_urlencoded = "0.5"
-serde_derive = "1.0"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 url = "1"
 byte_string = "1.0"
 libsodium-ffi = { version = "0.1", optional = true }

--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -4,15 +4,6 @@
 //! or you could specify a configuration file. The format of configuration file is defined
 //! in mod `config`.
 
-extern crate clap;
-extern crate env_logger;
-#[macro_use]
-extern crate log;
-extern crate futures;
-extern crate shadowsocks;
-extern crate time;
-extern crate tokio;
-
 use std::{
     env,
     io::{self, Write},
@@ -23,7 +14,7 @@ use std::{
 use clap::{App, Arg};
 use env_logger::{fmt::Formatter, Builder};
 use futures::{future::Either, Future};
-use log::{LevelFilter, Record};
+use log::{debug, error, info, LevelFilter, Record};
 use tokio::runtime::Runtime;
 
 use shadowsocks::{plugin::PluginConfig, run_local, Config, ConfigType, Mode, ServerAddr, ServerConfig};

--- a/src/bin/monitor/unix.rs
+++ b/src/bin/monitor/unix.rs
@@ -1,5 +1,6 @@
 use futures::{Future, Stream};
 use libc;
+use log::{error, info};
 use std::io;
 use tokio_signal::unix::Signal;
 

--- a/src/bin/monitor/windows.rs
+++ b/src/bin/monitor/windows.rs
@@ -1,4 +1,5 @@
 use futures::{self, Future, Stream};
+use log::{error, info};
 use std::io;
 use tokio_signal::windows::Event;
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -7,15 +7,6 @@
 //! *It should be notice that the extented configuration file is not suitable for the server
 //! side.*
 
-extern crate clap;
-extern crate env_logger;
-#[macro_use]
-extern crate log;
-extern crate futures;
-extern crate shadowsocks;
-extern crate time;
-extern crate tokio;
-
 use std::{
     env,
     io::{self, Write},
@@ -25,7 +16,7 @@ use std::{
 use clap::{App, Arg};
 use env_logger::{fmt::Formatter, Builder};
 use futures::{future::Either, Future};
-use log::{LevelFilter, Record};
+use log::{debug, error, info, LevelFilter, Record};
 use tokio::runtime::Runtime;
 
 use shadowsocks::{plugin::PluginConfig, run_server, Config, ConfigType, Mode, ServerAddr, ServerConfig};

--- a/src/bin/ssdns.rs
+++ b/src/bin/ssdns.rs
@@ -1,14 +1,5 @@
 //! DNS over shadowsocks
 
-extern crate clap;
-extern crate shadowsocks;
-extern crate tokio;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-extern crate futures;
-extern crate time;
-
 use std::{
     env,
     io::{self, Write},
@@ -18,7 +9,7 @@ use std::{
 use clap::{App, Arg};
 use env_logger::{fmt::Formatter, Builder};
 use futures::Future;
-use log::{LevelFilter, Record};
+use log::{debug, error, info, LevelFilter, Record};
 use tokio::runtime::Runtime;
 
 use shadowsocks::{run_dns, Config, ConfigType, ServerAddr, ServerConfig};

--- a/src/bin/ssurl.rs
+++ b/src/bin/ssurl.rs
@@ -3,10 +3,6 @@
 //! SS-URI = "ss://" userinfo "@" hostname ":" port [ "/" ] [ "?" plugin ] [ "#" tag ]
 //! userinfo = websafe-base64-encode-utf8(method  ":" password)
 
-extern crate clap;
-extern crate qrcode;
-extern crate shadowsocks;
-
 use clap::{App, Arg};
 use qrcode::{types::Color, QrCode};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,8 @@ use std::{
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
 use bytes::Bytes;
 use json5;
+use log::{error, trace};
+use serde::{Deserialize, Serialize};
 use serde_urlencoded;
 use trust_dns_resolver::config::{NameServerConfigGroup, ResolverConfig};
 use url::{self, Url};

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -5,7 +5,7 @@ pub use self::{
     cipher::{CipherCategory, CipherResult, CipherType},
     stream::{new_stream, BoxStreamCipher, StreamCipher},
 };
-use crate::openssl::symm;
+use ::openssl::symm;
 use std::convert::From;
 
 pub mod aead;

--- a/src/crypto/ring.rs
+++ b/src/crypto/ring.rs
@@ -13,9 +13,9 @@ use crate::crypto::{
     CipherType,
 };
 
-use bytes::{BufMut, Bytes, BytesMut};
-
 use byte_string::ByteStr;
+use bytes::{BufMut, Bytes, BytesMut};
+use log::error;
 
 /// AEAD ciphers provided by Ring
 pub enum RingAeadCryptoVariant {

--- a/src/crypto/siv.rs
+++ b/src/crypto/siv.rs
@@ -2,7 +2,7 @@
 
 use std::ptr;
 
-use miscreant::aead::{Aes128PmacSivAead, Aes256PmacSivAead, Aead};
+use miscreant::aead::{Aead, Aes128PmacSivAead, Aes256PmacSivAead};
 
 use crate::crypto::{
     aead::{increase_nonce, make_skey},
@@ -13,9 +13,9 @@ use crate::crypto::{
     CipherType,
 };
 
-use bytes::{BufMut, BytesMut};
-
 use byte_string::ByteStr;
+use bytes::{BufMut, BytesMut};
+use log::error;
 
 /// AEAD ciphers provided by Miscreant
 pub enum MiscreantCryptoVariant {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,41 +70,6 @@
 #![crate_name = "shadowsocks"]
 #![recursion_limit = "128"]
 
-extern crate base64;
-extern crate byte_string;
-extern crate byteorder;
-extern crate bytes;
-extern crate digest;
-#[macro_use]
-extern crate futures;
-extern crate libc;
-#[cfg(feature = "sodium")]
-extern crate libsodium_ffi;
-#[macro_use]
-extern crate log;
-extern crate json5;
-extern crate md5;
-#[cfg(feature = "miscreant")]
-extern crate miscreant;
-extern crate openssl;
-extern crate rand;
-extern crate ring;
-extern crate serde_urlencoded;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-#[macro_use]
-extern crate tokio_io;
-extern crate dns_parser;
-extern crate lru_cache;
-extern crate spin;
-extern crate tokio;
-#[cfg(any(unix, windows))]
-extern crate tokio_signal;
-extern crate trust_dns_resolver;
-extern crate typenum;
-extern crate url;
-
 /// ShadowSocks version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -14,6 +14,7 @@
 
 use crate::config::{Config, ServerAddr};
 use futures::{stream::futures_unordered, Future, Stream};
+use log::{error, info};
 use std::{
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},

--- a/src/plugin/ss_plugin.rs
+++ b/src/plugin/ss_plugin.rs
@@ -1,5 +1,6 @@
 use super::{PluginConfig, PluginMode};
 use crate::config::ServerAddr;
+use log::trace;
 use std::{
     net::SocketAddr,
     process::{Command, Stdio},

--- a/src/relay/local.rs
+++ b/src/relay/local.rs
@@ -14,9 +14,6 @@ use crate::{
 /// Relay server running under local environment.
 ///
 /// ```no_run
-/// extern crate tokio;
-/// extern crate shadowsocks;
-///
 /// use shadowsocks::{
 ///     config::{Config, ConfigType, ServerConfig},
 ///     crypto::CipherType,

--- a/src/relay/server.rs
+++ b/src/relay/server.rs
@@ -14,9 +14,6 @@ use crate::{
 /// Relay server running on server side.
 ///
 /// ```no_run
-/// extern crate tokio;
-/// extern crate shadowsocks;
-///
 /// use shadowsocks::{
 ///     config::{Config, ConfigType, ServerConfig},
 ///     crypto::CipherType,

--- a/src/relay/socks5.rs
+++ b/src/relay/socks5.rs
@@ -14,10 +14,9 @@ use std::{
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::{BufMut, Bytes, BytesMut, IntoBuf};
-
-use futures::{Async, Future, Poll};
-
-use tokio_io::{io::read_exact, AsyncRead, AsyncWrite};
+use futures::{try_ready, Async, Future, Poll};
+use log::error;
+use tokio_io::{io::read_exact, try_nb, AsyncRead, AsyncWrite};
 
 pub use self::consts::{
     SOCKS5_AUTH_METHOD_GSSAPI,

--- a/src/relay/tcprelay/aead.rs
+++ b/src/relay/tcprelay/aead.rs
@@ -40,6 +40,7 @@ use std::{
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, BytesMut};
+use log::error;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use crate::crypto::{self, BoxAeadDecryptor, BoxAeadEncryptor, CipherType};

--- a/src/relay/tcprelay/client.rs
+++ b/src/relay/tcprelay/client.rs
@@ -5,10 +5,10 @@ use std::{
     net::SocketAddr,
 };
 
+use futures::{self, Async, Future, Poll};
+use log::trace;
 use tokio::net::TcpStream;
 use tokio_io::{io::flush, AsyncRead, AsyncWrite};
-
-use futures::{self, Async, Future, Poll};
 
 use crate::relay::socks5::{
     self,

--- a/src/relay/tcprelay/context.rs
+++ b/src/relay/tcprelay/context.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use futures::{future, Future, Stream};
+use log::debug;
 use tokio::{self, net::UdpSocket, timer::Interval};
 
 /// TCP Relay Server Context

--- a/src/relay/tcprelay/crypto_io.rs
+++ b/src/relay/tcprelay/crypto_io.rs
@@ -6,16 +6,15 @@ use std::{
     time::{Duration, Instant},
 };
 
+use bytes::{BufMut, BytesMut};
 use futures::{Async, Future, Poll};
-
 use tokio::timer::Delay;
 use tokio_io::{
     io::{copy, Copy},
+    try_nb,
     AsyncRead,
     AsyncWrite,
 };
-
-use bytes::{BufMut, BytesMut};
 
 use super::{
     utils::{copy_timeout, copy_timeout_opt, CopyTimeout, CopyTimeoutOpt},

--- a/src/relay/tcprelay/mod.rs
+++ b/src/relay/tcprelay/mod.rs
@@ -16,21 +16,20 @@ use crate::{
     relay::{boxed_future, dns_resolver::resolve, socks5::Address},
 };
 
+use byte_string::ByteStr;
+use bytes::{BufMut, BytesMut};
+use futures::{self, Async, Future, Poll};
+use log::{error, trace};
 use tokio::{
     net::{tcp::ConnectFuture, TcpStream},
     timer::Timeout,
 };
 use tokio_io::{
     io::{read_exact, write_all, ReadHalf, WriteHalf},
+    try_nb,
     AsyncRead,
     AsyncWrite,
 };
-
-use futures::{self, Async, Future, Poll};
-
-use bytes::{BufMut, BytesMut};
-
-use byte_string::ByteStr;
 
 pub use self::crypto_io::{DecryptedRead, EncryptedWrite};
 

--- a/src/relay/tcprelay/server.rs
+++ b/src/relay/tcprelay/server.rs
@@ -21,7 +21,7 @@ use futures::{
     stream::{futures_unordered, Stream},
     Future,
 };
-
+use log::{debug, error, info, trace};
 use tokio::{
     self,
     net::{TcpListener, TcpStream},

--- a/src/relay/tcprelay/socks5_local.rs
+++ b/src/relay/tcprelay/socks5_local.rs
@@ -4,6 +4,7 @@ use std::{io, net::SocketAddr, sync::Arc};
 
 use futures::{self, stream::Stream, Future};
 
+use log::{debug, error, info, trace, warn};
 use tokio::{
     self,
     net::{TcpListener, TcpStream},

--- a/src/relay/tcprelay/utils.rs
+++ b/src/relay/tcprelay/utils.rs
@@ -5,14 +5,14 @@ use std::{
     time::{Duration, Instant},
 };
 
+use futures::{Async, Future, Poll};
 use tokio::timer::Delay;
 use tokio_io::{
     io::{copy, Copy},
+    try_nb,
     AsyncRead,
     AsyncWrite,
 };
-
-use futures::{Async, Future, Poll};
 
 use super::BUFFER_SIZE;
 

--- a/src/relay/udprelay/dns.rs
+++ b/src/relay/udprelay/dns.rs
@@ -10,6 +10,7 @@ use std::{
 
 use dns_parser::{Packet, RRData};
 use futures::{self, future::join_all, stream::futures_unordered, Future, Stream};
+use log::{debug, error, info, trace};
 use tokio::{self, net::UdpSocket};
 
 use super::{

--- a/src/relay/udprelay/local.rs
+++ b/src/relay/udprelay/local.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use futures::{self, Future, Stream};
-
+use log::{debug, error, info};
 use tokio::{self, net::UdpSocket, util::FutureExt};
 
 use crate::{

--- a/src/relay/udprelay/mod.rs
+++ b/src/relay/udprelay/mod.rs
@@ -46,7 +46,7 @@ use std::{
 
 use tokio::net::UdpSocket;
 
-use futures::{Async, Future, Poll, Stream};
+use futures::{try_ready, Async, Future, Poll, Stream};
 
 pub mod dns;
 pub mod local;

--- a/src/relay/udprelay/server.rs
+++ b/src/relay/udprelay/server.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use futures::{self, stream::futures_unordered, Future, Stream};
-
+use log::{debug, error, info};
 use tokio::{self, net::UdpSocket, util::FutureExt};
 
 use crate::{

--- a/src/relay/utils.rs
+++ b/src/relay/utils.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use futures::{Async, Future, Poll};
+use futures::{try_ready, Async, Future, Poll};
 use tokio_io::{
     io::{write_all, WriteAll},
     AsyncWrite,

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -1,11 +1,3 @@
-extern crate dns_parser;
-extern crate env_logger;
-extern crate rand;
-extern crate shadowsocks;
-extern crate tokio;
-#[macro_use]
-extern crate log;
-
 use std::{
     collections::HashSet,
     net::{SocketAddr, UdpSocket},
@@ -14,6 +6,7 @@ use std::{
 };
 
 use dns_parser::{Builder, Packet, QueryClass, QueryType};
+use log::trace;
 use shadowsocks::{
     config::{Config, ConfigType},
     run_dns,

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -1,10 +1,3 @@
-extern crate env_logger;
-extern crate futures;
-extern crate log;
-extern crate shadowsocks;
-extern crate tokio;
-extern crate tokio_io;
-
 use std::{
     net::{SocketAddr, ToSocketAddrs},
     thread,

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,12 +1,5 @@
 #![cfg_attr(clippy, allow(blacklisted_name))]
 
-extern crate bytes;
-extern crate env_logger;
-extern crate futures;
-extern crate shadowsocks;
-extern crate tokio;
-extern crate tokio_io;
-
 use std::{
     io::Cursor,
     net::SocketAddr,


### PR DESCRIPTION
Now when we have upgraded to Rust 2018 edition, the `extern crate` statements are not really needed. For macros they can be imported using the normal module import system.

Also used the little `features = ["derive"]` trick on `serde` in order to not have to depend on both crates explicitly.