### PR TITLE
DNS relay refactor and improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ camellia-cfb = ["openssl"]
 single-threaded = []
 trust-dns = ["trust-dns-resolver"]
 openssl-vendored = ["openssl/vendored"]
+local-dns-relay = []
 
 [dependencies]
 log = "0.4"
@@ -80,6 +81,7 @@ byte_string = "1.0"
 libsodium-sys = { version = "0.2", optional = true }
 miscreant = { version = "0.5", optional = true }
 trust-dns-resolver = { version = "0.19", features = ["dns-over-rustls", "dns-over-https-rustls"], optional = true }
+trust-dns-proto = "0.19"
 hkdf = "0.8"
 hmac = "0.7"
 sha-1 = "0.8"
@@ -108,7 +110,6 @@ lazy_static = "1.4"
 winapi = { version = "0.3", features = ["mswsock", "winsock2"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-trust-dns-proto = "0.19"
 
 # Just for the ioctl call macro
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ name = "ssmanager"
 path = "src/bin/manager.rs"
 
 [profile.release]
-lto = true
+lto = "fat"
 codegen-units = 1
 incremental = false
-panic = 'abort'
+panic = "abort"
 
 [features]
 default = ["sodium", "rc4", "aes-cfb", "aes-ctr", "trust-dns"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ single-threaded = []
 trust-dns = ["trust-dns-resolver"]
 openssl-vendored = ["openssl/vendored"]
 local-dns-relay = []
+local-flow-stat = []
 
 [dependencies]
 log = "0.4"
@@ -108,8 +109,6 @@ lazy_static = "1.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["mswsock", "winsock2"] }
-
-[target.'cfg(target_os = "android")'.dependencies]
 
 # Just for the ioctl call macro
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]

--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -264,7 +264,6 @@ impl AccessControl {
 
     /// Check if domain name is in proxy_list.
     /// If so, it should be resolved from remote (for Android's DNS relay)
-    #[cfg(target_os = "android")]
     pub async fn check_qname_in_proxy_list(&self, addr: &Address) -> bool {
         // Addresses in proxy_list will be proxied
         if self.white_list.check_address_matched(addr) {
@@ -278,11 +277,6 @@ impl AccessControl {
     ///
     /// FIXME: This function may perform a DNS resolution
     pub async fn check_target_bypassed(&self, context: &Context, addr: &Address) -> bool {
-        // Always redirect TCP DNS query (for android)
-        if cfg!(target_os = "android") && addr.port() == 53 {
-            return false;
-        }
-
         // Addresses in bypass_list will be bypassed
         if self.black_list.check_address_matched(addr) {
             return true;

--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -152,18 +152,21 @@ fn main() {
         );
 
     if cfg!(target_os = "android") {
-        app = app
-            .arg(
-                Arg::with_name("VPN_MODE")
-                    .long("vpn")
-                    .help("Enable VPN mode (only for Android)"),
-            )
-            .arg(
-                Arg::with_name("STAT_PATH")
-                    .long("stat-path")
-                    .takes_value(true)
-                    .help("Specify stat_path for traffic stat (only for Android)"),
-            );
+        app = app.arg(
+            Arg::with_name("VPN_MODE")
+                .long("vpn")
+                .help("Enable VPN mode (only for Android)"),
+        );
+    }
+
+    #[cfg(feature = "local-flow-stat")]
+    {
+        app = app.arg(
+            Arg::with_name("STAT_PATH")
+                .long("stat-path")
+                .takes_value(true)
+                .help("Specify stat_path for traffic stat (only for Android)"),
+        );
     }
 
     #[cfg(feature = "local-dns-relay")]
@@ -243,12 +246,15 @@ fn main() {
     if cfg!(target_os = "android") {
         config.local_dns_path = Some("local_dns_path".to_owned());
 
-        if let Some(stat_path) = matches.value_of("STAT_PATH") {
-            config.stat_path = Some(stat_path.to_owned());
-        }
-
         if matches.is_present("VPN_MODE") {
             config.protect_path = Some("protect_path".to_owned());
+        }
+    }
+
+    #[cfg(feature = "local-flow-stat")]
+    {
+        if let Some(stat_path) = matches.value_of("STAT_PATH") {
+            config.stat_path = Some(stat_path.to_owned());
         }
     }
 

--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -166,7 +166,7 @@ fn main() {
             );
     }
 
-    #[cfg(target_os = "android")]
+    #[cfg(feature = "local-dns-relay")]
     {
         app = app
             .arg(
@@ -184,7 +184,7 @@ fn main() {
                     .help("Specify the address of remote DNS server (only for Android)"),
             )
             .arg(
-                Arg::with_name("DNS_RELAY_ADDR")
+                Arg::with_name("DNS_LOCAL_ADDR")
                     .long("dns-relay")
                     .takes_value(true)
                     .default_value("127.0.0.1:5450")
@@ -252,7 +252,7 @@ fn main() {
         }
     }
 
-    #[cfg(target_os = "android")]
+    #[cfg(feature = "local-dns-relay")]
     {
         use std::net::SocketAddr;
 
@@ -268,9 +268,9 @@ fn main() {
             config.remote_dns_addr = Some(addr);
         }
 
-        if let Some(dns_relay_addr) = matches.value_of("DNS_RELAY_ADDR") {
-            let addr = dns_relay_addr.parse::<SocketAddr>().expect("dns relay address");
-            config.dns_relay_addr = Some(addr);
+        if let Some(dns_relay_addr) = matches.value_of("DNS_LOCAL_ADDR") {
+            let addr = dns_relay_addr.parse::<ServerAddr>().expect("dns relay address");
+            config.dns_local_addr = Some(addr);
         }
     }
 
@@ -284,7 +284,7 @@ fn main() {
             .parse::<ServerAddr>()
             .expect("`local-addr` should be \"IP:Port\" or \"Domain:Port\"");
 
-        config.local = Some(local_addr);
+        config.local_addr = Some(local_addr);
     }
 
     if matches.is_present("UDP_ONLY") {
@@ -330,7 +330,7 @@ fn main() {
 
     // DONE READING options
 
-    if config.local.is_none() {
+    if config.local_addr.is_none() {
         eprintln!(
             "missing `local_address`, consider specifying it by --local-addr command line option, \
              or \"local_address\" and \"local_port\" in configuration file"

--- a/src/bin/manager.rs
+++ b/src/bin/manager.rs
@@ -139,7 +139,7 @@ fn main() {
             Err(..) => ServerAddr::from((bind_addr, 0)),
         };
 
-        config.local = Some(bind_addr);
+        config.local_addr = Some(bind_addr);
     }
 
     if matches.is_present("UDP_ONLY") {
@@ -159,7 +159,7 @@ fn main() {
     }
 
     if let Some(m) = matches.value_of("MANAGER_ADDRESS") {
-        config.manager_address = Some(
+        config.manager_addr = Some(
             m.parse::<ManagerAddr>()
                 .expect("\"IP:Port\", \"Domain:Port\" or \"/path/to/unix.sock\" for `manager_address`"),
         );
@@ -180,7 +180,7 @@ fn main() {
 
     // DONE reading options
 
-    if config.manager_address.is_none() {
+    if config.manager_addr.is_none() {
         eprintln!(
             "missing `manager_address`, consider specifying it by --manager-address command line option, \
              or \"manager_address\" and \"manager_port\" keys in configuration file"

--- a/src/bin/redir.rs
+++ b/src/bin/redir.rs
@@ -221,7 +221,7 @@ fn main() {
             .parse::<ServerAddr>()
             .expect("`local-addr` should be \"IP:Port\" or \"Domain:Port\"");
 
-        config.local = Some(local_addr);
+        config.local_addr = Some(local_addr);
     }
 
     if let Some(url) = matches.value_of("FORWARD_ADDR") {
@@ -281,7 +281,7 @@ fn main() {
 
     // DONE READING options
 
-    if config.local.is_none() {
+    if config.local_addr.is_none() {
         eprintln!(
             "missing `local_address`, consider specifying it by --local-addr command line option, \
              or \"local_address\" and \"local_port\" in configuration file"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -190,7 +190,7 @@ fn main() {
             Err(..) => ServerAddr::from((bind_addr, 0)),
         };
 
-        config.local = Some(bind_addr);
+        config.local_addr = Some(bind_addr);
     }
 
     if matches.is_present("UDP_ONLY") {
@@ -222,7 +222,7 @@ fn main() {
     };
 
     if let Some(m) = matches.value_of("MANAGER_ADDRESS") {
-        config.manager_address = Some(
+        config.manager_addr = Some(
             m.parse::<ManagerAddr>()
                 .expect("\"IP:Port\", \"Domain:Port\" or \"/path/to/unix.sock\" for `manager_address`"),
         );

--- a/src/bin/tunnel.rs
+++ b/src/bin/tunnel.rs
@@ -196,7 +196,7 @@ fn main() {
             .parse::<ServerAddr>()
             .expect("`local-addr` should be \"IP:Port\" or \"Domain:Port\"");
 
-        config.local = Some(local_addr);
+        config.local_addr = Some(local_addr);
     };
 
     if let Some(url) = matches.value_of("FORWARD_ADDR") {
@@ -243,7 +243,7 @@ fn main() {
 
     // DONE READING options
 
-    if config.local.is_none() {
+    if config.local_addr.is_none() {
         eprintln!(
             "missing `local_address`, consider specifying it by --local-addr command line option, \
              or \"local_address\" and \"local_port\" in configuration file"

--- a/src/config.rs
+++ b/src/config.rs
@@ -914,6 +914,7 @@ pub struct Config {
     /// UDP Transparent Proxy type
     pub udp_redir: RedirType,
     /// Android flow statistic report Unix socket path
+    #[cfg(feature = "local-flow-stat")]
     pub stat_path: Option<String>,
     /// Path to protect callback unix address, only for Android
     pub protect_path: Option<String>,
@@ -1014,6 +1015,7 @@ impl Config {
             acl: None,
             tcp_redir: RedirType::tcp_default(),
             udp_redir: RedirType::udp_default(),
+            #[cfg(feature = "local-flow-stat")]
             stat_path: None,
             protect_path: None,
             local_dns_path: None,

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,9 +22,11 @@ use trust_dns_resolver::TokioAsyncResolver;
 
 #[cfg(feature = "trust-dns")]
 use crate::relay::dns_resolver::create_resolver;
+#[cfg(feature = "local-flow-stat")]
+use crate::relay::flow::ServerFlowStatistic;
 use crate::{
     config::{Config, ConfigType, ServerConfig},
-    relay::{dns_resolver::resolve, flow::ServerFlowStatistic, socks5::Address},
+    relay::{dns_resolver::resolve, socks5::Address},
 };
 
 // Entries for server's bloom filter
@@ -165,6 +167,7 @@ pub struct Context {
     nonce_ppbloom: Mutex<PingPongBloom>,
 
     // For Android's flow stat report
+    #[cfg(feature = "local-flow-stat")]
     local_flow_statistic: ServerFlowStatistic,
 
     // For DNS relay's ACL domain name reverse lookup
@@ -187,6 +190,7 @@ impl Context {
             server_state,
             server_running: AtomicBool::new(true),
             nonce_ppbloom,
+            #[cfg(feature = "local-flow-stat")]
             local_flow_statistic: ServerFlowStatistic::new(),
             #[cfg(feature = "local-dns-relay")]
             reverse_lookup_cache,
@@ -327,6 +331,7 @@ impl Context {
     }
 
     /// Get client flow statistics
+    #[cfg(feature = "local-flow-stat")]
     pub fn local_flow_statistic(&self) -> &ServerFlowStatistic {
         &self.local_flow_statistic
     }

--- a/src/relay/dns.rs
+++ b/src/relay/dns.rs
@@ -1,0 +1,76 @@
+//! DNS relay
+
+use std::io::{self, ErrorKind};
+
+use futures::{future::select_all, FutureExt};
+use log::{debug, error, trace, warn};
+use tokio::runtime::Handle;
+
+use crate::{
+    config::{Config, ConfigType},
+    context::{Context, ServerState},
+    plugin::{PluginMode, Plugins},
+    relay::{dnsrelay::run as run_dns, utils::set_nofile},
+};
+
+/// DNS relay server running under local environment.
+pub async fn run(mut config: Config, rt: Handle) -> io::Result<()> {
+    trace!("initializing local server with {:?}", config);
+
+    assert_eq!(config.config_type, ConfigType::DnsLocal);
+
+    if let Some(nofile) = config.nofile {
+        debug!("setting RLIMIT_NOFILE to {}", nofile);
+        if let Err(err) = set_nofile(nofile) {
+            match err.kind() {
+                ErrorKind::PermissionDenied => {
+                    warn!("insufficient permission to change RLIMIT_NOFILE, try to restart as root user");
+                }
+                ErrorKind::InvalidInput => {
+                    warn!("invalid `nofile` value {}, decrease it and try again", nofile);
+                }
+                _ => {
+                    error!("failed to set RLIMIT_NOFILE with value {}, error: {}", nofile, err);
+                }
+            }
+            return Err(err);
+        }
+    }
+
+    // Create a context containing a DNS resolver and server running state flag.
+    let state = ServerState::new_shared(&config, rt).await;
+
+    let mut vf = Vec::new();
+
+    let context = if config.mode.enable_tcp() {
+        // Run TCP local server if
+        //
+        //  1. Enabled TCP relay
+        //  2. Not in tunnel mode. (Socks5 UDP relay requires TCP port enabled)
+
+        if config.has_server_plugins() {
+            let plugins = Plugins::launch_plugins(&mut config, PluginMode::Client)?;
+
+            // Wait until all plugins actually start
+            // Some plugins require quite a lot bootstrap time
+            Plugins::check_plugins_started(&config).await?;
+
+            vf.push(plugins.into_future().boxed());
+        }
+
+        Context::new_shared(config, state)
+    } else {
+        Context::new_shared(config, state)
+    };
+
+    let server = run_dns(context.clone());
+    vf.push(server.boxed());
+
+    let (res, ..) = select_all(vf.into_iter()).await;
+    error!("one of servers exited unexpectly, result: {:?}", res);
+
+    // Tells all detached tasks to exit
+    context.set_server_stopped();
+
+    Err(io::Error::new(io::ErrorKind::Other, "server exited unexpectly"))
+}

--- a/src/relay/manager.rs
+++ b/src/relay/manager.rs
@@ -418,7 +418,7 @@ impl ManagerService {
         let mut config = Config::new(ConfigType::Server);
         config.server.push(svr_cfg);
 
-        config.local = self.context.config().local.clone();
+        config.local_addr = self.context.config().local_addr.clone();
 
         if let Some(mode) = p.mode {
             config.mode = match mode.parse::<Mode>() {
@@ -558,10 +558,10 @@ pub async fn run(config: Config, rt: Handle) -> io::Result<()> {
     let state = ServerState::new_shared(&config, rt.clone()).await;
     let context = Context::new_shared(config, state.clone());
 
-    let bind_addr = match context.config().manager_address {
+    let bind_addr = match context.config().manager_addr {
         Some(ref a) => a,
         None => {
-            let err = Error::new(ErrorKind::Other, "missing `manager_address` in configuration");
+            let err = Error::new(ErrorKind::Other, "missing `manager_addr` in configuration");
             return Err(err);
         }
     };
@@ -574,7 +574,7 @@ pub async fn run(config: Config, rt: Handle) -> io::Result<()> {
     if !config.server.is_empty() {
         for svr_cfg in &config.server {
             let mut clean_config = Config::new(ConfigType::Server);
-            clean_config.local = config.local.clone();
+            clean_config.local_addr = config.local_addr.clone();
             clean_config.mode = config.mode;
             clean_config.no_delay = config.no_delay;
             clean_config.udp_timeout = config.udp_timeout;

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,7 +1,7 @@
 //! Relay server in local and server side implementations.
 
+pub mod dns;
 pub(crate) mod dns_resolver;
-#[cfg(target_os = "android")]
 pub mod dnsrelay;
 pub(crate) mod flow;
 pub(crate) mod loadbalancing;

--- a/src/relay/server.rs
+++ b/src/relay/server.rs
@@ -93,7 +93,7 @@ pub(crate) async fn run_with(
     // If specified manager-address, reports transmission statistic to it
     //
     // Dont do that if server is created by manager
-    if context.config().manager_address.is_some() {
+    if context.config().manager_addr.is_some() {
         let report_fut = manager_report_task(context.clone(), flow_stat);
         vf.push(report_fut.boxed());
     }
@@ -108,7 +108,7 @@ pub(crate) async fn run_with(
 }
 
 async fn manager_report_task(context: SharedContext, flow_stat: SharedMultiServerFlowStatistic) -> io::Result<()> {
-    let manager_addr = context.config().manager_address.as_ref().unwrap();
+    let manager_addr = context.config().manager_addr.as_ref().unwrap();
     let mut socket = ManagerDatagram::bind_for(manager_addr).await?;
 
     while context.server_running() {

--- a/src/relay/sys/unix/mod.rs
+++ b/src/relay/sys/unix/mod.rs
@@ -50,7 +50,6 @@ cfg_if! {
         ///
         /// More detail could be found in [shadowsocks-android](https://github.com/shadowsocks/shadowsocks-android) project.
         async fn protect(protect_path: &Option<String>, fd: RawFd) -> io::Result<()> {
-            use std::{io::Read, time::Duration};
             use tokio::io::AsyncReadExt;
 
             // ignore if protect_path is not specified
@@ -58,8 +57,6 @@ cfg_if! {
                 Some(path) => path,
                 None => return Ok(()),
             };
-
-            let timeout = Some(Duration::new(1, 0));
 
             let mut stream = self::uds::UnixStream::connect(path).await?;
 

--- a/src/relay/sys/unix/uds.rs
+++ b/src/relay/sys/unix/uds.rs
@@ -159,6 +159,7 @@ fn send_with_fd(socket: RawFd, bs: &[u8], fds: &[RawFd]) -> io::Result<usize> {
         });
 
         let cmsg_data = libc::CMSG_DATA(cmsg_header);
+        #[allow(clippy::cast_ptr_alignment)] // false positive
         let cmsg_data_slice = slice::from_raw_parts_mut(cmsg_data as *mut RawFd, fds.len());
         cmsg_data_slice.copy_from_slice(fds);
 

--- a/src/relay/tcprelay/http_local.rs
+++ b/src/relay/tcprelay/http_local.rs
@@ -638,7 +638,7 @@ impl ServerData for ServerScore {
 
 /// Starts a TCP local server with HTTP proxy protocol
 pub async fn run(context: SharedContext) -> io::Result<()> {
-    let local_addr = context.config().local.as_ref().expect("local config");
+    let local_addr = context.config().local_addr.as_ref().expect("local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let bypass_client = Client::builder().build::<_, Body>(DirectConnector::new(context.clone()));

--- a/src/relay/tcprelay/local.rs
+++ b/src/relay/tcprelay/local.rs
@@ -13,6 +13,7 @@ pub async fn run(context: SharedContext) -> io::Result<()> {
         ConfigType::Socks5Local => socks5_local::run(context).await,
         ConfigType::HttpLocal => http_local::run(context).await,
         ConfigType::RedirLocal => redir_local::run(context).await,
+        ConfigType::DnsLocal => unreachable!(),
         ConfigType::Server => unreachable!(),
         ConfigType::Manager => unreachable!(),
     }

--- a/src/relay/tcprelay/proxy_stream.rs
+++ b/src/relay/tcprelay/proxy_stream.rs
@@ -197,9 +197,12 @@ impl AsyncRead for ProxyStream {
         let p = forward_call!(self, poll_read, cx, buf);
 
         // Flow statistic for Android client
-        if cfg!(target_os = "android") && self.is_proxied() {
-            if let Poll::Ready(Ok(n)) = p {
-                self.context().local_flow_statistic().tcp().incr_tx(n as u64);
+        #[cfg(feature = "local-flow-stat")]
+        {
+            if self.is_proxied() {
+                if let Poll::Ready(Ok(n)) = p {
+                    self.context().local_flow_statistic().tcp().incr_tx(n as u64);
+                }
             }
         }
 
@@ -212,9 +215,12 @@ impl AsyncWrite for ProxyStream {
         let p = forward_call!(self, poll_write, cx, buf);
 
         // Flow statistic for Android client
-        if cfg!(target_os = "android") && self.is_proxied() {
-            if let Poll::Ready(Ok(n)) = p {
-                self.context().local_flow_statistic().tcp().incr_rx(n as u64);
+        #[cfg(feature = "local-flow-stat")]
+        {
+            if self.is_proxied() {
+                if let Poll::Ready(Ok(n)) = p {
+                    self.context().local_flow_statistic().tcp().incr_rx(n as u64);
+                }
             }
         }
 

--- a/src/relay/tcprelay/proxy_stream.rs
+++ b/src/relay/tcprelay/proxy_stream.rs
@@ -279,9 +279,11 @@ async fn connect_proxy_server(context: &Context, svr_cfg: &ServerConfig) -> io::
 
     let svr_addr = match context.config().config_type {
         ConfigType::Server => svr_cfg.addr(),
-        ConfigType::Socks5Local | ConfigType::TunnelLocal | ConfigType::HttpLocal | ConfigType::RedirLocal => {
-            svr_cfg.external_addr()
-        }
+        ConfigType::Socks5Local
+        | ConfigType::TunnelLocal
+        | ConfigType::HttpLocal
+        | ConfigType::RedirLocal
+        | ConfigType::DnsLocal => svr_cfg.external_addr(),
         ConfigType::Manager => unreachable!("ConfigType::Manager shouldn't need to connect to proxy server"),
     };
 

--- a/src/relay/tcprelay/redir_local.rs
+++ b/src/relay/tcprelay/redir_local.rs
@@ -88,7 +88,7 @@ async fn handle_redir_client(server: &SharedPlainServerStatistic, s: TcpStream, 
 }
 
 pub async fn run(context: SharedContext) -> io::Result<()> {
-    let local_addr = context.config().local.as_ref().expect("local config");
+    let local_addr = context.config().local_addr.as_ref().expect("local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let redir_ty = context.config().tcp_redir;

--- a/src/relay/tcprelay/server.rs
+++ b/src/relay/tcprelay/server.rs
@@ -70,7 +70,7 @@ async fn handle_client(
         return Ok(());
     }
 
-    let bind_addr = match context.config().local {
+    let bind_addr = match context.config().local_addr {
         None => None,
         Some(ref addr) => {
             let ba = addr.bind_addr(&*context).await?;

--- a/src/relay/tcprelay/socks5_local.rs
+++ b/src/relay/tcprelay/socks5_local.rs
@@ -218,7 +218,7 @@ async fn handle_socks5_client(
 
 /// Starts a TCP local server with Socks5 proxy protocol
 pub async fn run(context: SharedContext) -> io::Result<()> {
-    let local_addr = context.config().local.as_ref().expect("local config");
+    let local_addr = context.config().local_addr.as_ref().expect("local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let mut listener = TcpListener::bind(&bind_addr)

--- a/src/relay/tcprelay/tunnel_local.rs
+++ b/src/relay/tcprelay/tunnel_local.rs
@@ -94,7 +94,7 @@ pub async fn run(context: SharedContext) -> io::Result<()> {
         "TCP relay must be enabled for TUNNEL"
     );
 
-    let local_addr = context.config().local.as_ref().expect("local config");
+    let local_addr = context.config().local_addr.as_ref().expect("local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let mut listener = TcpListener::bind(&bind_addr)

--- a/src/relay/udprelay/association.rs
+++ b/src/relay/udprelay/association.rs
@@ -318,7 +318,8 @@ impl ProxyAssociation {
             );
         }
 
-        if cfg!(target_os = "android") {
+        #[cfg(feature = "local-flow-stat")]
+        {
             context.local_flow_statistic().udp().incr_tx(send_len as u64);
         }
 
@@ -420,7 +421,8 @@ impl ProxyAssociation {
         let mut payload = Vec::new();
         cur.read_to_end(&mut payload)?;
 
-        if cfg!(target_os = "android") {
+        #[cfg(feature = "local-flow-stat")]
+        {
             context.local_flow_statistic().udp().incr_rx(recv_n as u64);
         }
 

--- a/src/relay/udprelay/local.rs
+++ b/src/relay/udprelay/local.rs
@@ -12,6 +12,7 @@ pub async fn run(context: SharedContext) -> io::Result<()> {
         ConfigType::Socks5Local => socks5_local::run(context).await,
         ConfigType::RedirLocal => redir_local::run(context).await,
         ConfigType::HttpLocal => unreachable!(),
+        ConfigType::DnsLocal => unreachable!(),
         ConfigType::Server => unreachable!(),
         ConfigType::Manager => unreachable!(),
     }

--- a/src/relay/udprelay/redir_local.rs
+++ b/src/relay/udprelay/redir_local.rs
@@ -74,7 +74,7 @@ impl ProxySend for ProxyHandler {
 
 /// Starts a UDP local server
 pub async fn run(context: SharedContext) -> io::Result<()> {
-    let local_addr = context.config().local.as_ref().expect("missing local config");
+    let local_addr = context.config().local_addr.as_ref().expect("missing local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let ty = context.config().udp_redir;

--- a/src/relay/udprelay/server.rs
+++ b/src/relay/udprelay/server.rs
@@ -57,7 +57,7 @@ impl UdpAssociation {
         mut response_tx: mpsc::Sender<(SocketAddr, BytesMut)>,
     ) -> io::Result<UdpAssociation> {
         // Create a socket for receiving packets
-        let local_addr = match context.config().local {
+        let local_addr = match context.config().local_addr {
             None => {
                 // Let system allocate an address for us
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0)

--- a/src/relay/udprelay/socks5_local.rs
+++ b/src/relay/udprelay/socks5_local.rs
@@ -83,7 +83,7 @@ fn assemble_packet(addr: Address, pkt: &[u8]) -> Bytes {
 
 /// Starts a UDP local server
 pub async fn run(context: SharedContext) -> io::Result<()> {
-    let local_addr = context.config().local.as_ref().expect("local config");
+    let local_addr = context.config().local_addr.as_ref().expect("local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let l = create_udp_socket(&bind_addr).await?;

--- a/src/relay/udprelay/tunnel_local.rs
+++ b/src/relay/udprelay/tunnel_local.rs
@@ -43,7 +43,7 @@ impl ProxySend for ProxyHandler {
 
 /// Starts a UDP local server
 pub async fn run(context: SharedContext) -> io::Result<()> {
-    let local_addr = context.config().local.as_ref().expect("local config");
+    let local_addr = context.config().local_addr.as_ref().expect("local config");
     let bind_addr = local_addr.bind_addr(&*context).await?;
 
     let l = create_udp_socket(&bind_addr).await?;

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -39,7 +39,7 @@ impl Socks5TestServer {
             },
             cli_config: {
                 let mut cfg = Config::new(ConfigType::Socks5Local);
-                cfg.local = Some(ServerAddr::from(local_addr));
+                cfg.local_addr = Some(ServerAddr::from(local_addr));
                 cfg.server = vec![ServerConfig::basic(svr_addr, pwd.to_owned(), method)];
                 cfg.mode = if enable_udp { Mode::TcpAndUdp } else { Mode::TcpOnly };
                 cfg

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -46,7 +46,7 @@ fn get_svr_config() -> Config {
 
 fn get_cli_config() -> Config {
     let mut cfg = Config::new(ConfigType::Socks5Local);
-    cfg.local = Some(LOCAL_ADDR.parse().unwrap());
+    cfg.local_addr = Some(LOCAL_ADDR.parse().unwrap());
     cfg.server = vec![ServerConfig::basic(
         SERVER_ADDR.parse().unwrap(),
         PASSWORD.to_owned(),


### PR DESCRIPTION
- Allow working in standalone mode
- Use same UDP socket for sending response packet
- Send TCP queries with ProxyStream directly

ref #213 