### PR TITLE
minimize target file in size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ lto = "fat"
 codegen-units = 1
 incremental = false
 panic = "abort"
+opt-level = "z"
 
 [features]
 default = [


### PR DESCRIPTION
The `opt-level = "z"` reduces target binaries to 80-90%.
If we `strip` it up, it will reduces to ≈55%.

- "z" on origin:

|           |   origin   | "z" opt-ed | SHRINK |
|-----------|-----------:|-----------:|-------:|
| sslocal   | 12,956,312 | 11,106,768 | 85.72% |
| ssserver  | 11,103,240 |  9,830,544 | 88.54% |
| ssurl     |  4,808,248 |  4,221,328 | 87.79% |
| ssmanager | 11,216,072 |  9,924,528 | 88.48% |

- "z" on `strip`-ed origin:

|           | `strip`-ed origin | "z" opt-ed | SHRINK |
|-----------|------------------:|-----------:|-------:|
| sslocal   |         9,089,056 |  7,274,528 | 80.03% |
| ssserver  |         7,392,928 |  6,266,528 | 84.76% |
| ssurl     |         2,535,872 |  2,310,592 | 91.12% |
| ssmanager |         7,503,520 |  6,344,352 | 84.55% |

- "z" + `strip` on origin:

|           |   origin   | "z" + strip | SHRINK |
|-----------|-----------:|------------:|-------:|
| sslocal   | 12,956,312 |   7,274,528 | 56.14% |
| ssserver  | 11,103,240 |   6,266,528 | 56.44% |
| ssurl     |  4,808,248 |   2,310,592 | 48.05% |
| ssmanager | 11,216,072 |   6,344,352 | 56.56% |

