### PR TITLE
Disable set_nofile in Android build

### DIFF
--- a/src/relay/utils.rs
+++ b/src/relay/utils.rs
@@ -18,7 +18,7 @@ where
     .map_err(From::from)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="android")))]
 pub fn set_nofile(nofile: u64) -> io::Result<()> {
     unsafe {
         // set both soft and hard limit
@@ -35,7 +35,7 @@ pub fn set_nofile(nofile: u64) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(any(not(unix), target_os="android"))]
 pub fn set_nofile(_nofile: u64) -> io::Result<()> {
     // set_rlimit only works on *nix systems
     //


### PR DESCRIPTION
RLIMT_NOFILE is private in Android system, so just disable the function here.

Not sure if this change will break the build/function on other platforms.