### PR TITLE
Use byte regexes to fix compiltation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ Example configuration:
 # Match with subdomains
 ||google.com
 # An internationalized domain name should be converted to punycode
-# |☃-⌘\.com - WRONG
+# |☃-⌘.com - WRONG
 |xn----dqo34k.com
 # ||джpумлатест.bрфa - WRONG
 ||xn--p-8sbkgc5ag7bhce.xn--ba-lmcq

--- a/crates/shadowsocks-service/src/acl/mod.rs
+++ b/crates/shadowsocks-service/src/acl/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use iprange::IpRange;
-use regex::{RegexSet, RegexSetBuilder};
+use regex::bytes::{RegexSet, RegexSetBuilder};
 
 use shadowsocks::{context::Context, relay::socks5::Address};
 
@@ -102,7 +102,7 @@ impl Rules {
 
     /// Check if the specified host matches any rules
     fn check_host_matched(&self, host: &str) -> bool {
-        self.rule_set.contains(host) || self.rule_tree.contains(host) || self.rule_regex.is_match(host)
+        self.rule_set.contains(host) || self.rule_tree.contains(host) || self.rule_regex.is_match(host.as_bytes())
     }
 
     /// Check if there are no rules for IP addresses


### PR DESCRIPTION
Fixes error `error: pattern can match invalid UTF-8` in regular expressions. It still rejects unicode characters with another error `error: Unicode not allowed here` but that's fine since there is no unicode characters in dns records anyway.