### PR TITLE
Add hashset-mode into ACL rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,17 @@ Example configuration:
 [outbound_block_list]
 127.0.0.1/8
 ::1
-(^|\.)baidu.com
+# Using regular expression
+^[a-z]{5}\.baidu\.com
+# Match exactly
+|baidu.com
+# Match with subdomains
+||google.com
+# An internationalized domain name should be converted to punycode
+# |☃-⌘\.com - WRONG
+|xn----dqo34k.com
+# ||джpумлатест.bрфa - WRONG
+||xn--p-8sbkgc5ag7bhce.xn--ba-lmcq
 
 # CLIENTS
 # For sslocal, ..., bypasses all targets by default
@@ -638,7 +648,7 @@ Example configuration:
 
 # Proxy these addresses
 [proxy_list]
-(^|\.)google.com
+||google.com
 8.8.8.8
 ```
 

--- a/crates/shadowsocks-service/src/acl/mod.rs
+++ b/crates/shadowsocks-service/src/acl/mod.rs
@@ -282,6 +282,7 @@ impl AccessControl {
 
         let outbound_block_regex = match RegexSetBuilder::new(outbound_block_rules_regex)
             .size_limit(REGEX_SIZE_LIMIT)
+            .unicode(false)
             .build()
         {
             Ok(r) => r,
@@ -294,6 +295,7 @@ impl AccessControl {
         let bypass_regex = match RegexSetBuilder::new(bypass_rules_regex)
             .case_insensitive(true)
             .size_limit(REGEX_SIZE_LIMIT)
+            .unicode(false)
             .build()
         {
             Ok(r) => r,
@@ -309,6 +311,7 @@ impl AccessControl {
         let proxy_regex = match RegexSetBuilder::new(proxy_rules_regex)
             .case_insensitive(true)
             .size_limit(REGEX_SIZE_LIMIT)
+            .unicode(false)
             .build()
         {
             Ok(r) => r,

--- a/crates/shadowsocks-service/src/acl/sub_domains_tree.rs
+++ b/crates/shadowsocks-service/src/acl/sub_domains_tree.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+struct DomainPart {
+    included: bool,
+    children: HashMap<String, DomainPart>,
+}
+
+impl DomainPart {
+    fn new() -> Self {
+        DomainPart {
+            included: false,
+            children: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SubDomainsTree(HashMap<String, DomainPart>);
+
+impl SubDomainsTree {
+    pub fn new() -> Self {
+        SubDomainsTree(HashMap::new())
+    }
+
+    pub fn insert(&mut self, value: &str) {
+        let mut current_map = &mut self.0;
+        let mut last_included = None;
+        for part in value.rsplit('.') {
+            let entry = current_map.entry(part.to_string()).or_insert_with(|| DomainPart::new());
+            // We don't need to include `a.b.c` if we already have `b.c`
+            if entry.included {
+                return;
+            }
+            current_map = &mut entry.children;
+            last_included = Some(&mut entry.included);
+        }
+        if let Some(last_included) = last_included {
+            *last_included = true;
+            // Remove all subdomains to free memory. `contains` will stop here anyway.
+            current_map.clear();
+        }
+    }
+
+    pub fn contains(&self, value: &str) -> bool {
+        let mut current_map = &self.0;
+        for part in value.rsplit('.') {
+            if let Some(el) = current_map.get(part) {
+                if el.included {
+                    return true;
+                }
+                current_map = &el.children;
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}


### PR DESCRIPTION
I have about 320000 hostnames rules and with regexps both performance and memory consumption are abysmal. Hashsets are much faster and smaller in my case. Memory decreased from 2.8GB to 35MB. It's possible to increase performance even further - replace default hasher with [ahash](https://github.com/tkaitchuck/aHash), but since it requires to add new package I'll leave that decision for you.

I added hashsets' parsing in backward-compatible fashion, so old rules will work without any changes. Also I added an optimization to regexp matcher. Since all dns records are encoded in ASCII, there is no need for unicode support in regexes.