### PR TITLE
`sslocal`, `ssservice`, `ssmanager` return non-zero exit codes when failing to launch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod service;
 pub mod sys;
 pub mod validator;
 
-/// Exit code when server exits unexpectly
+/// Exit code when server exits unexpectedly
 pub const EXIT_CODE_SERVER_EXIT_UNEXPECTEDLY: sysexits::ExitCode = sysexits::ExitCode::Software;
 /// Exit code when server aborted
 pub const EXIT_CODE_SERVER_ABORTED: sysexits::ExitCode = sysexits::ExitCode::Software;
@@ -20,6 +20,8 @@ pub const EXIT_CODE_SERVER_ABORTED: sysexits::ExitCode = sysexits::ExitCode::Sof
 pub const EXIT_CODE_LOAD_CONFIG_FAILURE: sysexits::ExitCode = sysexits::ExitCode::Config;
 /// Exit code when loading ACL from file fails
 pub const EXIT_CODE_LOAD_ACL_FAILURE: sysexits::ExitCode = sysexits::ExitCode::Config;
+/// Exit code when insufficient params are passed via CLI
+pub const EXIT_CODE_INSUFFICIENT_PARAMS: sysexits::ExitCode = sysexits::ExitCode::Usage;
 
 /// Build timestamp in UTC
 pub const BUILD_TIME: &str = build_time::build_time_utc!();

--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -27,8 +27,7 @@ use shadowsocks_service::{
 use crate::logging;
 use crate::{
     config::{Config as ServiceConfig, RuntimeMode},
-    monitor,
-    validator,
+    monitor, validator,
 };
 
 /// Defines command line options
@@ -763,12 +762,12 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
                 "missing `local_address`, consider specifying it by --local-addr command line option, \
                     or \"local_address\" and \"local_port\" in configuration file"
             );
-            return ExitCode::SUCCESS;
+            return crate::EXIT_CODE_INSUFFICIENT_PARAMS.into();
         }
 
         if let Err(err) = config.check_integrity() {
             eprintln!("config integrity check failed, {}", err);
-            return ExitCode::SUCCESS;
+            return crate::EXIT_CODE_LOAD_CONFIG_FAILURE.into();
         }
 
         #[cfg(unix)]

--- a/src/service/manager.rs
+++ b/src/service/manager.rs
@@ -24,8 +24,7 @@ use shadowsocks_service::{
 use crate::logging;
 use crate::{
     config::{Config as ServiceConfig, RuntimeMode},
-    monitor,
-    validator,
+    monitor, validator,
 };
 
 /// Defines command line options
@@ -435,12 +434,12 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
                 "missing `manager_address`, consider specifying it by --manager-address command line option, \
                     or \"manager_address\" and \"manager_port\" keys in configuration file"
             );
-            return ExitCode::SUCCESS;
+            return crate::EXIT_CODE_INSUFFICIENT_PARAMS.into();
         }
 
         if let Err(err) = config.check_integrity() {
             eprintln!("config integrity check failed, {}", err);
-            return ExitCode::SUCCESS;
+            return crate::EXIT_CODE_LOAD_CONFIG_FAILURE.into();
         }
 
         #[cfg(unix)]

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -22,8 +22,7 @@ use shadowsocks_service::{
 use crate::logging;
 use crate::{
     config::{Config as ServiceConfig, RuntimeMode},
-    monitor,
-    validator,
+    monitor, validator,
 };
 
 /// Defines command line options
@@ -448,12 +447,12 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
                     --server-addr, --encrypt-method, --password command line option, \
                         or configuration file, check more details in https://shadowsocks.org/en/config/quick-guide.html"
             );
-            return ExitCode::SUCCESS;
+            return crate::EXIT_CODE_INSUFFICIENT_PARAMS.into();
         }
 
         if let Err(err) = config.check_integrity() {
             eprintln!("config integrity check failed, {}", err);
-            return ExitCode::SUCCESS;
+            return crate::EXIT_CODE_LOAD_CONFIG_FAILURE.into();
         }
 
         #[cfg(unix)]


### PR DESCRIPTION
I noticed `sslocal` was exiting with `0` when run completely naked (no args), which surely isn't correct. This fixes that.

I don't think it would cause problems downstream, although I cannot be absolutely sure.