### PR TITLE
fix spelling

### DIFF
--- a/crates/shadowsocks-service/src/local/redir/server.rs
+++ b/crates/shadowsocks-service/src/local/redir/server.rs
@@ -52,7 +52,7 @@ impl Redir {
         self.udp_expiry_duration = Some(d);
     }
 
-    /// Set total UDP association to be kept simultaneouslyin server
+    /// Set total UDP association to be kept simultaneously in server
     pub fn set_udp_capacity(&mut self, c: usize) {
         self.udp_capacity = Some(c);
     }

--- a/crates/shadowsocks-service/src/local/socks/server/mod.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/mod.rs
@@ -60,7 +60,7 @@ impl Socks {
         self.udp_expiry_duration = Some(d);
     }
 
-    /// Set total UDP association to be kept simultaneouslyin server
+    /// Set total UDP association to be kept simultaneously in server
     pub fn set_udp_capacity(&mut self, c: usize) {
         self.udp_capacity = Some(c);
     }

--- a/crates/shadowsocks-service/src/local/tunnel/server.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/server.rs
@@ -41,7 +41,7 @@ impl Tunnel {
         self.udp_expiry_duration = Some(d);
     }
 
-    /// Set total UDP association to be kept simultaneouslyin server
+    /// Set total UDP association to be kept simultaneously in server
     pub fn set_udp_capacity(&mut self, c: usize) {
         self.udp_capacity = Some(c);
     }


### PR DESCRIPTION
The space in `simultaneously in` was removed by mistake.