### PR TITLE
feat(deploy): support k8s deployment (#739)

### DIFF
--- a/k8s/chart/.helmignore
+++ b/k8s/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: shadowsocks-rust
+description: A Helm chart for shadowsocks-rust
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.x.x"

--- a/k8s/chart/templates/NOTES.txt
+++ b/k8s/chart/templates/NOTES.txt
@@ -1,0 +1,20 @@
+{{- $port := "<port>" -}}
+{{- if not .Values.configMapName -}}
+{{- $port = (.Values.servers | first).server_port -}}
+{{- end -}}
+1. Get the shadowsocks URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "shadowsocks-rust.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "shadowsocks-rust.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "shadowsocks-rust.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ $port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "shadowsocks-rust.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/k8s/chart/templates/_helpers.tpl
+++ b/k8s/chart/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "shadowsocks-rust.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "shadowsocks-rust.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "shadowsocks-rust.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "shadowsocks-rust.labels" -}}
+helm.sh/chart: {{ include "shadowsocks-rust.chart" . }}
+{{ include "shadowsocks-rust.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "shadowsocks-rust.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "shadowsocks-rust.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "shadowsocks-rust.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "shadowsocks-rust.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "shadowsocks-rust.portName" -}}
+{{- if .name -}}
+{{- .name -}}
+{{- else -}}
+{{- printf "ss-%d" (.server_port | int) -}} 
+{{- end -}}
+{{- end -}}

--- a/k8s/chart/templates/config.yaml
+++ b/k8s/chart/templates/config.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.configMapName -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "shadowsocks-rust.fullname" . }}
+  labels:
+    {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {
+      "servers": {{- .Values.servers | toPrettyJson | nindent 8 }}
+    }
+{{- end -}}

--- a/k8s/chart/templates/deployment.yaml
+++ b/k8s/chart/templates/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "shadowsocks-rust.fullname" . }}
+  labels:
+    {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "shadowsocks-rust.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "shadowsocks-rust.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "shadowsocks-rust.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ default (include "shadowsocks-rust.fullname" .) .Values.configMapName }}
+      - name: plugins
+        emptyDir: {}
+      {{- if .Values.downloadPlugins }}
+      initContainers:
+      - name: plugin-downloader
+        image: busybox
+        command:
+        - sh
+        - -c
+        - |
+          TAG=$(wget -qO- https://api.github.com/repos/shadowsocks/v2ray-plugin/releases/latest | grep tag_name | cut -d '"' -f4)
+          wget https://github.com/shadowsocks/v2ray-plugin/releases/download/$TAG/v2ray-plugin-linux-amd64-$TAG.tar.gz
+          tar -xf *.gz
+          rm *.gz
+          mv v2ray* /usr/local/bin/v2ray-plugin
+          chmod +x /usr/local/bin/v2ray-plugin
+
+          TAG=$(wget -qO- https://api.github.com/repos/teddysun/xray-plugin/releases/latest | grep tag_name | cut -d '"' -f4)
+          wget https://github.com/teddysun/xray-plugin/releases/download/$TAG/xray-plugin-linux-amd64-$TAG.tar.gz
+          tar -xf *.gz
+          rm *.gz
+          mv xray* /usr/local/bin/xray-plugin
+          chmod +x /usr/local/bin/xray-plugin
+        volumeMounts:
+        - name: plugins
+          mountPath: /usr/local/bin
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/shadowsocks-rust
+          readOnly: true
+        - name: plugins
+          mountPath: /usr/local/bin
+        ports:
+        {{- $hostPort := .Values.hostPort -}}
+        {{- range $i, $svr := .Values.servers }}
+        - name: {{ include "shadowsocks-rust.portName" $svr }}
+          containerPort: {{ $svr.server_port }}
+          {{- if $hostPort }}
+          hostPort: {{ $svr.server_port }}
+          {{- end }}
+          protocol: TCP
+        {{ end -}}
+        {{- /* use the first port for health check */ -}}
+        {{- $defaultPort := (.Values.servers | first).server_port -}}
+        livenessProbe:
+          tcpSocket:
+            port: {{ $defaultPort }}
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          tcpSocket:
+            port: {{ $defaultPort }}
+          initialDelaySeconds: 2
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/chart/templates/hpa.yaml
+++ b/k8s/chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "shadowsocks-rust.fullname" . }}
+  labels:
+    {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "shadowsocks-rust.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/k8s/chart/templates/service.yaml
+++ b/k8s/chart/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "shadowsocks-rust.fullname" . }}
+  labels:
+    {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- range $i, $svr := .Values.servers }}
+  - name: {{ include "shadowsocks-rust.portName" $svr }}
+    targetPort: {{ $svr.server_port }}
+    protocol: TCP
+    port: {{ default $svr.server_port $svr.service_port }}
+  {{ end -}}
+  selector:
+    {{- include "shadowsocks-rust.selectorLabels" . | nindent 4 }}

--- a/k8s/chart/templates/serviceaccount.yaml
+++ b/k8s/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "shadowsocks-rust.serviceAccountName" . }}
+  labels:
+    {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/k8s/chart/templates/tests/test-connection.yaml
+++ b/k8s/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "shadowsocks-rust.fullname" . }}-test-connection"
+  labels:
+    {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "shadowsocks-rust.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -1,0 +1,92 @@
+# Default values for shadowsocks-rust.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This is the shadowsocks config which will be mount to /etc/shadowocks-rust.
+# You can put arbitrary yaml here, it will translation to json before mounting.
+servers:
+- server: 0.0.0.0
+  server_port: 8388
+  service_port: 80 # the k8s service port, default to server_port
+  password: mypassword
+  timeout: 7200
+  method: aes-256-gcm
+  fast_open: true
+  nameserver: 8.8.8.8
+  mode: tcp_and_udp
+  # plugin: v2ray-plugin
+  # plugin_opts: server;tls;host=github.com
+
+# Whether to download v2ray and xray plugin.
+downloadPlugins: false
+
+# Name of the ConfigMap with config.json configuration for shadowsocks-rust. 
+configMapName: ""
+
+service:
+  # Change to LoadBalancer if you are behind a cloud provider like aws, gce, or tke.
+  type: ClusterIP
+
+# Bind shadowsocks port port to host, i.e., we can use host:port to access shawdowsocks server.
+hostPort: false
+
+replicaCount: 1
+
+image:
+  repository: teddysun/shadowsocks-rust
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "debian-1.9.1"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 20m
+    memory: 32Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/k8s/shadowsocks-rust.yaml
+++ b/k8s/shadowsocks-rust.yaml
@@ -1,0 +1,151 @@
+---
+# Source: shadowsocks-rust/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: shadowsocks-rust
+  labels:
+    helm.sh/chart: shadowsocks-rust-0.1.0
+    app.kubernetes.io/name: shadowsocks-rust
+    app.kubernetes.io/instance: shadowsocks-rust
+    app.kubernetes.io/version: "1.x.x"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: shadowsocks-rust/templates/config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: shadowsocks-rust
+  labels:
+    helm.sh/chart: shadowsocks-rust-0.1.0
+    app.kubernetes.io/name: shadowsocks-rust
+    app.kubernetes.io/instance: shadowsocks-rust
+    app.kubernetes.io/version: "1.x.x"
+    app.kubernetes.io/managed-by: Helm
+data:
+  config.json: |
+    {
+      "servers":
+        [
+          {
+            "fast_open": true,
+            "method": "aes-256-gcm",
+            "mode": "tcp_and_udp",
+            "nameserver": "8.8.8.8",
+            "password": "mypassword",
+            "server": "0.0.0.0",
+            "server_port": 8388,
+            "service_port": 80,
+            "timeout": 7200
+          }
+        ]
+    }
+---
+# Source: shadowsocks-rust/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: shadowsocks-rust
+  labels:
+    helm.sh/chart: shadowsocks-rust-0.1.0
+    app.kubernetes.io/name: shadowsocks-rust
+    app.kubernetes.io/instance: shadowsocks-rust
+    app.kubernetes.io/version: "1.x.x"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: ss-8388
+    targetPort: 8388
+    protocol: TCP
+    port: 80
+  selector:
+    app.kubernetes.io/name: shadowsocks-rust
+    app.kubernetes.io/instance: shadowsocks-rust
+---
+# Source: shadowsocks-rust/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shadowsocks-rust
+  labels:
+    helm.sh/chart: shadowsocks-rust-0.1.0
+    app.kubernetes.io/name: shadowsocks-rust
+    app.kubernetes.io/instance: shadowsocks-rust
+    app.kubernetes.io/version: "1.x.x"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: shadowsocks-rust
+      app.kubernetes.io/instance: shadowsocks-rust
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: shadowsocks-rust
+        app.kubernetes.io/instance: shadowsocks-rust
+    spec:
+      serviceAccountName: shadowsocks-rust
+      securityContext:
+        {}
+      volumes:
+      - name: config
+        configMap:
+          name: shadowsocks-rust
+      - name: plugins
+        emptyDir: {}
+      containers:
+      - name: shadowsocks-rust
+        securityContext:
+          {}
+        image: "teddysun/shadowsocks-rust:debian-1.9.1"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: config
+          mountPath: /etc/shadowsocks-rust
+          readOnly: true
+        - name: plugins
+          mountPath: /usr/local/bin
+        ports:
+        - name: ss-8388
+          containerPort: 8388
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 8388
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          tcpSocket:
+            port: 8388
+          initialDelaySeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 20m
+            memory: 32Mi
+---
+# Source: shadowsocks-rust/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "shadowsocks-rust-test-connection"
+  labels:
+    helm.sh/chart: shadowsocks-rust-0.1.0
+    app.kubernetes.io/name: shadowsocks-rust
+    app.kubernetes.io/instance: shadowsocks-rust
+    app.kubernetes.io/version: "1.x.x"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['shadowsocks-rust:']
+  restartPolicy: Never


### PR DESCRIPTION
- helm chart
- kubectl with raw manifest which generated via helm
- update README

One more thing, we could host the chart repo with GitHub pages or within a Docker oci image.