### PR TITLE
CI: build check and release for Apple Silicon

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Ctarget-feature=+aes,+ssse3"
   RUST_LOG: "trace"
 
 jobs:
@@ -61,3 +60,21 @@ jobs:
             -W clippy::absurd_extreme_comparisons
             -W clippy::erasing_op
             -A clippy::collapsible_else_if
+      - name: prepare AppleSilicon build
+        uses: actions-rs/toolchain@v1
+        with:
+          target: aarch64-apple-darwin
+        if: runner.os == 'macOS'
+
+      # https://github.com/actions/virtual-environments/issues/2557#issuecomment-769611326
+      - if: runner.os == 'macOS'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_12.4.app &&
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+
+      - name: Check compilation for Apple Silicon
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target aarch64-apple-darwin
+        if: runner.os == 'macOS'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,6 +68,9 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest]
         os: [macos-latest]
+        target:
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v2
 
@@ -83,11 +86,17 @@ jobs:
         with:
           profile: minimal
 
+      # https://github.com/actions/virtual-environments/issues/2557#issuecomment-769611326
+      - if: ${{ matrix.target }} == 'aarch-apple-darwin'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_12.4.app &&
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+
       - name: Build release
         shell: bash
         run: |
           cd build
-          ./build-host-release
+          ./build-host-release -t ${{ matrix.target }}
 
       - name: Upload Github Assets
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Currently we can only use x86_64 macOS to cross-build aarch64 platform, which is this PR try to do.

For #569

