### PR TITLE
Add Docker and its GitHub Actions auto build support

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,36 @@
+name: Build Docker Images
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bin: 
+          - ssserver
+          - sslocal
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.bin }}-rust
+      - name: Build and release Docker images
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/386,linux/amd64,linux/arm64/v8
+          target: ${{ matrix.bin }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM --platform=$BUILDPLATFORM rust:1.53.0-buster AS build
+
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y build-essential curl musl-tools
+
+WORKDIR /root/shadowsocks-rust
+
+ADD . .
+
+RUN rustup install "$(cat rust-toolchain)" && \
+    case "$TARGETARCH" in \
+    "386") \
+        RUST_TARGET="i686-unknown-linux-musl" \
+        MUSL="i686-linux-musl" \
+        ;; \
+    "amd64") \
+        RUST_TARGET="x86_64-unknown-linux-musl" \
+        MUSL="x86_64-linux-musl" \
+        ;; \
+    "arm64") \
+        RUST_TARGET="aarch64-unknown-linux-musl" \
+        MUSL="aarch64-linux-musl" \
+        ;; \
+    *) \
+        echo "Doesn't support $TARGETARCH architecture" \
+        exit 1 \
+        ;; \
+    esac && \
+    wget -qO- "https://musl.cc/$MUSL-cross.tgz" | tar -xzC /root/ && \
+    CC=/root/$MUSL-cross/bin/$MUSL-gcc && \
+    rustup target add $RUST_TARGET && \
+    RUSTFLAGS="-C linker=$CC" CC=$CC cargo build --target $RUST_TARGET --release && \
+    mv target/$RUST_TARGET/release/ss* target/release/
+
+FROM alpine:3.14 AS sslocal
+
+COPY --from=build /root/shadowsocks-rust/target/release/sslocal /usr/bin
+
+COPY --from=build /root/shadowsocks-rust/examples/config.json /etc/shadowsocks-rust/
+
+ENTRYPOINT [ "sslocal", "--log-without-time", "-c", "/etc/shadowsocks-rust/config.json" ]
+
+FROM alpine:3.14 AS ssserver
+
+COPY --from=build /root/shadowsocks-rust/target/release/ssserver /usr/bin
+
+COPY --from=build /root/shadowsocks-rust/examples/config.json /etc/shadowsocks-rust/
+
+ENTRYPOINT [ "ssserver", "--log-without-time", "-c", "/etc/shadowsocks-rust/config.json" ]

--- a/examples/config.json
+++ b/examples/config.json
@@ -5,5 +5,5 @@
     "local_address": "127.0.0.1",
     "password": "password",
     "timeout": 300,
-    "method": "aes-256-cfb"
+    "method": "aes-256-gcm"
 }


### PR DESCRIPTION
Resolved #570. Provide multi-arch Docker support for shaodowsocks-rust.

## TODO

- [x] Determine how to provide `ssserver` and `sslocal`, etc.
- [x] Improve CI build time.