### PR TITLE
add release i386

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       matrix:
         target:
+          - i686-unknown-linux-musl
           - x86_64-pc-windows-gnu
-          - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - arm-unknown-linux-gnueabi
           - arm-unknown-linux-gnueabihf
           - arm-unknown-linux-musleabi


### PR DESCRIPTION
This adds i386 builds in workflow.

BTW, I'm confused with the difference between `arm-unknown-linux-musleabihf` and
`armv7-unknown-linux-musleabihf`, would anyone tell me that? Thanks so much.