### PR TITLE
Disable secure mode in mimalloc allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ tokio = { version = "1", features = ["rt", "signal"] }
 
 ipnet = { version = "2.3", optional = true }
 
-mimalloc = { version = "0.1", optional = true }
+mimalloc = { version = "0.1", default-features = false, optional = true }
 tcmalloc = { version = "0.3", optional = true }
 jemallocator = { version = "0.3", optional = true }
 snmalloc-rs = { version = "0.2", optional = true }


### PR DESCRIPTION
By default mimalloc has ["secure"](https://github.com/microsoft/mimalloc#secure-mode) feature enabled which has some performance penalty and a little memory overhead (due to guard pages). It's useless for safe rust code, but can be useful for unsafe. I'm not sure if it useful for shadowsocks-rust project, but personally I disable it in my builds.