### PR TITLE
Test on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
+sudo: false
 language: rust
-cache: cargo
+matrix:
+    include:
+        - os: windows
+          rust: stable
 
-rust:
-    - stable
-    - beta
-    - nightly
+        - os: osx
+          rust: stable
 
-os:
-    - linux
-    - osx
+        - os: linux
+          rust: stable
+        - os: linux
+          rust: beta
+        - os: linux
+          rust: nightly
 
 env:
     - RUSTFLAGS="-Ctarget-feature=+aes,+ssse3" RUSTDOCFLAGS="-Ctarget-feature=+aes,+ssse3"
-
-sudo: false
 
 addons:
     apt:
@@ -27,5 +30,15 @@ install:
     #- export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH
     #- export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH
     - export SODIUM_BUILD_STATIC=yes
+
+    # Install OpenSSL on Windows
+    - if [ "${TRAVIS_OS_NAME}" = "windows" ]; then
+          curl -O http://slproweb.com/download/Win64OpenSSL-1_1_0j.exe;
+          cmd.exe /C 'Win64OpenSSL-1_1_0j.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"';
+          export OPENSSL_LIB_DIR=/c/OpenSSL/lib;
+          export OPENSSL_INCLUDE_DIR=/c/OpenSSL/include;
+          export OPENSSL_DIR=/c/OpenSSL/bin;
+      fi
+
 script:
     - cargo test --no-fail-fast --features miscreant

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,5 @@ install:
       fi
 
 script:
+    - cargo build
     - cargo test --no-fail-fast --features miscreant


### PR DESCRIPTION
Would be nice to be able to run CI tests on Windows. To make sure it does not break.. Also there seems to be issues building the crate on Windows right now. So would be good to get that resolved as well. As such I have marked the Windows build as OK to fail for now.

In the process `cache: cargo` got lost. I have personally not really seen any speedup with caching. Cargo generates a huge amount of data. And the time it takes to download and unpack this on build start and then pack and upload again on a finished build is usually longer than it just takes to do a clean build.

Also, to not make the CI run forever I opted for not running all three Rust versions on all platforms. Keeping `beta` and `nightly` on Linux but only testing `stable` on the other two platforms. What do you think about that?