### PR TITLE
Be more conservative when skipping resolving

### DIFF
--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -85,14 +85,14 @@ impl Rules {
         self.rule.is_match(host)
     }
 
-    /// Check if there are no rules for IPv4 addresses
-    fn is_ipv4_empty(&self) -> bool {
-        self.ipv4.is_empty()
+    /// Check if there are no rules for IP addresses
+    fn is_ip_empty(&self) -> bool {
+        self.ipv4.is_empty() && self.ipv6.is_empty()
     }
 
-    /// Check if there are no rules for IPv6 addresses
-    fn is_ipv6_empty(&self) -> bool {
-        self.ipv6.is_empty()
+    /// Check if there are no rules for domain names
+    fn is_host_empty(&self) -> bool {
+        self.rule.len() == 0
     }
 }
 
@@ -296,20 +296,17 @@ impl AccessControl {
         None
     }
 
-    /// If there are no IPv4 rules
-    pub fn is_ipv4_empty(&self) -> bool {
+    /// If there are no IP rules
+    pub fn is_ip_empty(&self) -> bool {
         match self.mode {
-            Mode::BlackList => self.black_list.is_ipv4_empty(),
-            Mode::WhiteList => self.white_list.is_ipv4_empty(),
+            Mode::BlackList => self.black_list.is_ip_empty(),
+            Mode::WhiteList => self.white_list.is_ip_empty(),
         }
     }
 
-    /// If there are no IPv6 rules
-    pub fn is_ipv6_empty(&self) -> bool {
-        match self.mode {
-            Mode::BlackList => self.black_list.is_ipv6_empty(),
-            Mode::WhiteList => self.white_list.is_ipv6_empty(),
-        }
+    /// If there are no domain name rules
+    pub fn is_host_empty(&self) -> bool {
+        self.black_list.is_host_empty() && self.white_list.is_host_empty()
     }
 
     /// Check if `IpAddr` should be proxied
@@ -343,7 +340,7 @@ impl AccessControl {
                 if let Some(value) = self.check_host_in_proxy_list(host) {
                     return !value;
                 }
-                if self.is_ipv4_empty() && self.is_ipv6_empty() {
+                if self.is_ip_empty() {
                     return !self.is_default_in_proxy_list();
                 }
                 if let Ok(vaddr) = context.dns_resolve(host, port).await {

--- a/src/relay/dnsrelay/mod.rs
+++ b/src/relay/dnsrelay/mod.rs
@@ -84,13 +84,7 @@ fn should_forward_by_query(acl: &Option<AccessControl>, query: &Query) -> Option
             Some(should_forward_by_ptr_name(acl, query.name()))
         } else {
             let result = check_name_in_proxy_list(acl, query.name());
-            if result == None && match query.query_type() {
-                RecordType::A => acl.is_ipv4_empty(),
-                RecordType::AAAA => acl.is_ipv6_empty(),
-                RecordType::ANY => acl.is_ipv4_empty() && acl.is_ipv6_empty(),
-                RecordType::PTR => unreachable!(),
-                _ => true,
-            } {
+            if result == None && acl.is_ip_empty() && acl.is_host_empty() {
                 Some(acl.is_default_in_proxy_list())
             } else {
                 result


### PR DESCRIPTION
As we examine CNAME records in answer section and possibly A/AAAA records in additional section, we should only skip the second stage only if the entire ACL is empty.