### PR TITLE
Strip symbols in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ lto = "fat"
 codegen-units = 1
 incremental = false
 panic = "abort"
+strip = true
 
 [features]
 default = [


### PR DESCRIPTION
Adds strip option since it was [stabilized](https://github.com/rust-lang/cargo/pull/10088). Closes #276.