### PR TITLE
Manage UDP associations with LFU strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,9 +757,9 @@ checksum = "33bfa6580d3aa7abe1f17d413dc9952d726eb588a0a8082821444cb89ffdabdf"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libmimalloc-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lfu_cache"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33bfa6580d3aa7abe1f17d413dc9952d726eb588a0a8082821444cb89ffdabdf"
+
+[[package]]
 name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,12 +836,6 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "lru_time_cache"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991058cf0e7f161b37a4a610ddbada9d2f051d0db76369b973de9f3466f1cba3"
 
 [[package]]
 name = "maplit"
@@ -1549,10 +1549,10 @@ dependencies = [
  "ipnet",
  "iprange",
  "json5",
+ "lfu_cache",
  "libc",
  "log",
  "log4rs",
- "lru_time_cache",
  "mio",
  "native-tls",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lfu_cache"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33bfa6580d3aa7abe1f17d413dc9952d726eb588a0a8082821444cb89ffdabdf"
+checksum = "29d2e56f95e5fda80586d85e2e98bb6dba8f71f4406161ce90698fa38ff16486"
 
 [[package]]
 name = "libc"

--- a/bin/sslocal.rs
+++ b/bin/sslocal.rs
@@ -357,7 +357,7 @@ fn main() {
 
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))]
         if let Some(iface) = matches.value_of("OUTBOUND_BIND_INTERFACE") {
-            config.outbound_bind_interface = Some(From::from(iface.to_owned()));
+            config.outbound_bind_interface = Some(iface.to_owned());
         }
 
         #[cfg(all(unix, not(target_os = "android")))]

--- a/bin/ssmanager.rs
+++ b/bin/ssmanager.rs
@@ -163,9 +163,9 @@ fn main() {
             config.outbound_fwmark = Some(mark.parse::<u32>().expect("an unsigned integer for `outbound-fwmark`"));
         }
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))]
         if let Some(iface) = matches.value_of("OUTBOUND_BIND_INTERFACE") {
-            config.outbound_bind_interface = Some(From::from(iface.to_owned()));
+            config.outbound_bind_interface = Some(iface.to_owned());
         }
 
         if let Some(m) = matches.value_of("MANAGER_ADDRESS") {

--- a/bin/ssserver.rs
+++ b/bin/ssserver.rs
@@ -204,9 +204,9 @@ fn main() {
             config.outbound_fwmark = Some(mark.parse::<u32>().expect("an unsigned integer for `outbound-fwmark`"));
         }
 
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))]
         if let Some(iface) = matches.value_of("OUTBOUND_BIND_INTERFACE") {
-            config.outbound_bind_interface = Some(From::from(iface.to_owned()));
+            config.outbound_bind_interface = Some(iface.to_owned());
         }
 
         if let Some(m) = matches.value_of("MANAGER_ADDRESS") {

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -77,7 +77,7 @@ once_cell = "1.7"
 thiserror = "1.0"
 
 spin = { version = "0.9", features = ["std"] }
-lru_time_cache = "0.11"
+lfu_cache = "1.2"
 bytes = "1.0"
 byte_string = "1.0"
 byteorder = "1.3"

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -77,7 +77,7 @@ once_cell = "1.7"
 thiserror = "1.0"
 
 spin = { version = "0.9", features = ["std"] }
-lfu_cache = "1.2"
+lfu_cache = "1.2.1"
 bytes = "1.0"
 byte_string = "1.0"
 byteorder = "1.3"

--- a/crates/shadowsocks-service/src/local/context.rs
+++ b/crates/shadowsocks-service/src/local/context.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::{net::IpAddr, time::Duration};
 
 #[cfg(feature = "local-dns")]
-use lru_time_cache::LruCache;
+use lfu_cache::TimedLfuCache;
 use shadowsocks::{
     config::ServerType,
     context::{Context, SharedContext},
@@ -32,7 +32,7 @@ pub struct ServiceContext {
 
     // For DNS relay's ACL domain name reverse lookup -- whether the IP shall be forwarded
     #[cfg(feature = "local-dns")]
-    reverse_lookup_cache: Mutex<LruCache<IpAddr, bool>>,
+    reverse_lookup_cache: Mutex<TimedLfuCache<IpAddr, bool>>,
 }
 
 impl Default for ServiceContext {
@@ -51,7 +51,10 @@ impl ServiceContext {
             acl: None,
             flow_stat: Arc::new(FlowStat::new()),
             #[cfg(feature = "local-dns")]
-            reverse_lookup_cache: Mutex::new(LruCache::with_expiry_duration(Duration::from_secs(3 * 24 * 60 * 60))),
+            reverse_lookup_cache: Mutex::new(TimedLfuCache::with_capacity_and_expiration(
+                10240, // XXX: It should be enough for a normal user.
+                Duration::from_secs(3 * 24 * 60 * 60),
+            )),
         }
     }
 

--- a/crates/shadowsocks-service/src/local/http/client_cache.rs
+++ b/crates/shadowsocks-service/src/local/http/client_cache.rs
@@ -3,7 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use hyper::{Body, Client};
-use lru_time_cache::LruCache;
+use lfu_cache::TimedLfuCache;
 use shadowsocks::config::ServerAddr;
 use tokio::sync::Mutex;
 
@@ -14,14 +14,14 @@ use super::{connector::ProxyConnector, http_client::ProxyHttpClient};
 /// Cached HTTP client for remote servers
 pub struct ProxyClientCache {
     context: Arc<ServiceContext>,
-    cache: Mutex<LruCache<ServerAddr, ProxyHttpClient>>,
+    cache: Mutex<TimedLfuCache<ServerAddr, ProxyHttpClient>>,
 }
 
 impl ProxyClientCache {
     pub fn new(context: Arc<ServiceContext>) -> ProxyClientCache {
         ProxyClientCache {
             context,
-            cache: Mutex::new(LruCache::with_expiry_duration_and_capacity(Duration::from_secs(60), 5)),
+            cache: Mutex::new(TimedLfuCache::with_capacity_and_expiration(5, Duration::from_secs(60))),
         }
     }
 

--- a/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
+++ b/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
@@ -59,7 +59,7 @@ impl AutoProxyClientStream {
         let addr = addr.into();
         let stream =
             TcpStream::connect_remote_with_opts(context.context_ref(), &addr, context.connect_opts_ref()).await?;
-        Ok(AutoProxyClientStream::Bypassed(stream.into()))
+        Ok(AutoProxyClientStream::Bypassed(stream))
     }
 
     /// Connect to target `addr` via shadowsocks' server configured by `svr_cfg`

--- a/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
@@ -8,12 +8,16 @@ use std::{
 };
 
 use async_trait::async_trait;
+use futures::future::{self, AbortHandle};
+use lfu_cache::TimedLfuCache;
 use log::{error, info, trace, warn};
 use shadowsocks::{
     lookup_then,
+    net::ConnectOpts,
     relay::{socks5::Address, udprelay::MAXIMUM_UDP_PAYLOAD_SIZE},
     ServerAddr,
 };
+use tokio::sync::Mutex;
 
 use crate::{
     config::RedirType,
@@ -32,10 +36,63 @@ use self::sys::UdpRedirSocket;
 
 mod sys;
 
+const INBOUND_SOCKET_CACHE_EXPIRATION: Duration = Duration::from_secs(60);
+const INBOUND_SOCKET_CACHE_CAPACITY: usize = 256;
+
+struct UdpRedirInboundCache {
+    cache: Arc<Mutex<TimedLfuCache<SocketAddr, Arc<UdpRedirSocket>>>>,
+    watcher: AbortHandle,
+}
+
+impl Drop for UdpRedirInboundCache {
+    fn drop(&mut self) {
+        self.watcher.abort();
+    }
+}
+
+impl UdpRedirInboundCache {
+    fn new() -> UdpRedirInboundCache {
+        let cache = Arc::new(Mutex::new(TimedLfuCache::with_capacity_and_expiration(
+            INBOUND_SOCKET_CACHE_CAPACITY,
+            INBOUND_SOCKET_CACHE_EXPIRATION,
+        )));
+
+        let (cleanup_fut, watcher) = {
+            let cache = cache.clone();
+            future::abortable(async move {
+                loop {
+                    tokio::time::sleep(INBOUND_SOCKET_CACHE_EXPIRATION).await;
+                    cache.lock().await.evict_expired();
+                }
+            })
+        };
+        tokio::spawn(cleanup_fut);
+
+        UdpRedirInboundCache { cache, watcher }
+    }
+}
+
 #[derive(Clone)]
 struct UdpRedirInboundWriter {
     redir_ty: RedirType,
     socket_opts: RedirSocketOpts,
+    inbound_cache: Arc<UdpRedirInboundCache>,
+}
+
+impl UdpRedirInboundWriter {
+    #[allow(unused_variables)]
+    fn new(redir_ty: RedirType, opts: &ConnectOpts) -> UdpRedirInboundWriter {
+        UdpRedirInboundWriter {
+            redir_ty,
+            socket_opts: RedirSocketOpts {
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                fwmark: opts.fwmark,
+
+                ..Default::default()
+            },
+            inbound_cache: Arc::new(UdpRedirInboundCache::new()),
+        }
+    }
 }
 
 #[async_trait]
@@ -61,12 +118,25 @@ impl UdpInboundWrite for UdpRedirInboundWriter {
             }
         };
 
-        // Create a socket binds to destination addr
-        // This only works for systems that supports binding to non-local addresses
-        //
-        // This socket has to set SO_REUSEADDR and SO_REUSEPORT.
-        // Outbound addresses could be connected from different source addresses.
-        let inbound = UdpRedirSocket::bind_nonlocal(self.redir_ty, addr, &self.socket_opts)?;
+        let inbound = {
+            let mut cache = self.inbound_cache.cache.lock().await;
+            if let Some(socket) = cache.get(&addr) {
+                socket.clone()
+            } else {
+                // Create a socket binds to destination addr
+                // This only works for systems that supports binding to non-local addresses
+                //
+                // This socket has to set SO_REUSEADDR and SO_REUSEPORT.
+                // Outbound addresses could be connected from different source addresses.
+                let inbound = UdpRedirSocket::bind_nonlocal(self.redir_ty, addr, &self.socket_opts)?;
+
+                // UDP socket could be shared between threads and is safe to be manipulated by multiple threads
+                let inbound = Arc::new(inbound);
+                cache.insert(addr, inbound.clone());
+
+                inbound
+            }
+        };
 
         // Send back to client
         inbound.send_to(data, peer_addr).await.map(|n| {
@@ -133,15 +203,7 @@ impl UdpRedir {
         #[allow(clippy::needless_update)]
         let manager = UdpAssociationManager::new(
             self.context.clone(),
-            UdpRedirInboundWriter {
-                redir_ty: self.redir_ty,
-                socket_opts: RedirSocketOpts {
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
-                    fwmark: self.context.connect_opts_ref().fwmark,
-
-                    ..Default::default()
-                },
-            },
+            UdpRedirInboundWriter::new(self.redir_ty, self.context.connect_opts_ref()),
             self.time_to_live,
             self.capacity,
             balancer,

--- a/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
@@ -80,7 +80,7 @@ struct UdpRedirInboundWriter {
 }
 
 impl UdpRedirInboundWriter {
-    #[allow(unused_variables)]
+    #[allow(unused_variables, clippy::needless_update)]
     fn new(redir_ty: RedirType, opts: &ConnectOpts) -> UdpRedirInboundWriter {
         UdpRedirInboundWriter {
             redir_ty,

--- a/crates/shadowsocks-service/src/local/tunnel/udprelay.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/udprelay.rs
@@ -5,8 +5,8 @@ use std::{io, net::SocketAddr, sync::Arc, time::Duration};
 use bytes::Bytes;
 use futures::future::{self, AbortHandle};
 use io::ErrorKind;
+use lfu_cache::TimedLfuCache;
 use log::{debug, error, info, trace, warn};
-use lru_time_cache::{Entry, LruCache};
 use shadowsocks::{
     lookup_then,
     net::UdpSocket as ShadowUdpSocket,
@@ -28,9 +28,12 @@ use crate::{
     net::MonProxySocket,
 };
 
+type AssociationMap = TimedLfuCache<SocketAddr, UdpAssociation>;
+type SharedAssociationMap = Arc<Mutex<AssociationMap>>;
+
 pub struct UdpTunnel {
     context: Arc<ServiceContext>,
-    assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+    assoc_map: SharedAssociationMap,
     cleanup_abortable: AbortHandle,
 }
 
@@ -44,8 +47,8 @@ impl UdpTunnel {
     pub fn new(context: Arc<ServiceContext>, time_to_live: Option<Duration>, capacity: Option<usize>) -> UdpTunnel {
         let time_to_live = time_to_live.unwrap_or(crate::DEFAULT_UDP_EXPIRY_DURATION);
         let assoc_map = Arc::new(Mutex::new(match capacity {
-            Some(capacity) => LruCache::with_expiry_duration_and_capacity(time_to_live, capacity),
-            None => LruCache::with_expiry_duration(time_to_live),
+            Some(capacity) => TimedLfuCache::with_capacity_and_expiration(capacity, time_to_live),
+            None => TimedLfuCache::with_expiration(time_to_live),
         }));
 
         let cleanup_abortable = {
@@ -54,8 +57,8 @@ impl UdpTunnel {
                 loop {
                     time::sleep(time_to_live).await;
 
-                    // iter() will trigger a cleanup of expired associations
-                    let _ = assoc_map.lock().await.iter();
+                    // cleanup expired associations
+                    let _ = assoc_map.lock().await.evict_expired();
                 }
             });
             tokio::spawn(cleanup_task);
@@ -126,24 +129,26 @@ impl UdpTunnel {
         data: &[u8],
     ) -> io::Result<()> {
         let mut assoc_map = self.assoc_map.lock().await;
-        match assoc_map.entry(peer_addr) {
-            Entry::Occupied(occ) => {
-                let assoc = occ.into_mut();
-                assoc.try_send(Bytes::copy_from_slice(data))
-            }
-            Entry::Vacant(vac) => {
-                let assoc = vac.insert(UdpAssociation::new(
-                    self.context.clone(),
-                    listener.clone(),
-                    peer_addr,
-                    forward_addr.clone(),
-                    self.assoc_map.clone(),
-                    balancer.clone(),
-                ));
-                trace!("created udp association for {}", peer_addr);
-                assoc.try_send(Bytes::copy_from_slice(data))
-            }
+
+        if let Some(assoc) = assoc_map.get(&peer_addr) {
+            return assoc.try_send(Bytes::copy_from_slice(data));
         }
+
+        let assoc = UdpAssociation::new(
+            self.context.clone(),
+            listener.clone(),
+            peer_addr,
+            forward_addr.clone(),
+            self.assoc_map.clone(),
+            balancer.clone(),
+        );
+
+        trace!("created udp association for {}", peer_addr);
+
+        assoc.try_send(Bytes::copy_from_slice(data))?;
+        assoc_map.insert(peer_addr, assoc);
+
+        Ok(())
     }
 }
 
@@ -164,7 +169,7 @@ impl UdpAssociation {
         inbound: Arc<UdpSocket>,
         peer_addr: SocketAddr,
         forward_addr: Address,
-        assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+        assoc_map: SharedAssociationMap,
         balancer: PingBalancer,
     ) -> UdpAssociation {
         let (assoc, sender) =
@@ -222,7 +227,7 @@ struct UdpAssociationContext {
     peer_addr: SocketAddr,
     forward_addr: Address,
     proxied_socket: SpinMutex<UdpAssociationState>,
-    assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+    assoc_map: SharedAssociationMap,
     balancer: PingBalancer,
 }
 
@@ -238,7 +243,7 @@ impl UdpAssociationContext {
         inbound: Arc<UdpSocket>,
         peer_addr: SocketAddr,
         forward_addr: Address,
-        assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+        assoc_map: SharedAssociationMap,
         balancer: PingBalancer,
     ) -> (Arc<UdpAssociationContext>, mpsc::Sender<Bytes>) {
         // Pending packets 1024 should be good enough for a server.

--- a/crates/shadowsocks-service/src/server/udprelay.rs
+++ b/crates/shadowsocks-service/src/server/udprelay.rs
@@ -5,8 +5,8 @@ use std::{io, net::SocketAddr, sync::Arc, time::Duration};
 use bytes::Bytes;
 use futures::future::{self, AbortHandle};
 use io::ErrorKind;
+use lfu_cache::{LfuCache, TimedLfuCache};
 use log::{debug, error, info, trace, warn};
-use lru_time_cache::{Entry, LruCache};
 use shadowsocks::{
     lookup_then,
     net::UdpSocket as OutboundUdpSocket,
@@ -26,9 +26,12 @@ use crate::net::MonProxySocket;
 
 use super::context::ServiceContext;
 
+type AssociationMap = TimedLfuCache<SocketAddr, UdpAssociation>;
+type SharedAssociationMap = Arc<Mutex<AssociationMap>>;
+
 pub struct UdpServer {
     context: Arc<ServiceContext>,
-    assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+    assoc_map: SharedAssociationMap,
     cleanup_abortable: AbortHandle,
 }
 
@@ -42,8 +45,8 @@ impl UdpServer {
     pub fn new(context: Arc<ServiceContext>, time_to_live: Option<Duration>, capacity: Option<usize>) -> UdpServer {
         let time_to_live = time_to_live.unwrap_or(crate::DEFAULT_UDP_EXPIRY_DURATION);
         let assoc_map = Arc::new(Mutex::new(match capacity {
-            Some(capacity) => LruCache::with_expiry_duration_and_capacity(time_to_live, capacity),
-            None => LruCache::with_expiry_duration(time_to_live),
+            Some(capacity) => TimedLfuCache::with_capacity_and_expiration(capacity, time_to_live),
+            None => TimedLfuCache::with_expiration(time_to_live),
         }));
 
         let cleanup_abortable = {
@@ -52,8 +55,8 @@ impl UdpServer {
                 loop {
                     time::sleep(time_to_live).await;
 
-                    // iter() will trigger a cleanup of expired associations
-                    let _ = assoc_map.lock().await.iter();
+                    // cleanup expired associations
+                    assoc_map.lock().await.evict_expired();
                 }
             });
             tokio::spawn(cleanup_task);
@@ -112,22 +115,25 @@ impl UdpServer {
         target_addr: Address,
         data: &[u8],
     ) -> io::Result<()> {
-        match self.assoc_map.lock().await.entry(peer_addr) {
-            Entry::Occupied(occ) => {
-                let assoc = occ.into_mut();
-                assoc.try_send((target_addr, Bytes::copy_from_slice(data)))
-            }
-            Entry::Vacant(vac) => {
-                let assoc = vac.insert(UdpAssociation::new(
-                    self.context.clone(),
-                    listener.clone(),
-                    peer_addr,
-                    self.assoc_map.clone(),
-                ));
-                trace!("created udp association for {}", peer_addr);
-                assoc.try_send((target_addr, Bytes::copy_from_slice(data)))
-            }
+        let mut assoc_map = self.assoc_map.lock().await;
+
+        if let Some(assoc) = assoc_map.get(&peer_addr) {
+            return assoc.try_send((target_addr, Bytes::copy_from_slice(data)));
         }
+
+        let assoc = UdpAssociation::new(
+            self.context.clone(),
+            listener.clone(),
+            peer_addr,
+            self.assoc_map.clone(),
+        );
+
+        trace!("created udp association for {}", peer_addr);
+
+        assoc.try_send((target_addr, Bytes::copy_from_slice(data)))?;
+        assoc_map.insert(peer_addr, assoc);
+
+        Ok(())
     }
 }
 
@@ -148,7 +154,7 @@ impl UdpAssociation {
         context: Arc<ServiceContext>,
         inbound: Arc<MonProxySocket>,
         peer_addr: SocketAddr,
-        assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+        assoc_map: SharedAssociationMap,
     ) -> UdpAssociation {
         let (assoc, sender) = UdpAssociationContext::new(context, inbound, peer_addr, assoc_map);
         UdpAssociation { assoc, sender }
@@ -200,8 +206,8 @@ struct UdpAssociationContext {
     peer_addr: SocketAddr,
     outbound_ipv4_socket: SpinMutex<UdpAssociationState>,
     outbound_ipv6_socket: SpinMutex<UdpAssociationState>,
-    assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
-    target_cache: Mutex<LruCache<SocketAddr, Address>>,
+    assoc_map: SharedAssociationMap,
+    target_cache: Mutex<LfuCache<SocketAddr, Address>>,
 }
 
 impl Drop for UdpAssociationContext {
@@ -215,7 +221,7 @@ impl UdpAssociationContext {
         context: Arc<ServiceContext>,
         inbound: Arc<MonProxySocket>,
         peer_addr: SocketAddr,
-        assoc_map: Arc<Mutex<LruCache<SocketAddr, UdpAssociation>>>,
+        assoc_map: SharedAssociationMap,
     ) -> (Arc<UdpAssociationContext>, mpsc::Sender<(Address, Bytes)>) {
         // Pending packets 1024 should be good enough for a server.
         // If there are plenty of packets stuck in the channel, dropping exccess packets is a good way to protect the server from
@@ -233,7 +239,7 @@ impl UdpAssociationContext {
             // when recv_from a SocketAddr, we have to know whch Address that client was originally requested.
             //
             // XXX: 64 target addresses should be enough for __one__ client.
-            target_cache: Mutex::new(LruCache::with_capacity(64)),
+            target_cache: Mutex::new(LfuCache::with_capacity(64)),
         });
 
         let l2r_task = {

--- a/crates/shadowsocks/Cargo.toml
+++ b/crates/shadowsocks/Cargo.toml
@@ -34,7 +34,7 @@ aead-cipher-extra = ["shadowsocks-crypto/v1-aead-extra"]
 [dependencies]
 log = "0.4"
 
-libc = "0.2"
+libc = "0.2.94"
 bytes = "1.0"
 cfg-if = "1"
 byte_string = "1.0"


### PR DESCRIPTION
- UDP associations that are not often used, like DNS queries, should be evicted firstly.
- UDP redir caches respond sockets that binds to non-local addresses to prevent creating sockets repeatedly.

## Remaining issues

- [x] `SIGSEGV` occationally, should be heap corrupted. https://github.com/edward-shen/lfu-cache/issues/2