### PR TITLE
Fix `conflicts_with` related errors

### DIFF
--- a/src/bin/local.rs
+++ b/src/bin/local.rs
@@ -56,7 +56,7 @@ fn main() {
         (about: "A fast tunnel proxy that helps you bypass firewalls.")
         (@arg VERBOSE: -v ... "Set the level of debug")
         (@arg UDP_ONLY: -u conflicts_with[TCP_AND_UDP] "Server mode UDP_ONLY")
-        (@arg TCP_AND_UDP: -U conflicts_with[UDP_ONLY] "Server mode TCP_AND_UDP")
+        (@arg TCP_AND_UDP: -U "Server mode TCP_AND_UDP")
 
         (@arg CONFIG: -c --config +takes_value required_unless_all(&["LOCAL_ADDR", "SERVER_CONFIG"]) "Shadowsocks configuration file (https://shadowsocks.org/en/config/quick-guide.html)")
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -44,7 +44,7 @@ fn main() {
         (about: "A fast tunnel proxy that helps you bypass firewalls.")
         (@arg VERBOSE: -v ... "Set the level of debug")
         (@arg UDP_ONLY: -u conflicts_with[TCP_AND_UDP] "Server mode UDP_ONLY")
-        (@arg TCP_AND_UDP: -U conflicts_with[UDP_ONLY] "Server mode TCP_AND_UDP")
+        (@arg TCP_AND_UDP: -U "Server mode TCP_AND_UDP")
 
         (@arg CONFIG: -c --config +takes_value required_unless("SERVER_ADDR") "Shadowsocks configuration file (https://shadowsocks.org/en/config/quick-guide.html)")
 

--- a/src/bin/ssurl.rs
+++ b/src/bin/ssurl.rs
@@ -73,7 +73,7 @@ fn main() {
         (version: shadowsocks::VERSION)
         (about: "Encode and decode ShadowSocks URL")
         (@arg ENCODE: -e --encode +takes_value conflicts_with[DECODE] "Encode the server configuration in the provided JSON file")
-        (@arg DECODE: -d --decode +takes_value conflicts_with[ENCODE] "Decode the server configuration from the provide ShadowSocks URL")
+        (@arg DECODE: -d --decode +takes_value "Decode the server configuration from the provide ShadowSocks URL")
         (@arg QRCODE: -c --qrcode !takes_value "Generate the QRCode with the provided configuration")
         (@group ACTION =>
             (@attributes +required ... arg[ENCODE DECODE])


### PR DESCRIPTION
Fixed #284 

> conflicts_with
> > NOTE: Conflicting rules take precedence over being required by default. Conflict rules only need to be set for one of the two arguments, they do not need to be set for each.