### PR TITLE
Move logging code into reused module

### DIFF
--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -4,57 +4,17 @@
 //! or you could specify a configuration file. The format of configuration file is defined
 //! in mod `config`.
 
-use std::{
-    env,
-    io::{self, Write},
-    net::SocketAddr,
-    process,
-};
+use std::{net::SocketAddr, process};
 
 use clap::{App, Arg};
-use env_logger::{fmt::Formatter, Builder};
 use futures::{future::Either, Future};
-use log::{debug, error, info, LevelFilter, Record};
+use log::{debug, error, info};
 use tokio::runtime::Runtime;
 
 use shadowsocks::{plugin::PluginConfig, run_local, Config, ConfigType, Mode, ServerAddr, ServerConfig};
 
+mod logging;
 mod monitor;
-
-fn log_time(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
-    if without_time {
-        writeln!(fmt, "[{}] {}", record.level(), record.args())
-    } else {
-        writeln!(
-            fmt,
-            "[{}][{}] {}",
-            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
-            record.level(),
-            record.args()
-        )
-    }
-}
-
-fn log_time_module(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
-    if without_time {
-        writeln!(
-            fmt,
-            "[{}] [{}] {}",
-            record.level(),
-            record.module_path().unwrap_or("*"),
-            record.args()
-        )
-    } else {
-        writeln!(
-            fmt,
-            "[{}][{}] [{}] {}",
-            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
-            record.level(),
-            record.module_path().unwrap_or("*"),
-            record.args()
-        )
-    }
-}
 
 fn main() {
     let matches = App::new("shadowsocks")
@@ -134,44 +94,10 @@ fn main() {
         )
         .get_matches();
 
-    let mut log_builder = Builder::new();
-    log_builder.filter(None, LevelFilter::Info);
-
     let without_time = matches.is_present("LOG_WITHOUT_TIME");
-
     let debug_level = matches.occurrences_of("VERBOSE");
-    match debug_level {
-        0 => {
-            // Default filter
-            log_builder.format(move |fmt, r| log_time(fmt, without_time, r));
-        }
-        1 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(Some("sslocal"), LevelFilter::Debug);
-        }
-        2 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder
-                .filter(Some("sslocal"), LevelFilter::Debug)
-                .filter(Some("shadowsocks"), LevelFilter::Debug);
-        }
-        3 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder
-                .filter(Some("sslocal"), LevelFilter::Trace)
-                .filter(Some("shadowsocks"), LevelFilter::Trace);
-        }
-        _ => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(None, LevelFilter::Trace);
-        }
-    }
 
-    if let Ok(env_conf) = env::var("RUST_LOG") {
-        log_builder.parse(&env_conf);
-    }
-
-    log_builder.init();
+    logging::init(without_time, debug_level);
 
     let mut has_provided_config = false;
 

--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -97,7 +97,7 @@ fn main() {
     let without_time = matches.is_present("LOG_WITHOUT_TIME");
     let debug_level = matches.occurrences_of("VERBOSE");
 
-    logging::init(without_time, debug_level);
+    logging::init(without_time, debug_level, "sslocal");
 
     let mut has_provided_config = false;
 

--- a/src/bin/logging/mod.rs
+++ b/src/bin/logging/mod.rs
@@ -5,7 +5,7 @@ use std::{
     io::{self, Write},
 };
 
-pub fn init(without_time: bool, debug_level: u64) {
+pub fn init(without_time: bool, debug_level: u64, bin_name: &str) {
     let mut log_builder = Builder::new();
     log_builder.filter(None, LevelFilter::Info);
 
@@ -16,18 +16,18 @@ pub fn init(without_time: bool, debug_level: u64) {
         }
         1 => {
             let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(Some("sslocal"), LevelFilter::Debug);
+            log_builder.filter(Some(bin_name), LevelFilter::Debug);
         }
         2 => {
             let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
             log_builder
-                .filter(Some("sslocal"), LevelFilter::Debug)
+                .filter(Some(bin_name), LevelFilter::Debug)
                 .filter(Some("shadowsocks"), LevelFilter::Debug);
         }
         3 => {
             let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
             log_builder
-                .filter(Some("sslocal"), LevelFilter::Trace)
+                .filter(Some(bin_name), LevelFilter::Trace)
                 .filter(Some("shadowsocks"), LevelFilter::Trace);
         }
         _ => {

--- a/src/bin/logging/mod.rs
+++ b/src/bin/logging/mod.rs
@@ -1,0 +1,79 @@
+use env_logger::{fmt::Formatter, Builder};
+use log::{LevelFilter, Record};
+use std::{
+    env,
+    io::{self, Write},
+};
+
+pub fn init(without_time: bool, debug_level: u64) {
+    let mut log_builder = Builder::new();
+    log_builder.filter(None, LevelFilter::Info);
+
+    match debug_level {
+        0 => {
+            // Default filter
+            log_builder.format(move |fmt, r| log_time(fmt, without_time, r));
+        }
+        1 => {
+            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
+            log_builder.filter(Some("sslocal"), LevelFilter::Debug);
+        }
+        2 => {
+            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
+            log_builder
+                .filter(Some("sslocal"), LevelFilter::Debug)
+                .filter(Some("shadowsocks"), LevelFilter::Debug);
+        }
+        3 => {
+            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
+            log_builder
+                .filter(Some("sslocal"), LevelFilter::Trace)
+                .filter(Some("shadowsocks"), LevelFilter::Trace);
+        }
+        _ => {
+            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
+            log_builder.filter(None, LevelFilter::Trace);
+        }
+    }
+
+    if let Ok(env_conf) = env::var("RUST_LOG") {
+        log_builder.parse(&env_conf);
+    }
+
+    log_builder.init();
+}
+
+fn log_time(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
+    if without_time {
+        writeln!(fmt, "[{}] {}", record.level(), record.args())
+    } else {
+        writeln!(
+            fmt,
+            "[{}][{}] {}",
+            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
+            record.level(),
+            record.args()
+        )
+    }
+}
+
+fn log_time_module(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
+    if without_time {
+        writeln!(
+            fmt,
+            "[{}] [{}] {}",
+            record.level(),
+            record.module_path().unwrap_or("*"),
+            record.args()
+        )
+    } else {
+        writeln!(
+            fmt,
+            "[{}][{}] [{}] {}",
+            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
+            record.level(),
+            record.module_path().unwrap_or("*"),
+            record.args()
+        )
+    }
+}

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -93,7 +93,7 @@ fn main() {
     let without_time = matches.is_present("LOG_WITHOUT_TIME");
     let debug_level = matches.occurrences_of("VERBOSE");
 
-    logging::init(without_time, debug_level);
+    logging::init(without_time, debug_level, "ssserver");
 
     let mut has_provided_config = false;
     let mut config = match matches.value_of("CONFIG") {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -7,56 +7,17 @@
 //! *It should be notice that the extented configuration file is not suitable for the server
 //! side.*
 
-use std::{
-    env,
-    io::{self, Write},
-    process,
-};
+use std::process;
 
 use clap::{App, Arg};
-use env_logger::{fmt::Formatter, Builder};
 use futures::{future::Either, Future};
-use log::{debug, error, info, LevelFilter, Record};
+use log::{debug, error, info};
 use tokio::runtime::Runtime;
 
 use shadowsocks::{plugin::PluginConfig, run_server, Config, ConfigType, Mode, ServerAddr, ServerConfig};
 
+mod logging;
 mod monitor;
-
-fn log_time(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
-    if without_time {
-        writeln!(fmt, "[{}] {}", record.level(), record.args())
-    } else {
-        writeln!(
-            fmt,
-            "[{}][{}] {}",
-            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
-            record.level(),
-            record.args()
-        )
-    }
-}
-
-fn log_time_module(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
-    if without_time {
-        writeln!(
-            fmt,
-            "[{}] [{}] {}",
-            record.level(),
-            record.module_path().unwrap_or("*"),
-            record.args()
-        )
-    } else {
-        writeln!(
-            fmt,
-            "[{}][{}] [{}] {}",
-            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
-            record.level(),
-            record.module_path().unwrap_or("*"),
-            record.args()
-        )
-    }
-}
 
 fn main() {
     let matches = App::new("shadowsocks")
@@ -129,44 +90,10 @@ fn main() {
         )
         .get_matches();
 
-    let mut log_builder = Builder::new();
-    log_builder.filter(None, LevelFilter::Info);
-
     let without_time = matches.is_present("LOG_WITHOUT_TIME");
-
     let debug_level = matches.occurrences_of("VERBOSE");
-    match debug_level {
-        0 => {
-            // Default filter
-            log_builder.format(move |fmt, r| log_time(fmt, without_time, r));
-        }
-        1 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(Some("ssserver"), LevelFilter::Debug);
-        }
-        2 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder
-                .filter(Some("ssserver"), LevelFilter::Debug)
-                .filter(Some("shadowsocks"), LevelFilter::Debug);
-        }
-        3 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder
-                .filter(Some("ssserver"), LevelFilter::Trace)
-                .filter(Some("shadowsocks"), LevelFilter::Trace);
-        }
-        _ => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(None, LevelFilter::Trace);
-        }
-    }
 
-    if let Ok(env_conf) = env::var("RUST_LOG") {
-        log_builder.parse(&env_conf);
-    }
-
-    log_builder.init();
+    logging::init(without_time, debug_level);
 
     let mut has_provided_config = false;
     let mut config = match matches.value_of("CONFIG") {

--- a/src/bin/ssdns.rs
+++ b/src/bin/ssdns.rs
@@ -78,7 +78,7 @@ fn main() {
     let without_time = matches.is_present("LOG_WITHOUT_TIME");
     let debug_level = matches.occurrences_of("VERBOSE");
 
-    logging::init(without_time, debug_level);
+    logging::init(without_time, debug_level, "ssdns");
 
     let mut has_provided_config = false;
 

--- a/src/bin/ssdns.rs
+++ b/src/bin/ssdns.rs
@@ -1,53 +1,15 @@
 //! DNS over shadowsocks
 
-use std::{
-    env,
-    io::{self, Write},
-    net::SocketAddr,
-};
+use std::net::SocketAddr;
 
 use clap::{App, Arg};
-use env_logger::{fmt::Formatter, Builder};
 use futures::Future;
-use log::{debug, error, info, LevelFilter, Record};
+use log::{debug, error, info};
 use tokio::runtime::Runtime;
 
 use shadowsocks::{run_dns, Config, ConfigType, ServerAddr, ServerConfig};
 
-fn log_time(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
-    if without_time {
-        writeln!(fmt, "[{}] {}", record.level(), record.args())
-    } else {
-        writeln!(
-            fmt,
-            "[{}][{}] {}",
-            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
-            record.level(),
-            record.args()
-        )
-    }
-}
-
-fn log_time_module(fmt: &mut Formatter, without_time: bool, record: &Record) -> io::Result<()> {
-    if without_time {
-        writeln!(
-            fmt,
-            "[{}] [{}] {}",
-            record.level(),
-            record.module_path().unwrap_or("*"),
-            record.args()
-        )
-    } else {
-        writeln!(
-            fmt,
-            "[{}][{}] [{}] {}",
-            time::now().strftime("%Y-%m-%d][%H:%M:%S.%f").unwrap(),
-            record.level(),
-            record.module_path().unwrap_or("*"),
-            record.args()
-        )
-    }
-}
+mod logging;
 
 fn main() {
     let matches = App::new("ssdns")
@@ -113,44 +75,10 @@ fn main() {
         )
         .get_matches();
 
-    let mut log_builder = Builder::new();
-    log_builder.filter(None, LevelFilter::Info);
-
     let without_time = matches.is_present("LOG_WITHOUT_TIME");
-
     let debug_level = matches.occurrences_of("VERBOSE");
-    match debug_level {
-        0 => {
-            // Default filter
-            log_builder.format(move |fmt, r| log_time(fmt, without_time, r));
-        }
-        1 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(Some("ssdns"), LevelFilter::Debug);
-        }
-        2 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder
-                .filter(Some("ssdns"), LevelFilter::Debug)
-                .filter(Some("shadowsocks"), LevelFilter::Debug);
-        }
-        3 => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder
-                .filter(Some("ssdns"), LevelFilter::Trace)
-                .filter(Some("shadowsocks"), LevelFilter::Trace);
-        }
-        _ => {
-            let log_builder = log_builder.format(move |fmt, r| log_time_module(fmt, without_time, r));
-            log_builder.filter(None, LevelFilter::Trace);
-        }
-    }
 
-    if let Ok(env_conf) = env::var("RUST_LOG") {
-        log_builder.parse(&env_conf);
-    }
-
-    log_builder.init();
+    logging::init(without_time, debug_level);
 
     let mut has_provided_config = false;
 


### PR DESCRIPTION
There was a lot of logging setup code that was shared between the binaries. I reduced duplication a lot by sharing the code via a module. Easier to keep in sync, is one benefit.