### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=build /root/shadowsocks-rust/target/release/sslocal /usr/bin
 
 COPY --from=build /root/shadowsocks-rust/examples/config.json /etc/shadowsocks-rust/
 
+USER nobody
+
 ENTRYPOINT [ "sslocal", "--log-without-time", "-c", "/etc/shadowsocks-rust/config.json" ]
 
 FROM alpine:3.14 AS ssserver
@@ -46,5 +48,7 @@ FROM alpine:3.14 AS ssserver
 COPY --from=build /root/shadowsocks-rust/target/release/ssserver /usr/bin
 
 COPY --from=build /root/shadowsocks-rust/examples/config.json /etc/shadowsocks-rust/
+
+USER nobody
 
 ENTRYPOINT [ "ssserver", "--log-without-time", "-c", "/etc/shadowsocks-rust/config.json" ]


### PR DESCRIPTION
Running programs as root that don't require it is a big security risk. Docker is only containerization and not virtualization.
Instead of using the user "nobody" a custom user may be created, but as shadowsocks-rust only uses networking and only reads the config file I see it as unnecessary.
If the server is intended to bind on a privileged port (<1024) Docker's port mapping may be used or a program such as nftables or setcap may be used.