### PR TITLE
Minor update

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,28 +10,10 @@ else
 fi
 
 if [ "$1" = "sslocal" -o "$1" = "ssserver" -o "$1" = "ssmanager" -o "$1" = "ssservice" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
-
-        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
-            case "$f" in
-                *.sh)
-                    if [ -x "$f" ]; then
-                        echo >&3 "$0: Launching $f";
-                        "$f"
-                    else
-                        # warn on shell scripts without exec bit
-                        echo >&3 "$0: Ignoring $f, not executable";
-                    fi
-                    ;;
-                *) echo >&3 "$0: Ignoring $f";;
-            esac
-        done
-
+    if [ -f "/etc/shadowsocks-rust/config.json" ]; then
         echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No configuration files found in /etc/shadowsocks-rust, skipping configuration"
     fi
 fi
 


### PR DESCRIPTION
- Remove useless configuration.
- Docker container running as root user, the program running as nobody user

For specific reasons, please refer to [shadowsocks-libev](https://github.com/shadowsocks/shadowsocks-libev/pull/2912).

Final result:

```bash
$ docker container logs condescending_dubinsky
/usr/local/bin/docker-entrypoint.sh: Configuration complete; ready for start up
INFO  shadowsocks server 1.15.0-alpha.5 build 2022-06-29T07:26:50.397766052+00:00
INFO  shadowsocks tcp server listening on 127.0.0.1:8388, inbound address 127.0.0.1:8388
```