### PR TITLE
update: remove rnd from security-iv-printable-prefix feature

### DIFF
--- a/crates/shadowsocks/src/context.rs
+++ b/crates/shadowsocks/src/context.rs
@@ -175,7 +175,7 @@ mod tests {
     fn generate_nonce() {
         let mut salt = vec![0u8; 64];
         let context = Context::new(ServerType::Server);
-        context.generate_nonce(CipherKind::NONE, &mut salt, false);
+        context.generate_nonce(CipherKind::AES_128_GCM, &mut salt, false);
         println!("generate nonce printable ascii: {:?}", ByteStr::new(&salt));
     }
 

--- a/crates/shadowsocks/src/context.rs
+++ b/crates/shadowsocks/src/context.rs
@@ -169,12 +169,13 @@ mod tests {
     use crate::config::ServerType;
     use crate::context::Context;
     use byte_string::ByteStr;
+    use shadowsocks_crypto::CipherKind;
 
     #[test]
     fn generate_nonce() {
         let mut salt = vec![0u8; 64];
         let context = Context::new(ServerType::Server);
-        context.generate_nonce(&mut salt, false);
+        context.generate_nonce(CipherKind::NONE, &mut salt, false);
         println!("generate nonce printable ascii: {:?}", ByteStr::new(&salt));
     }
 


### PR DESCRIPTION
I wrote little rust. So it is welcome to tell me any problems in the commit.

The feature `security-iv-printable-prefix` works well for me. I found the original solution used `Rand` package to generate the index. It is repeated for nonce calculation. So I updated the codes to prefix processing of nonce.