### PR TITLE
Fix #311. Fix mips and mipsel build

### DIFF
--- a/build/Dockerfile.mips-unknown-linux-musl
+++ b/build/Dockerfile.mips-unknown-linux-musl
@@ -1,3 +1,3 @@
-FROM rustembedded/cross:mips-unknown-linux-musl
+FROM rustembedded/cross:mips-unknown-linux-musl-0.2.1
 
 # ENV RUSTFLAGS=""

--- a/build/Dockerfile.mipsel-unknown-linux-musl
+++ b/build/Dockerfile.mipsel-unknown-linux-musl
@@ -1,3 +1,3 @@
-FROM rustembedded/cross:mipsel-unknown-linux-musl
+FROM rustembedded/cross:mipsel-unknown-linux-musl-0.2.1
 
 # ENV RUSTFLAGS=""


### PR DESCRIPTION
Waiting this issue fixed: https://github.com/rust-lang/libc/issues/1848

Then we can switch back to `mips-unknown-linux-musl`

Fix #311 