### PR TITLE
🏓 Ping balancer: treat ping timeouts as failures

### DIFF
--- a/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
@@ -480,6 +480,8 @@ impl PingChecker {
                 Err(err)
             }
             Err(..) => {
+                use std::io::{Error, ErrorKind};
+
                 // Timeout
                 trace!(
                     "checked remote {} server {} latency timeout, elapsed {} ms",
@@ -488,8 +490,9 @@ impl PingChecker {
                     elapsed
                 );
 
-                // NOTE: timeout is still available, but server is too slow
-                Ok(elapsed)
+                // NOTE: timeout exceeded. Count as error.
+                let err = Error::new(ErrorKind::TimedOut, "Request timed out");
+                Err(err)
             }
         }
     }

--- a/crates/shadowsocks-service/src/local/loadbalancing/server_stat.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/server_stat.rs
@@ -2,13 +2,13 @@
 
 use std::collections::VecDeque;
 
-/// Interval of active probing
-pub const DEFAULT_CHECK_INTERVAL_SEC: u64 = 6;
-/// Timeout of each probing
-pub const DEFAULT_CHECK_TIMEOUT_SEC: u64 = 2; // Latency shouldn't greater than 2 secs, that's too long
+/// Interval between each check
+pub const DEFAULT_CHECK_INTERVAL_SEC: u64 = 10;
+/// Timeout of each check
+pub const DEFAULT_CHECK_TIMEOUT_SEC: u64 = 5; // A common connection timeout of 5 seconds.
 
 const MAX_SERVER_RTT: u32 = DEFAULT_CHECK_TIMEOUT_SEC as u32 * 1000;
-const MAX_LATENCY_QUEUE_SIZE: usize = 99;
+const MAX_LATENCY_QUEUE_SIZE: usize = 59; // Account for the last 10 minutes.
 
 /// Statistic score
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
- Treat timeouts as failures, so requests that receive no response count as failures.
- Increase check timeout from 2s to 5s to avoid penalties on slow servers.
- Increase check interval from 6s to 10s.