### PR TITLE
Add arm-unknown-linux-musleabi release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ jobs:
                       docker build -t shadowsocks-rust:x86_64-unknown-linux-musl -f Dockerfile.x86_64-unknown-linux-musl .
                       docker build -t shadowsocks-rust:x86_64-unknown-linux-gnu -f Dockerfile.x86_64-unknown-linux-gnu .
                       docker build -t shadowsocks-rust:arm-unknown-linux-gnueabihf -f Dockerfile.arm-unknown-linux-gnueabihf .
+                      docker build -t shadowsocks-rust:arm-unknown-linux-musleabi -f Dockerfile.arm-unknown-linux-musleabi .
                       docker build -t shadowsocks-rust:aarch64-unknown-linux-gnu -f Dockerfile.aarch64-unknown-linux-gnu .
             - run:
                   name: "Install Rust"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,6 +17,7 @@ jobs:
           - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
           - arm-unknown-linux-gnueabihf
+          - arm-unknown-linux-musleabi
           - aarch64-unknown-linux-gnu
           - mips-unknown-linux-musl
           - mipsel-unknown-linux-musl

--- a/Cross.toml
+++ b/Cross.toml
@@ -17,6 +17,9 @@ image = "shadowsocks-rust:x86_64-pc-windows-gnu"
 [target.arm-unknown-linux-gnueabihf]
 image = "shadowsocks-rust:arm-unknown-linux-gnueabihf"
 
+[target.arm-unknown-linux-musleabi]
+image = "shadowsocks-rust:arm-unknown-linux-musleabi"
+
 [target.aarch64-unknown-linux-gnu]
 image = "shadowsocks-rust:aarch64-unknown-linux-gnu"
 

--- a/build/Dockerfile.arm-unknown-linux-musleabi
+++ b/build/Dockerfile.arm-unknown-linux-musleabi
@@ -1,0 +1,3 @@
+FROM rustembedded/cross:arm-unknown-linux-musleabi
+
+ENV RUSTFLAGS="-Ctarget-feature=+aes"

--- a/build/build-release
+++ b/build/build-release
@@ -27,6 +27,7 @@ if [[ "${#targets[@]}" == "0" ]]; then
         "x86_64-pc-windows-gnu"
 
         "arm-unknown-linux-gnueabihf" # armhf, hard
+        "arm-unknown-linux-musleabi"  # arm, soft
         "aarch64-unknown-linux-gnu"
 
         "mips-unknown-linux-musl"     # big endian


### PR DESCRIPTION
Some old routers (like xiaomi R1D/R2D) could use arm-unknown-linux-musleabi release.