### PR TITLE
Remove the VPN option hack

### DIFF
--- a/src/plugin/ss_plugin.rs
+++ b/src/plugin/ss_plugin.rs
@@ -22,13 +22,6 @@ pub fn plugin_cmd(plugin: &PluginConfig, remote: &ServerAddr, local: &SocketAddr
 
     if let Some(ref opt) = plugin.plugin_opt {
         cmd.env("SS_PLUGIN_OPTIONS", opt);
-        #[cfg(target_os = "android")]
-        {
-            // Add VPN flags to the commandline as well
-            if opt.contains(";V") {
-                cmd.arg("-V");
-            }
-        }
     }
 
     cmd


### PR DESCRIPTION
Remove the previous hack, according to the discussion here: https://github.com/shadowsocks/shadowsocks-rust/pull/278