### PR TITLE
Fix bugs in #235

### DIFF
--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -282,8 +282,8 @@ impl AccessControl {
 
     pub fn check_ip_in_proxy_list(&self, ip: &IpAddr) -> bool {
         match self.mode {
-            Mode::BlackList => self.black_list.check_ip_matched(ip),
-            Mode::WhiteList => !self.white_list.check_ip_matched(ip),
+            Mode::BlackList => !self.black_list.check_ip_matched(ip),
+            Mode::WhiteList => self.white_list.check_ip_matched(ip),
         }
     }
 

--- a/src/relay/dnsrelay/mod.rs
+++ b/src/relay/dnsrelay/mod.rs
@@ -151,24 +151,24 @@ async fn acl_lookup(
             let timeout = Some(Duration::new(3, 0));
             try_timeout(local_lookup(qname, qtype, local), timeout).await.ok()
         }
-    }.unwrap_or_else(|| Message::new());
+    }.unwrap_or_else(Message::new);
 
     match qname_in_proxy_list {
         Some(true) => {
-            let remote_response = remote_response_fut.await.unwrap_or_else(|| Message::new());
+            let remote_response = remote_response_fut.await.unwrap_or_else(Message::new);
             debug!("pick remote response (qname): {:?}", remote_response);
-            return Ok((remote_response.clone(), true));
+            return Ok((remote_response, true));
         }
         Some(false) => {
             debug!("pick local response (qname): {:?}", local_response);
-            return Ok((local_response.clone(), false));
+            return Ok((local_response, false));
         }
         None => (),
     }
 
     if local_response.answer_count() == 0 {
-        let remote_response = remote_response_fut.await.unwrap_or_else(|| Message::new());
-        return Ok((remote_response.clone(), true));
+        let remote_response = remote_response_fut.await.unwrap_or_else(Message::new);
+        return Ok((remote_response, true));
     }
 
     for rec in local_response.answers() {
@@ -179,13 +179,13 @@ async fn acl_lookup(
         };
         if !forward {
             debug!("pick local response (ip): {:?}", local_response);
-            return Ok((local_response.clone(), false))
+            return Ok((local_response, false))
         }
     }
 
-    let remote_response = remote_response_fut.await.unwrap_or_else(|| Message::new());
+    let remote_response = remote_response_fut.await.unwrap_or_else(Message::new);
     debug!("pick remote response (ip): {:?}", remote_response);
-    Ok((remote_response.clone(), true))
+    Ok((remote_response, true))
 }
 
 /// Start a DNS relay local server


### PR DESCRIPTION
1. Fix the return value of `acl::check_ip_in_proxy_list`.
2. Fix the condition order in `context::check_ip_in_proxy_list`
3. Keep the value whether the qname is resolved by remote or local in `add_to_reverse_lookup_cache`

Tested locally, all routes in Android client should work now.