### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ lru_time_cache = "0.10"
 hyper = { version = "0.13", optional = true }
 http = { version = "0.2", optional = true }
 tower = { version = "0.3", optional = true }
-pin-project = "0.4"
+pin-project = "0.4.17"
 socket2 = "0.3"
 cfg-if = "0.1"
 bloomfilter = "^1.0.2"

--- a/src/relay/tcprelay/http_local.rs
+++ b/src/relay/tcprelay/http_local.rs
@@ -55,7 +55,7 @@ use crate::{
 
 use super::ProxyStream;
 
-#[pin_project]
+#[pin_project(project = ProxyHttpStreamProj)]
 enum ProxyHttpStream {
     Http(#[pin] ProxyStream),
     #[cfg(feature = "local-http-native-tls")]
@@ -167,13 +167,10 @@ impl ProxyHttpStream {
 
 macro_rules! forward_call {
     ($self:expr, $method:ident $(, $param:expr)*) => {
-        // #[project]
         match $self.as_mut().project() {
-            // ProxyHttpStream::Http(stream) => stream.$method($($param),*),
-            __ProxyHttpStreamProjection::Http(stream) => stream.$method($($param),*),
+            ProxyHttpStreamProj::Http(stream) => stream.$method($($param),*),
             #[cfg(any(feature = "local-http-native-tls", feature = "local-http-rustls"))]
-            // ProxyHttpStream::Https(stream, ..) => stream.$method($($param),*),
-            __ProxyHttpStreamProjection::Https(stream, ..) => stream.$method($($param),*),
+            ProxyHttpStreamProj::Https(stream, ..) => stream.$method($($param),*),
         }
     };
 }


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*