### PR TITLE
Lazy server disable implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Create a ShadowSocks' configuration file. Example
 
 Detailed explanation could be found in [shadowsocks' documentation](https://github.com/shadowsocks/shadowsocks/wiki).
 
-In shadowsocks-rust, we also have an extended configuration file format, which is able to define more than one servers:
+In shadowsocks-rust, we also have an extended configuration file format, which is able to define more than one server. You can also disable individual servers.
 
 ```json
 {
@@ -141,6 +141,13 @@ In shadowsocks-rust, we also have an extended configuration file format, which i
             "address": "127.0.0.1",
             "port": 1081,
             "password": "hello-kitty",
+            "method": "chacha20-ietf-poly1305"
+        },
+        {
+            "disable": true,
+            "address": "eg.disable.me",
+            "port": 1080,
+            "password": "hello-internet",
             "method": "chacha20-ietf-poly1305"
         }
     ],

--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ Example configuration:
     "servers": [
         {
             // Fields are the same as the single server's configuration
+            
+            // Individual server can be disabled
+            // "disable": true,
             "address": "0.0.0.0",
             "port": 8389,
             "method": "aes-256-gcm",

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -138,6 +138,8 @@ struct SSServerExtConfig {
     password: String,
     method: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    disable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     plugin: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     plugin_opts: Option<String>,
@@ -872,7 +874,16 @@ impl Config {
 
         // Ext servers
         if let Some(servers) = config.servers {
-            for svr in servers {
+            // Filter out disabled servers
+            let enabled_servers = servers
+                .into_iter()
+                .filter(|ext_cfg| match ext_cfg.disable {
+                    Some(true) => false,
+                    _ => true,
+                })
+                .collect::<Vec<_>>();
+
+            for svr in enabled_servers {
                 let address = svr.server;
                 let port = svr.server_port;
 
@@ -1263,9 +1274,9 @@ impl fmt::Display for Config {
         }
 
         // Servers
-        // For 1 servers, uses standard configure format
         match self.server.len() {
             0 => {}
+            // For 1 server, uses standard configure format
             1 if self.server[0].id().is_none() && self.server[0].remarks().is_none() => {
                 let svr = &self.server[0];
 
@@ -1290,6 +1301,7 @@ impl fmt::Display for Config {
                 });
                 jconf.timeout = svr.timeout().map(|t| t.as_secs());
             }
+            // For >1 servers, uses extended multiple server format
             _ => {
                 let mut vsvr = Vec::new();
 
@@ -1305,6 +1317,7 @@ impl fmt::Display for Config {
                         },
                         password: svr.password().to_string(),
                         method: svr.method().to_string(),
+                        disable: None,
                         plugin: svr.plugin().map(|p| p.plugin.to_string()),
                         plugin_opts: svr.plugin().and_then(|p| p.plugin_opts.clone()),
                         plugin_args: svr.plugin().and_then(|p| {

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -874,16 +874,12 @@ impl Config {
 
         // Ext servers
         if let Some(servers) = config.servers {
-            // Filter out disabled servers
-            let enabled_servers = servers
-                .into_iter()
-                .filter(|ext_cfg| match ext_cfg.disable {
-                    Some(true) => false,
-                    _ => true,
-                })
-                .collect::<Vec<_>>();
+            for svr in servers {
+                // Skip if server is disabled
+                if svr.disable.unwrap_or(false) {
+                    continue;
+                }
 
-            for svr in enabled_servers {
                 let address = svr.server;
                 let port = svr.server_port;
 


### PR DESCRIPTION
See shadowsocks/shadowsocks-rust#394

This is a lazy implementation that simply filters for `disable` before the vector of `shadowsocks::ServerConfig` is created.

- Benefit: simply, lazy, no memory usage, no modification to `shadowsocks::ServerConfig`
- Downside: `Display` trait for `shadowsocks_service::Config` is not aware of disabled servers