### PR TITLE
support multiple local servers in configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "shadowsocks"
-version = "1.9.2"
+version = "1.10.0"
 dependencies = [
  "arc-swap 1.2.0",
  "async-trait",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "shadowsocks-rust"
-version = "1.9.2"
+version = "1.10.0"
 dependencies = [
  "byte_string",
  "byteorder",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "shadowsocks-service"
-version = "1.9.2"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "byte_string",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
 
 [[package]]
 name = "async-trait"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e098e9c493fdf92832223594d9a164f96bdf17ba81a42aff86f85c76768726a"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -148,9 +148,9 @@ checksum = "11aade7a05aa8c3a351cedc44c3fc45806430543382fcc4743a9b757a2a0b4ed"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -993,15 +993,15 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -1013,9 +1013,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg",
  "cc",
@@ -1253,21 +1253,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "54fd1046a3107eb58f42de31d656fee6853e5d276c455fd943742dce89fc3dd3"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -1371,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1654,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
+checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1753,15 +1752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,9 +1778,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1840,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1892,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadowsocks-rust"
-version = "1.9.2"
+version = "1.10.0"
 authors = ["Shadowsocks Contributors"]
 description = "shadowsocks is a fast tunnel proxy that helps you bypass firewalls."
 repository = "https://github.com/shadowsocks/shadowsocks-rust"
@@ -122,7 +122,7 @@ mimalloc = { version = "0.1", optional = true }
 tcmalloc = { version = "0.3", optional = true }
 jemallocator = { version = "0.3", optional = true }
 
-shadowsocks-service = { version = "1.9.2", path = "./crates/shadowsocks-service" }
+shadowsocks-service = { version = "1.10.0", path = "./crates/shadowsocks-service" }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ cfg-if = "1"
 qrcode = { version = "0.12", default-features = false }
 
 futures = "0.3"
-tokio = { version = "1.2", features = ["rt", "signal"] }
+tokio = { version = "1", features = ["rt", "signal"] }
 
 mimalloc = { version = "0.1", optional = true }
 tcmalloc = { version = "0.3", optional = true }

--- a/bin/common/validator/mod.rs
+++ b/bin/common/validator/mod.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 #[cfg(feature = "local-dns")]
 use shadowsocks_service::local::dns::NameServerAddr;
@@ -24,6 +24,7 @@ validate_type!(
     ServerAddr,
     "should be either ip:port or domain:port"
 );
+validate_type!(validate_ip_addr, IpAddr, "should be a valid IPv4 or IPv6 address");
 validate_type!(validate_socket_addr, SocketAddr, "should be ip:port");
 validate_type!(validate_address, Address, "should be either ip:port or domain:port");
 validate_type!(

--- a/bin/ssmanager.rs
+++ b/bin/ssmanager.rs
@@ -16,10 +16,10 @@ use tokio::{self, runtime::Builder};
 
 use shadowsocks_service::{
     acl::AccessControl,
-    config::{Config, ConfigType, ManagerConfig, ManagerServerHost, Mode},
+    config::{Config, ConfigType, ManagerConfig, ManagerServerHost},
     run_manager,
     shadowsocks::{
-        config::ManagerAddr,
+        config::{ManagerAddr, Mode},
         crypto::v1::{available_ciphers, CipherKind},
     },
 };
@@ -138,16 +138,17 @@ fn main() {
         config.local_addr = Some(bind_addr);
     }
 
+    // Overrides
     if matches.is_present("UDP_ONLY") {
-        if config.mode.enable_tcp() {
-            config.mode = Mode::TcpAndUdp;
-        } else {
-            config.mode = Mode::UdpOnly;
+        if let Some(ref mut m) = config.manager {
+            m.mode = m.mode.merge(Mode::UdpOnly);
         }
     }
 
     if matches.is_present("TCP_AND_UDP") {
-        config.mode = Mode::TcpAndUdp;
+        if let Some(ref mut m) = config.manager {
+            m.mode = Mode::TcpAndUdp;
+        }
     }
 
     if matches.is_present("NO_DELAY") {

--- a/bin/ssmanager.rs
+++ b/bin/ssmanager.rs
@@ -7,10 +7,7 @@
 //! *It should be notice that the extented configuration file is not suitable for the server
 //! side.*
 
-use std::{
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
+use std::{net::IpAddr, time::Duration};
 
 use clap::{clap_app, Arg};
 use futures::future::{self, Either};
@@ -22,7 +19,7 @@ use shadowsocks_service::{
     config::{Config, ConfigType, ManagerConfig, ManagerServerHost, Mode},
     run_manager,
     shadowsocks::{
-        config::{ManagerAddr, ServerAddr},
+        config::ManagerAddr,
         crypto::v1::{available_ciphers, CipherKind},
     },
 };
@@ -50,7 +47,7 @@ fn main() {
                 the only required fields are \"manager_address\" and \"manager_port\". \
                 Servers defined will be created when process is started.")
 
-        (@arg BIND_ADDR: -b --("bind-addr") +takes_value "Bind address, outbound socket will bind this address")
+        (@arg BIND_ADDR: -b --("bind-addr") +takes_value {validator::validate_ip_addr} "Bind address, outbound socket will bind this address")
         (@arg SERVER_HOST: -s --("server-host") +takes_value "Host name or IP address of your remote server")
 
         (@arg NO_DELAY: --("no-delay") !takes_value "Set TCP_NODELAY option for socket")
@@ -137,11 +134,7 @@ fn main() {
     };
 
     if let Some(bind_addr) = matches.value_of("BIND_ADDR") {
-        let bind_addr = match bind_addr.parse::<IpAddr>() {
-            Ok(ip) => ServerAddr::from(SocketAddr::new(ip, 0)),
-            Err(..) => ServerAddr::from((bind_addr, 0)),
-        };
-
+        let bind_addr = bind_addr.parse::<IpAddr>().expect("bind-addr");
         config.local_addr = Some(bind_addr);
     }
 

--- a/bin/ssserver.rs
+++ b/bin/ssserver.rs
@@ -7,10 +7,7 @@
 //! *It should be notice that the extented configuration file is not suitable for the server
 //! side.*
 
-use std::{
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
+use std::{net::IpAddr, time::Duration};
 
 use clap::{clap_app, Arg};
 use futures::future::{self, Either};
@@ -48,7 +45,7 @@ fn main() {
 
         (@arg CONFIG: -c --config +takes_value required_unless("SERVER_ADDR") "Shadowsocks configuration file (https://shadowsocks.org/en/config/quick-guide.html)")
 
-        (@arg BIND_ADDR: -b --("bind-addr") +takes_value "Bind address, outbound socket will bind this address")
+        (@arg BIND_ADDR: -b --("bind-addr") +takes_value {validator::validate_ip_addr} "Bind address, outbound socket will bind this address")
 
         (@arg SERVER_ADDR: -s --("server-addr") +takes_value {validator::validate_server_addr} requires[PASSWORD ENCRYPT_METHOD] "Server address")
         (@arg PASSWORD: -k --password +takes_value requires[SERVER_ADDR] "Server's password")
@@ -175,11 +172,7 @@ fn main() {
     }
 
     if let Some(bind_addr) = matches.value_of("BIND_ADDR") {
-        let bind_addr = match bind_addr.parse::<IpAddr>() {
-            Ok(ip) => ServerAddr::from(SocketAddr::new(ip, 0)),
-            Err(..) => ServerAddr::from((bind_addr, 0)),
-        };
-
+        let bind_addr = bind_addr.parse::<IpAddr>().expect("bind-addr");
         config.local_addr = Some(bind_addr);
     }
 

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadowsocks-service"
-version = "1.9.2"
+version = "1.10.0"
 authors = ["Shadowsocks Contributors"]
 description = "shadowsocks is a fast tunnel proxy that helps you bypass firewalls."
 repository = "https://github.com/shadowsocks/shadowsocks-rust"
@@ -105,7 +105,7 @@ regex = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 json5 = "0.3"
 
-shadowsocks = { version = "1.9.2", path = "../shadowsocks" }
+shadowsocks = { version = "1.10.0", path = "../shadowsocks" }
 
 strum = { version = "0.20", optional = true }
 strum_macros = { version = "0.20", optional = true }

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -80,7 +80,7 @@ byteorder = "1.3"
 rand = { version = "0.8", optional = true }
 
 futures = "0.3"
-tokio = { version = "1.2", features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }
 tokio-native-tls = { version = "0.3", optional = true }
 native-tls = { version = "0.2.7", optional = true, features = ["alpn"] }
 tokio-rustls = { version = "0.22", optional = true }

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -1638,7 +1638,7 @@ impl fmt::Display for Config {
         match self.server.len() {
             0 => {}
             // For 1 server, uses standard configure format
-            1 if self.server[0].id().is_none() && self.server[0].remarks().is_none() => {
+            1 if self.server[0].is_basic() => {
                 let svr = &self.server[0];
 
                 jconf.server = Some(match *svr.addr() {

--- a/crates/shadowsocks-service/src/dns/mod.rs
+++ b/crates/shadowsocks-service/src/dns/mod.rs
@@ -1,0 +1,57 @@
+//! DNS resolvers
+
+use shadowsocks::{dns_resolver::DnsResolver, net::ConnectOpts};
+
+use crate::config::DnsConfig;
+
+#[allow(unused_variables)]
+pub async fn build_dns_resolver(dns: DnsConfig, ipv6_first: bool, connect_opts: &ConnectOpts) -> Option<DnsResolver> {
+    match dns {
+        DnsConfig::System => {
+            #[cfg(feature = "trust-dns")]
+            if crate::hint_support_default_system_resolver() {
+                use log::warn;
+
+                return match DnsResolver::trust_dns_system_resolver(ipv6_first).await {
+                    Ok(r) => Some(r),
+                    Err(err) => {
+                        warn!(
+                            "initialize trust-dns DNS system resolver failed, fallback to default system resolver, error: {}",
+                            err
+                        );
+                        None
+                    }
+                };
+            }
+
+            None
+        }
+        #[cfg(feature = "trust-dns")]
+        DnsConfig::TrustDns(dns) => match DnsResolver::trust_dns_resolver(dns, ipv6_first).await {
+            Ok(r) => Some(r),
+            Err(err) => {
+                use log::warn;
+
+                warn!(
+                    "initialize trust-dns DNS resolver failed, fallback to default system resolver, error: {}",
+                    err
+                );
+                None
+            }
+        },
+        #[cfg(feature = "local-dns")]
+        DnsConfig::LocalDns(ns) => {
+            use crate::{config::Mode, local::dns::dns_resolver::DnsResolver as LocalDnsResolver};
+            use log::trace;
+
+            trace!("initializing direct DNS resolver for {}", ns);
+
+            let mut resolver = LocalDnsResolver::new(ns);
+            resolver.set_mode(Mode::TcpAndUdp);
+            resolver.set_ipv6_first(ipv6_first);
+            resolver.set_connect_opts(connect_opts.clone());
+
+            Some(DnsResolver::custom_resolver(resolver))
+        }
+    }
+}

--- a/crates/shadowsocks-service/src/dns/mod.rs
+++ b/crates/shadowsocks-service/src/dns/mod.rs
@@ -41,8 +41,9 @@ pub async fn build_dns_resolver(dns: DnsConfig, ipv6_first: bool, connect_opts: 
         },
         #[cfg(feature = "local-dns")]
         DnsConfig::LocalDns(ns) => {
-            use crate::{config::Mode, local::dns::dns_resolver::DnsResolver as LocalDnsResolver};
+            use crate::local::dns::dns_resolver::DnsResolver as LocalDnsResolver;
             use log::trace;
+            use shadowsocks::config::Mode;
 
             trace!("initializing direct DNS resolver for {}", ns);
 

--- a/crates/shadowsocks-service/src/lib.rs
+++ b/crates/shadowsocks-service/src/lib.rs
@@ -60,6 +60,7 @@ pub use shadowsocks;
 
 pub mod acl;
 pub mod config;
+mod dns;
 #[cfg(feature = "local")]
 pub mod local;
 #[cfg(feature = "manager")]

--- a/crates/shadowsocks-service/src/local/dns/dns_resolver.rs
+++ b/crates/shadowsocks-service/src/local/dns/dns_resolver.rs
@@ -8,13 +8,11 @@ use std::{
 use async_trait::async_trait;
 use futures::future;
 use log::{debug, trace};
-use shadowsocks::{dns_resolver::DnsResolve, net::ConnectOpts};
+use shadowsocks::{config::Mode, dns_resolver::DnsResolve, net::ConnectOpts};
 use trust_dns_resolver::proto::{
     op::{Message, Query},
     rr::{DNSClass, Name, RData, RecordType},
 };
-
-use crate::config::Mode;
 
 use super::{client_cache::DnsClientCache, config::NameServerAddr};
 

--- a/crates/shadowsocks-service/src/local/dns/server.rs
+++ b/crates/shadowsocks-service/src/local/dns/server.rs
@@ -16,6 +16,7 @@ use futures::future::{self, Either};
 use log::{debug, error, info, trace, warn};
 use rand::{thread_rng, Rng};
 use shadowsocks::{
+    config::Mode,
     lookup_then,
     net::{TcpListener, UdpSocket as ShadowUdpSocket},
     relay::{udprelay::MAXIMUM_UDP_PAYLOAD_SIZE, Address},
@@ -33,7 +34,6 @@ use trust_dns_resolver::proto::{
 
 use crate::{
     acl::AccessControl,
-    config::Mode,
     local::{context::ServiceContext, loadbalancing::PingBalancer},
 };
 

--- a/crates/shadowsocks-service/src/local/http/server.rs
+++ b/crates/shadowsocks-service/src/local/http/server.rs
@@ -17,10 +17,7 @@ use hyper::{
 use log::{error, info};
 use shadowsocks::{config::ServerAddr, lookup_then};
 
-use crate::{
-    config::ClientConfig,
-    local::{context::ServiceContext, loadbalancing::PingBalancer},
-};
+use crate::local::{context::ServiceContext, loadbalancing::PingBalancer};
 
 use super::{client_cache::ProxyClientCache, connector::BypassConnector, dispatcher::HttpDispatcher};
 
@@ -47,7 +44,7 @@ impl Http {
     }
 
     /// Run server
-    pub async fn run(self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    pub async fn run(self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let bypass_client = Client::builder().build::<_, Body>(BypassConnector::new(self.context.clone()));
 
         let context = self.context.clone();

--- a/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
@@ -16,6 +16,7 @@ use byte_string::ByteStr;
 use futures::future::{self, AbortHandle};
 use log::{debug, info, trace};
 use shadowsocks::{
+    config::Mode,
     relay::{
         socks5::Address,
         tcprelay::proxy_stream::ProxyClientStream,
@@ -28,7 +29,7 @@ use tokio::{
     time,
 };
 
-use crate::{config::Mode, local::context::ServiceContext};
+use crate::local::context::ServiceContext;
 
 use super::{
     server_data::ServerIdent,

--- a/crates/shadowsocks-service/src/local/redir/server.rs
+++ b/crates/shadowsocks-service/src/local/redir/server.rs
@@ -3,9 +3,10 @@
 use std::{io, sync::Arc, time::Duration};
 
 use futures::{future, FutureExt};
+use shadowsocks::ServerAddr;
 
 use crate::{
-    config::{ClientConfig, Mode, RedirType},
+    config::{Mode, RedirType},
     local::{context::ServiceContext, loadbalancing::PingBalancer},
 };
 
@@ -73,7 +74,7 @@ impl Redir {
     }
 
     /// Start serving
-    pub async fn run(self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    pub async fn run(self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let mut vfut = Vec::new();
 
         if self.mode.enable_tcp() {
@@ -88,7 +89,7 @@ impl Redir {
         res
     }
 
-    async fn run_tcp_tunnel(&self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    async fn run_tcp_tunnel(&self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         run_tcp_redir(
             self.context.clone(),
             client_config,
@@ -99,7 +100,7 @@ impl Redir {
         .await
     }
 
-    async fn run_udp_tunnel(&self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    async fn run_udp_tunnel(&self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let server = UdpRedir::new(
             self.context.clone(),
             self.udp_redir,

--- a/crates/shadowsocks-service/src/local/redir/tcprelay/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/tcprelay/mod.rs
@@ -8,14 +8,14 @@ use std::{
 };
 
 use log::{debug, error, info, trace};
-use shadowsocks::{lookup_then, net::TcpListener as ShadowTcpListener, relay::socks5::Address};
+use shadowsocks::{lookup_then, net::TcpListener as ShadowTcpListener, relay::socks5::Address, ServerAddr};
 use tokio::{
     net::{TcpListener, TcpStream},
     time,
 };
 
 use crate::{
-    config::{ClientConfig, RedirType},
+    config::RedirType,
     local::{
         context::ServiceContext,
         loadbalancing::PingBalancer,
@@ -111,14 +111,14 @@ async fn handle_redir_client(
 
 pub async fn run_tcp_redir(
     context: Arc<ServiceContext>,
-    client_config: &ClientConfig,
+    client_config: &ServerAddr,
     balancer: PingBalancer,
     redir_ty: RedirType,
     nodelay: bool,
 ) -> io::Result<()> {
     let listener = match *client_config {
-        ClientConfig::SocketAddr(ref saddr) => TcpListener::bind_redir(redir_ty, *saddr).await?,
-        ClientConfig::DomainName(ref dname, port) => {
+        ServerAddr::SocketAddr(ref saddr) => TcpListener::bind_redir(redir_ty, *saddr).await?,
+        ServerAddr::DomainName(ref dname, port) => {
             lookup_then!(context.context_ref(), dname, port, |addr| {
                 TcpListener::bind_redir(redir_ty, addr).await
             })?

--- a/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
@@ -12,10 +12,11 @@ use log::{error, info, trace, warn};
 use shadowsocks::{
     lookup_then,
     relay::{socks5::Address, udprelay::MAXIMUM_UDP_PAYLOAD_SIZE},
+    ServerAddr,
 };
 
 use crate::{
-    config::{ClientConfig, RedirType},
+    config::RedirType,
     local::{
         context::ServiceContext,
         loadbalancing::PingBalancer,
@@ -112,10 +113,10 @@ impl UdpRedir {
         }
     }
 
-    pub async fn run(&self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    pub async fn run(&self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let listener = match *client_config {
-            ClientConfig::SocketAddr(ref saddr) => UdpRedirSocket::listen(self.redir_ty, *saddr)?,
-            ClientConfig::DomainName(ref dname, port) => {
+            ServerAddr::SocketAddr(ref saddr) => UdpRedirSocket::listen(self.redir_ty, *saddr)?,
+            ServerAddr::DomainName(ref dname, port) => {
                 lookup_then!(self.context.context_ref(), dname, port, |addr| {
                     UdpRedirSocket::listen(self.redir_ty, addr)
                 })?

--- a/crates/shadowsocks-service/src/local/socks/server/mod.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/mod.rs
@@ -4,13 +4,10 @@ use std::{io, net::SocketAddr, sync::Arc, time::Duration};
 
 use futures::{future, FutureExt};
 use log::{error, info};
-use shadowsocks::{lookup_then, net::TcpListener as ShadowTcpListener, ServerAddr};
+use shadowsocks::{config::Mode, lookup_then, net::TcpListener as ShadowTcpListener, ServerAddr};
 use tokio::{net::TcpStream, time};
 
-use crate::{
-    config::Mode,
-    local::{context::ServiceContext, loadbalancing::PingBalancer},
-};
+use crate::local::{context::ServiceContext, loadbalancing::PingBalancer};
 
 #[cfg(feature = "local-socks4")]
 use self::socks4::Socks4TcpHandler;

--- a/crates/shadowsocks-service/src/local/socks/server/socks4/tcprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks4/tcprelay.rs
@@ -7,19 +7,17 @@ use std::{
 };
 
 use log::{debug, trace, warn};
+use shadowsocks::config::Mode;
 use tokio::{
     io::{AsyncWriteExt, BufReader},
     net::TcpStream,
 };
 
-use crate::{
-    config::Mode,
-    local::{
-        context::ServiceContext,
-        loadbalancing::PingBalancer,
-        net::AutoProxyClientStream,
-        utils::establish_tcp_tunnel,
-    },
+use crate::local::{
+    context::ServiceContext,
+    loadbalancing::PingBalancer,
+    net::AutoProxyClientStream,
+    utils::establish_tcp_tunnel,
 };
 
 use crate::local::socks::socks4::{Address, Command, HandshakeRequest, HandshakeResponse, ResultCode};

--- a/crates/shadowsocks-service/src/local/socks/server/socks5/tcprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks5/tcprelay.rs
@@ -8,6 +8,7 @@ use std::{
 
 use log::{debug, error, trace, warn};
 use shadowsocks::{
+    config::Mode,
     relay::socks5::{
         self,
         Address,
@@ -23,7 +24,6 @@ use shadowsocks::{
 use tokio::net::TcpStream;
 
 use crate::{
-    config::Mode,
     local::{
         context::ServiceContext,
         loadbalancing::PingBalancer,

--- a/crates/shadowsocks-service/src/local/socks/server/socks5/tcprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks5/tcprelay.rs
@@ -7,20 +7,23 @@ use std::{
 };
 
 use log::{debug, error, trace, warn};
-use shadowsocks::relay::socks5::{
-    self,
-    Address,
-    Command,
-    HandshakeRequest,
-    HandshakeResponse,
-    Reply,
-    TcpRequestHeader,
-    TcpResponseHeader,
+use shadowsocks::{
+    relay::socks5::{
+        self,
+        Address,
+        Command,
+        HandshakeRequest,
+        HandshakeResponse,
+        Reply,
+        TcpRequestHeader,
+        TcpResponseHeader,
+    },
+    ServerAddr,
 };
 use tokio::net::TcpStream;
 
 use crate::{
-    config::{ClientConfig, Mode},
+    config::Mode,
     local::{
         context::ServiceContext,
         loadbalancing::PingBalancer,
@@ -32,7 +35,7 @@ use crate::{
 
 pub struct Socks5TcpHandler {
     context: Arc<ServiceContext>,
-    udp_bind_addr: Option<Arc<ClientConfig>>,
+    udp_bind_addr: Option<Arc<ServerAddr>>,
     nodelay: bool,
     balancer: PingBalancer,
     mode: Mode,
@@ -41,7 +44,7 @@ pub struct Socks5TcpHandler {
 impl Socks5TcpHandler {
     pub fn new(
         context: Arc<ServiceContext>,
-        udp_bind_addr: Option<Arc<ClientConfig>>,
+        udp_bind_addr: Option<Arc<ServerAddr>>,
         nodelay: bool,
         balancer: PingBalancer,
         mode: Mode,

--- a/crates/shadowsocks-service/src/local/socks/server/socks5/udprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks5/udprelay.rs
@@ -18,16 +18,14 @@ use shadowsocks::{
         socks5::{Address, UdpAssociateHeader},
         udprelay::MAXIMUM_UDP_PAYLOAD_SIZE,
     },
+    ServerAddr,
 };
 use tokio::{net::UdpSocket, time};
 
-use crate::{
-    config::ClientConfig,
-    local::{
-        context::ServiceContext,
-        loadbalancing::PingBalancer,
-        net::{UdpAssociationManager, UdpInboundWrite},
-    },
+use crate::local::{
+    context::ServiceContext,
+    loadbalancing::PingBalancer,
+    net::{UdpAssociationManager, UdpInboundWrite},
 };
 
 #[derive(Clone)]
@@ -69,10 +67,10 @@ impl Socks5UdpServer {
         }
     }
 
-    pub async fn run(&self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    pub async fn run(&self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let socket = match *client_config {
-            ClientConfig::SocketAddr(ref saddr) => ShadowUdpSocket::listen(&saddr).await?,
-            ClientConfig::DomainName(ref dname, port) => {
+            ServerAddr::SocketAddr(ref saddr) => ShadowUdpSocket::listen(&saddr).await?,
+            ServerAddr::DomainName(ref dname, port) => {
                 lookup_then!(&self.context.context_ref(), dname, port, |addr| {
                     ShadowUdpSocket::listen(&addr).await
                 })?

--- a/crates/shadowsocks-service/src/local/tunnel/server.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/server.rs
@@ -3,12 +3,9 @@
 use std::{io, sync::Arc, time::Duration};
 
 use futures::{future, FutureExt};
-use shadowsocks::{relay::socks5::Address, ServerAddr};
+use shadowsocks::{config::Mode, relay::socks5::Address, ServerAddr};
 
-use crate::{
-    config::Mode,
-    local::{context::ServiceContext, loadbalancing::PingBalancer},
-};
+use crate::local::{context::ServiceContext, loadbalancing::PingBalancer};
 
 use super::{tcprelay::run_tcp_tunnel, udprelay::UdpTunnel};
 
@@ -62,15 +59,15 @@ impl Tunnel {
     }
 
     /// Start serving
-    pub async fn run(self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
+    pub async fn run(self, tcp_addr: &ServerAddr, udp_addr: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let mut vfut = Vec::new();
 
         if self.mode.enable_tcp() {
-            vfut.push(self.run_tcp_tunnel(client_config, balancer.clone()).boxed());
+            vfut.push(self.run_tcp_tunnel(tcp_addr, balancer.clone()).boxed());
         }
 
         if self.mode.enable_udp() {
-            vfut.push(self.run_udp_tunnel(client_config, balancer).boxed());
+            vfut.push(self.run_udp_tunnel(udp_addr, balancer).boxed());
         }
 
         let (res, ..) = future::select_all(vfut).await;

--- a/crates/shadowsocks-service/src/local/tunnel/server.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/server.rs
@@ -3,10 +3,10 @@
 use std::{io, sync::Arc, time::Duration};
 
 use futures::{future, FutureExt};
-use shadowsocks::relay::socks5::Address;
+use shadowsocks::{relay::socks5::Address, ServerAddr};
 
 use crate::{
-    config::{ClientConfig, Mode},
+    config::Mode,
     local::{context::ServiceContext, loadbalancing::PingBalancer},
 };
 
@@ -62,7 +62,7 @@ impl Tunnel {
     }
 
     /// Start serving
-    pub async fn run(self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    pub async fn run(self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let mut vfut = Vec::new();
 
         if self.mode.enable_tcp() {
@@ -77,7 +77,7 @@ impl Tunnel {
         res
     }
 
-    async fn run_tcp_tunnel(&self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    async fn run_tcp_tunnel(&self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         run_tcp_tunnel(
             self.context.clone(),
             client_config,
@@ -88,7 +88,7 @@ impl Tunnel {
         .await
     }
 
-    async fn run_udp_tunnel(&self, client_config: &ClientConfig, balancer: PingBalancer) -> io::Result<()> {
+    async fn run_udp_tunnel(&self, client_config: &ServerAddr, balancer: PingBalancer) -> io::Result<()> {
         let mut server = UdpTunnel::new(self.context.clone(), self.udp_expiry_duration, self.udp_capacity);
         server.run(client_config, balancer, &self.forward_addr).await
     }

--- a/crates/shadowsocks-service/src/local/tunnel/udprelay.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/udprelay.rs
@@ -14,6 +14,7 @@ use shadowsocks::{
         socks5::Address,
         udprelay::{ProxySocket, MAXIMUM_UDP_PAYLOAD_SIZE},
     },
+    ServerAddr,
 };
 use spin::Mutex as SpinMutex;
 use tokio::{
@@ -23,7 +24,6 @@ use tokio::{
 };
 
 use crate::{
-    config::ClientConfig,
     local::{context::ServiceContext, loadbalancing::PingBalancer},
     net::MonProxySocket,
 };
@@ -71,13 +71,13 @@ impl UdpTunnel {
 
     pub async fn run(
         &mut self,
-        client_config: &ClientConfig,
+        client_config: &ServerAddr,
         balancer: PingBalancer,
         forward_addr: &Address,
     ) -> io::Result<()> {
         let socket = match *client_config {
-            ClientConfig::SocketAddr(ref saddr) => ShadowUdpSocket::listen(&saddr).await?,
-            ClientConfig::DomainName(ref dname, port) => {
+            ServerAddr::SocketAddr(ref saddr) => ShadowUdpSocket::listen(&saddr).await?,
+            ServerAddr::DomainName(ref dname, port) => {
                 lookup_then!(&self.context.context_ref(), dname, port, |addr| {
                     ShadowUdpSocket::listen(&addr).await
                 })?

--- a/crates/shadowsocks-service/src/manager/mod.rs
+++ b/crates/shadowsocks-service/src/manager/mod.rs
@@ -31,7 +31,6 @@ pub async fn run(config: Config) -> io::Result<()> {
     }
 
     let mut manager = Manager::new(config.manager.expect("missing manager config"));
-    manager.set_mode(config.mode);
 
     let mut connect_opts = ConnectOpts {
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -73,7 +72,7 @@ pub async fn run(config: Config) -> io::Result<()> {
     }
 
     for svr_cfg in config.server {
-        manager.add_server(svr_cfg, None).await;
+        manager.add_server(svr_cfg).await;
     }
 
     manager.run().await

--- a/crates/shadowsocks-service/src/server/mod.rs
+++ b/crates/shadowsocks-service/src/server/mod.rs
@@ -91,7 +91,6 @@ pub async fn run(config: Config) -> io::Result<()> {
         if let Some(d) = config.udp_timeout {
             server.set_udp_expiry_duration(d);
         }
-        server.set_mode(config.mode);
         if let Some(ref m) = config.manager {
             server.set_manager_addr(m.addr.clone());
         }

--- a/crates/shadowsocks/Cargo.toml
+++ b/crates/shadowsocks/Cargo.toml
@@ -51,7 +51,7 @@ async-trait = "0.1"
 
 mio = "0.7"
 socket2 = "0.3"
-tokio = { version = "1.2", features = ["io-util", "macros", "net", "parking_lot", "process", "rt", "sync"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "parking_lot", "process", "rt", "sync"] }
 
 trust-dns-resolver = { version = "0.20", optional = true }
 arc-swap = { version = "1.2", optional = true }

--- a/crates/shadowsocks/Cargo.toml
+++ b/crates/shadowsocks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadowsocks"
-version = "1.9.2"
+version = "1.10.0"
 authors = ["Shadowsocks Contributors"]
 description = "shadowsocks is a fast tunnel proxy that helps you bypass firewalls."
 repository = "https://github.com/shadowsocks/shadowsocks-rust"

--- a/crates/shadowsocks/src/config.rs
+++ b/crates/shadowsocks/src/config.rs
@@ -371,6 +371,11 @@ impl ServerConfig {
 
         Ok(svrconfig)
     }
+
+    /// Check if it is a basic format server
+    pub fn is_basic(&self) -> bool {
+        self.remarks.is_none() && self.id.is_none()
+    }
 }
 
 /// Shadowsocks URL parsing Error

--- a/examples/config_ext.json
+++ b/examples/config_ext.json
@@ -1,22 +1,34 @@
 {
+    "locals": [
+        {
+            "local_address": "127.0.0.1",
+            "local_port": 1080
+        },
+        {
+            "local_address": "127.0.0.1",
+            "local_port": 3128,
+            "protocol": "http"
+        },
+        {
+            "local_address": "127.0.0.1",
+            "local_port": 53,
+            "protocol": "tunnel",
+            "forward_address": "8.8.8.8",
+            "forward_port": 53
+        }
+    ],
     "servers": [
         {
-            "address": "127.0.0.1",
-            "port": 8388,
-            "password": "password-svr1",
-            "method": "bf-cfb"
-        },
-        {
-            "address": "127.0.0.1",
-            "port": 8384,
+            "server": "127.0.0.1",
+            "server_port": 8384,
             "password": "password-svr2",
-            "method": "aes-256-cfb"
+            "method": "chacha20-ietf-poly1305"
         },
         {
-            "address": "127.0.0.1",
-            "port": 8385,
+            "server": "127.0.0.1",
+            "server_port": 8385,
             "password": "password-svr3",
-            "method": "rc4-md5"
+            "method": "aes-128-gcm"
         }
     ]
 }

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -10,7 +10,7 @@ use tokio::{
 };
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, ProtocolType},
+    config::{Config, ConfigType},
     run_local,
     run_server,
 };
@@ -19,10 +19,17 @@ use shadowsocks_service::{
 async fn dns_relay() {
     let _ = env_logger::try_init();
 
-    let mut local_config = Config::load_from_str(
+    let local_config = Config::load_from_str(
         r#"{
-            "local_port": 6110,
-            "local_address": "127.0.0.1",
+            "locals": [
+                {
+                    "local_address": "127.0.0.1",
+                    "local_port": 6110,
+                    "protocol": "dns",
+                    "local_dns_address": "114.114.114.114",
+                    "remote_dns_address": "8.8.8.8"
+                }
+            ],
             "server": "127.0.0.1",
             "server_port": 6120,
             "password": "password",
@@ -31,9 +38,6 @@ async fn dns_relay() {
         ConfigType::Local,
     )
     .unwrap();
-    local_config.local_protocol = ProtocolType::Dns;
-    local_config.local_dns_addr = Some("114.114.114.114:53".parse().unwrap());
-    local_config.remote_dns_addr = Some("8.8.8.8:53".parse().unwrap());
 
     let server_config = Config::load_from_str(
         r#"{

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -9,7 +9,7 @@ use tokio::{
 };
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, ProtocolType},
+    config::{Config, ConfigType},
     run_local,
     run_server,
 };
@@ -18,10 +18,15 @@ use shadowsocks_service::{
 async fn http_proxy() {
     let _ = env_logger::try_init();
 
-    let mut local_config = Config::load_from_str(
+    let local_config = Config::load_from_str(
         r#"{
-            "local_port": 5110,
-            "local_address": "127.0.0.1",
+            "locals": [
+                {
+                    "local_port": 5110,
+                    "local_address": "127.0.0.1",
+                    "protocol": "http"
+                }
+            ],
             "server": "127.0.0.1",
             "server_port": 5120,
             "password": "password",
@@ -30,7 +35,6 @@ async fn http_proxy() {
         ConfigType::Local,
     )
     .unwrap();
-    local_config.local_protocol = ProtocolType::Http;
 
     let server_config = Config::load_from_str(
         r#"{

--- a/tests/socks4.rs
+++ b/tests/socks4.rs
@@ -11,7 +11,7 @@ use tokio::{
 };
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, ProtocolType},
+    config::{Config, ConfigType, LocalConfig, ProtocolType},
     local::socks::client::Socks4TcpClient,
     run_local,
     run_server,
@@ -45,9 +45,8 @@ impl Socks4TestServer {
             },
             cli_config: {
                 let mut cfg = Config::new(ConfigType::Local);
-                cfg.local_addr = Some(ServerAddr::from(local_addr));
+                cfg.local = vec![LocalConfig::new(ServerAddr::from(local_addr), ProtocolType::Socks)];
                 cfg.server = vec![ServerConfig::new(svr_addr, pwd.to_owned(), method)];
-                cfg.local_protocol = ProtocolType::Socks;
                 cfg
             },
         }

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -11,7 +11,7 @@ use tokio::{
 };
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, Mode, ProtocolType},
+    config::{Config, ConfigType, LocalConfig, Mode, ProtocolType},
     local::socks::client::socks5::Socks5TcpClient,
     run_local,
     run_server,
@@ -47,10 +47,9 @@ impl Socks5TestServer {
             },
             cli_config: {
                 let mut cfg = Config::new(ConfigType::Local);
-                cfg.local_addr = Some(ServerAddr::from(local_addr));
+                cfg.local = vec![LocalConfig::new(ServerAddr::from(local_addr), ProtocolType::Socks)];
                 cfg.server = vec![ServerConfig::new(svr_addr, pwd.to_owned(), method)];
                 cfg.mode = if enable_udp { Mode::TcpAndUdp } else { Mode::TcpOnly };
-                cfg.local_protocol = ProtocolType::Socks;
                 cfg
             },
         }

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -11,12 +11,12 @@ use tokio::{
 };
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, LocalConfig, Mode, ProtocolType},
+    config::{Config, ConfigType, LocalConfig, ProtocolType},
     local::socks::client::socks5::Socks5TcpClient,
     run_local,
     run_server,
     shadowsocks::{
-        config::{ServerAddr, ServerConfig},
+        config::{Mode, ServerAddr, ServerConfig},
         crypto::v1::CipherKind,
         relay::socks5::Address,
     },
@@ -42,14 +42,14 @@ impl Socks5TestServer {
             svr_config: {
                 let mut cfg = Config::new(ConfigType::Server);
                 cfg.server = vec![ServerConfig::new(svr_addr, pwd.to_owned(), method)];
-                cfg.mode = if enable_udp { Mode::TcpAndUdp } else { Mode::TcpOnly };
+                cfg.server[0].set_mode(if enable_udp { Mode::TcpAndUdp } else { Mode::TcpOnly });
                 cfg
             },
             cli_config: {
                 let mut cfg = Config::new(ConfigType::Local);
                 cfg.local = vec![LocalConfig::new(ServerAddr::from(local_addr), ProtocolType::Socks)];
+                cfg.local[0].mode = if enable_udp { Mode::TcpAndUdp } else { Mode::TcpOnly };
                 cfg.server = vec![ServerConfig::new(svr_addr, pwd.to_owned(), method)];
-                cfg.mode = if enable_udp { Mode::TcpAndUdp } else { Mode::TcpOnly };
                 cfg
             },
         }

--- a/tests/tunnel.rs
+++ b/tests/tunnel.rs
@@ -11,20 +11,26 @@ use tokio::{
 };
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, ProtocolType},
+    config::{Config, ConfigType},
     run_local,
     run_server,
-    shadowsocks::relay::socks5::Address,
 };
 
 #[tokio::test]
 async fn tcp_tunnel() {
     let _ = env_logger::try_init();
 
-    let mut local_config = Config::load_from_str(
+    let local_config = Config::load_from_str(
         r#"{
-            "local_port": 9110,
-            "local_address": "127.0.0.1",
+            "locals": [
+                {
+                    "local_port": 9110,
+                    "local_address": "127.0.0.1",
+                    "protocol": "tunnel",
+                    "forward_address": "www.example.com",
+                    "forward_port": 80
+                }
+            ],
             "server": "127.0.0.1",
             "server_port": 9120,
             "password": "password",
@@ -33,8 +39,6 @@ async fn tcp_tunnel() {
         ConfigType::Local,
     )
     .unwrap();
-    local_config.local_protocol = ProtocolType::Tunnel;
-    local_config.forward = Some("www.example.com:80".parse::<Address>().unwrap());
 
     let server_config = Config::load_from_str(
         r#"{
@@ -75,10 +79,17 @@ async fn udp_tunnel() {
 
     let _ = env_logger::try_init();
 
-    let mut local_config = Config::load_from_str(
+    let local_config = Config::load_from_str(
         r#"{
-            "local_port": 9210,
-            "local_address": "127.0.0.1",
+            "locals": [
+                {
+                    "local_port": 9210,
+                    "local_address": "127.0.0.1",
+                    "protocol": "tunnel",
+                    "forward_address": "8.8.8.8",
+                    "forward_port": 53
+                }
+            ],
             "server": "127.0.0.1",
             "server_port": 9220,
             "password": "password",
@@ -88,8 +99,6 @@ async fn udp_tunnel() {
         ConfigType::Local,
     )
     .unwrap();
-    local_config.local_protocol = ProtocolType::Tunnel;
-    local_config.forward = Some("8.8.8.8:53".parse::<Address>().unwrap());
 
     let server_config = Config::load_from_str(
         r#"{

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -7,7 +7,7 @@ use log::debug;
 use tokio::time::{self, Duration};
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, Mode, ProtocolType},
+    config::{Config, ConfigType, LocalConfig, Mode, ProtocolType},
     local::socks::client::socks5::Socks5UdpClient,
     run_local,
     run_server,
@@ -35,14 +35,13 @@ fn get_svr_config() -> Config {
 
 fn get_cli_config() -> Config {
     let mut cfg = Config::new(ConfigType::Local);
-    cfg.local_addr = Some(LOCAL_ADDR.parse().unwrap());
+    cfg.local = vec![LocalConfig::new(LOCAL_ADDR.parse().unwrap(), ProtocolType::Socks)];
     cfg.server = vec![ServerConfig::new(
         SERVER_ADDR.parse::<SocketAddr>().unwrap(),
         PASSWORD.to_owned(),
         METHOD,
     )];
     cfg.mode = Mode::TcpAndUdp;
-    cfg.local_protocol = ProtocolType::Socks;
     cfg
 }
 

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -7,11 +7,11 @@ use log::debug;
 use tokio::time::{self, Duration};
 
 use shadowsocks_service::{
-    config::{Config, ConfigType, LocalConfig, Mode, ProtocolType},
+    config::{Config, ConfigType, LocalConfig, ProtocolType},
     local::socks::client::socks5::Socks5UdpClient,
     run_local,
     run_server,
-    shadowsocks::{crypto::v1::CipherKind, relay::socks5::Address, ServerConfig},
+    shadowsocks::{config::Mode, crypto::v1::CipherKind, relay::socks5::Address, ServerConfig},
 };
 
 const SERVER_ADDR: &str = "127.0.0.1:8093";
@@ -29,19 +29,19 @@ fn get_svr_config() -> Config {
         PASSWORD.to_owned(),
         METHOD,
     )];
-    cfg.mode = Mode::TcpAndUdp;
+    cfg.server[0].set_mode(Mode::TcpAndUdp);
     cfg
 }
 
 fn get_cli_config() -> Config {
     let mut cfg = Config::new(ConfigType::Local);
     cfg.local = vec![LocalConfig::new(LOCAL_ADDR.parse().unwrap(), ProtocolType::Socks)];
+    cfg.local[0].mode = Mode::TcpAndUdp;
     cfg.server = vec![ServerConfig::new(
         SERVER_ADDR.parse::<SocketAddr>().unwrap(),
         PASSWORD.to_owned(),
         METHOD,
     )];
-    cfg.mode = Mode::TcpAndUdp;
     cfg
 }
 


### PR DESCRIPTION
ref #452

- support `locals` in configuration file, running multiple local server
  instance simultaneously
- support `unix://` in `dns` configuration

BREAKING CHANGE:

- `sslocal`'s `--dns-addr` is now only available in Android
- shadowsocks-service's `Config` struct have lots of changes