### PR TITLE
[#243] Support cross compiling for aarch64-unknown-linux-gnu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
                   docker build -t shadowsocks-rust:x86_64-pc-windows-gnu -f Dockerfile.x86_64-pc-windows-gnu .
                   docker build -t shadowsocks-rust:x86_64-unknown-linux-musl -f Dockerfile.x86_64-unknown-linux-musl .
                   docker build -t shadowsocks-rust:arm-unknown-linux-gnueabihf -f Dockerfile.arm-unknown-linux-gnueabihf .
+                  docker build -t shadowsocks-rust:aarch64-unknown-linux-gnu -f Dockerfile.aarch64-unknown-linux-gnu .
             - run: |
                   curl "https://sh.rustup.rs" -o "rust-init.sh"
                   chmod +x "rust-init.sh"

--- a/Cross.toml
+++ b/Cross.toml
@@ -16,3 +16,6 @@ image = "shadowsocks-rust:x86_64-pc-windows-gnu"
 
 [target.arm-unknown-linux-gnueabihf]
 image = "shadowsocks-rust:arm-unknown-linux-gnueabihf"
+
+[target.aarch64-unknown-linux-gnu]
+image = "shadowsocks-rust:aarch64-unknown-linux-gnu"

--- a/build/Dockerfile.aarch64-unknown-linux-gnu
+++ b/build/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,0 +1,3 @@
+FROM rustembedded/cross:aarch64-unknown-linux-gnu
+
+ENV RUSTFLAGS="-Ctarget-feature=+aes"

--- a/build/build-release
+++ b/build/build-release
@@ -20,7 +20,7 @@ while getopts "t:" opt; do
 done
 
 if [[ "${#targets[@]}" == "0" ]]; then
-    targets=("x86_64-unknown-linux-musl" "x86_64-pc-windows-gnu" "arm-unknown-linux-gnueabihf")
+    targets=("x86_64-unknown-linux-musl" "x86_64-pc-windows-gnu" "arm-unknown-linux-gnueabihf" "aarch64-unknown-linux-gnu")
 fi
 
 function build() {


### PR DESCRIPTION
Latest Ubuntu Server 20.04 LTS released with rpi 64bit support.
It might be better than using Raspbian.
https://ubuntu.com/download/raspberry-pi
