### PR TITLE
Remove (or make optional) some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,6 @@ dependencies = [
  "json5",
  "libc",
  "log",
- "log4rs",
  "lru_time_cache",
  "native-tls",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,6 @@ dependencies = [
  "nix",
  "once_cell",
  "pin-project",
- "qrcode",
  "rand",
  "regex",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ server = ["shadowsocks-service/server"]
 # Enable manager server
 manager = ["shadowsocks-service/manager"]
 # Enable utility
-utility = []
+utility = ["qrcode"]
 # Enable service
 service = ["local", "server", "manager"]
 
@@ -146,7 +146,7 @@ thiserror = "1.0"
 
 clap = { version = "3.1", features = ["wrap_help", "suggestions"] }
 cfg-if = "1"
-qrcode = { version = "0.12", default-features = false }
+qrcode = { version = "0.12", default-features = false, optional = true }
 exitcode = "1"
 build-time = "0.1"
 directories = "4.0"

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -80,7 +80,6 @@ neon = ["shadowsocks/neon"]
 
 [dependencies]
 log = "0.4"
-log4rs = "1.0"
 
 cfg-if = "1"
 qrcode = { version = "0.12", default-features = false }

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -82,7 +82,6 @@ neon = ["shadowsocks/neon"]
 log = "0.4"
 
 cfg-if = "1"
-qrcode = { version = "0.12", default-features = false }
 pin-project = "1.0"
 once_cell = "1.8"
 thiserror = "1.0"

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -123,7 +123,7 @@ smoltcp = { version = "0.8", optional = true, default-features = false, features
 serde = { version = "1.0", features = ["derive"] }
 json5 = "0.4"
 
-shadowsocks = { version = "1.14.1", path = "../shadowsocks" }
+shadowsocks = { version = "1.14.1", path = "../shadowsocks", default-features = false }
 
 # Just for the ioctl call macro
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]


### PR DESCRIPTION
The service crate specifies some dependencies that it does not need. I also found that depending on `shadowsocks-service` directly enables `trust-dns` even if `trust-dns` is not specified.