### PR TITLE
Update debian deb script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+shadowsocks-rust (1.12.5) unstable; urgency=medium
+
+  ## Bug Fixes
+
+  - #725 High CPU consumption on Linux Kernel < 4.11 when TCP Fast Open is enabled.
+
+ -- ty <zonyitoo@gmail.com>  Fri, 17 Dec 2021 00:13:26 +0800
+  
 shadowsocks-rust (1.12.4) unstable; urgency=medium
 
   ## Features
@@ -17,6 +25,8 @@ shadowsocks-rust (1.12.4) unstable; urgency=medium
 
   - Deprecating `SS_LOG_VERBOSE_LEVEL` and `SS_LOG_WITHOUT_TIME` (introduced in [v1.12.3](https://github.com/shadowsocks/shadowsocks-rust/releases/tag/v1.12.3)) in flavor of configuring in the configuration file
 
+ -- ty <zonyitoo@gmail.com>  Sun, 28 Nov 2021 15:01:54 +0800
+
 shadowsocks-rust (1.12.3) unstable; urgency=medium
 
   ## Features
@@ -30,6 +40,8 @@ shadowsocks-rust (1.12.3) unstable; urgency=medium
     - Server created from command line argument without `--password` will try to read it from TTY
     - Servers' `"password"` field or `--password` option support `${VAR_NAME}` format to read password from environment variable `VAR_NAME`
 
+ -- ty <zonyitoo@gmail.com>  Fri, 26 Nov 2021 00:12:13 +0800
+
 shadowsocks-rust (1.12.2) unstable; urgency=medium
 
   ## BUG Fixes
@@ -39,6 +51,8 @@ shadowsocks-rust (1.12.2) unstable; urgency=medium
   ## Miscellaneous
 
   - Removed direct dependency to [`mio`](https://crates.io/crates/mio), sending file descriptors through UDS now with [`sendfd`](https://crates.io/crates/sendfd).
+
+ -- ty <zonyitoo@gmail.com>  Tue, 16 Nov 00:11:44 2021 +0800
 
 shadowsocks-rust (1.12.1) unstable; urgency=medium
 
@@ -50,6 +64,8 @@ shadowsocks-rust (1.12.1) unstable; urgency=medium
 
     - #674 MIPS targets in pre-built releases binaries will be compressed by `upx`
     - #670 Servers created by command line options in `ssserver` will have mode `tcp_only`
+
+ -- ty <zonyitoo@gmail.com>  Tue, 9 Nov 2021 23:27:48 +0800
 
 shadowsocks-rust (1.12.0) unstable; urgency=medium
 
@@ -80,6 +96,8 @@ shadowsocks-rust (1.12.0) unstable; urgency=medium
   - #596 Support Snapcraft https://snapcraft.io/shadowsocks-rust
   - TFO on Linux queue length set to 1024 to match backlogs
   - Completely remove Replay Attack Protection with Ping-Pong bloom filter in default build configuration
+
+ -- ty <zonyitoo@gmail.com>  Tue, 2 Nov 2021 12:52:17 +0800
 
 shadowsocks-rust (1.11.2) unstable; urgency=medium
 

--- a/debian/shadowsocks-rust-local@.service
+++ b/debian/shadowsocks-rust-local@.service
@@ -12,6 +12,7 @@ After=network.target
 [Service]
 Type=simple
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/usr/bin/sslocal --log-without-time -c /etc/shadowsocks-rust/%i.json
 
 [Install]

--- a/debian/shadowsocks-rust-local@.service
+++ b/debian/shadowsocks-rust-local@.service
@@ -13,7 +13,7 @@ After=network.target
 Type=simple
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-ExecStart=/usr/bin/sslocal --log-without-time -c /etc/shadowsocks-rust/%i.json
+ExecStart=/usr/bin/ssservice local --log-without-time -c /etc/shadowsocks-rust/%i.json
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/shadowsocks-rust-server@.service
+++ b/debian/shadowsocks-rust-server@.service
@@ -13,7 +13,7 @@ After=network.target
 Type=simple
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-ExecStart=/usr/bin/ssserver --log-without-time -c /etc/shadowsocks-rust/%i.json
+ExecStart=/usr/bin/ssservice server --log-without-time -c /etc/shadowsocks-rust/%i.json
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/shadowsocks-rust-server@.service
+++ b/debian/shadowsocks-rust-server@.service
@@ -12,6 +12,7 @@ After=network.target
 [Service]
 Type=simple
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/usr/bin/ssserver --log-without-time -c /etc/shadowsocks-rust/%i.json
 
 [Install]

--- a/debian/shadowsocks-rust.default
+++ b/debian/shadowsocks-rust.default
@@ -15,7 +15,7 @@ START=yes
 CONFFILE="/etc/shadowsocks-rust/config.json"
 
 # Extra command line arguments
-DAEMON_ARGS="-u"
+DAEMON_ARGS="--log-without-time"
 
 # User and group to run the server as
 USER=nobody

--- a/debian/shadowsocks-rust.init
+++ b/debian/shadowsocks-rust.init
@@ -16,8 +16,8 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=shadowsocks-rust        # Introduce a short description here
 NAME=shadowsocks-rust        # Introduce the short server's name here
-DAEMON=/usr/bin/ssserver     # Introduce the server's location here
-DAEMON_ARGS="-u --log-without-time" # Arguments to run the daemon with
+DAEMON=/usr/bin/ssservice    # Introduce the server's location here
+DAEMON_ARGS="--log-without-time" # Arguments to run the daemon with
 PIDFILE=/var/run/$NAME/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -55,10 +55,8 @@ do_start()
     #   0 if daemon has been started
     #   1 if daemon was already running
     #   2 if daemon could not be started
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$GROUP --exec $DAEMON --test > /dev/null \
-        || return 1
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$GROUP --exec $DAEMON -- \
-        -c "$CONFFILE" -u -f $PIDFILE $DAEMON_ARGS \
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER:$GROUP --exec $DAEMON server \
+        -c "$CONFFILE" -f $PIDFILE $DAEMON_ARGS \
         || return 2
 }
 

--- a/debian/shadowsocks-rust.postinst
+++ b/debian/shadowsocks-rust.postinst
@@ -21,6 +21,7 @@ pathfind() {
 case "$1" in
 	configure|reconfigure)
 		pathfind setcap && setcap \
+            cap_net_bind_service+ep /usr/bin/ssservice \
 			cap_net_bind_service+ep /usr/bin/sslocal \
 			cap_net_bind_service+ep /usr/bin/ssserver
 		if [ ! -f /etc/shadowsocks-rust/config.json ]; then

--- a/debian/shadowsocks-rust.service
+++ b/debian/shadowsocks-rust.service
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/default/shadowsocks-rust
 User=nobody
 Group=nogroup
 LimitNOFILE=32768
-ExecStart=/usr/bin/ssserver --log-without-time -c ${CONFFILE} ${DAEMON_ARGS}
+ExecStart=/usr/bin/ssservice server -c ${CONFFILE} ${DAEMON_ARGS}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There are some problems with the current script.

1. Unable to bind ports (port < 1024)
bind the low port will prompt ```Permission denied```
solution: add AmbientCapabilities config.

2. changlog has some problem
For example, compile with a warning.
```
dpkg-source: warning: shadowsocks-rust/debian/changelog(l20): found start of entry where expected more change data or trailer
```
3. replace sserver/sslocal to ssservice.

4. removed some wrong startup parameters.

The following commands will work properly after updating the script.
```
sudo systemctl start shadowsocks-rust.service
```
