### PR TITLE
Fix the build without trust-dns

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -128,7 +128,7 @@ impl ServerState {
 
     #[cfg(not(feature = "trust-dns"))]
     pub async fn new_shared(_config: &Config, _rt: Handle) -> SharedServerState {
-        Arc::new(ServerState { dns_resolver: None })
+        Arc::new(ServerState { })
     }
 
     /// Get the global shared resolver


### PR DESCRIPTION
If disabling the `trust-dns` feature, there will be a compilation error, as `dns_resolver` is not defined.