### PR TITLE
Fix typo in file 'dns_resolver.rs'.

### DIFF
--- a/crates/shadowsocks-service/src/local/dns/dns_resolver.rs
+++ b/crates/shadowsocks-service/src/local/dns/dns_resolver.rs
@@ -156,7 +156,7 @@ impl DnsResolve for DnsResolver {
 
                     match res_v6 {
                         Ok(res) => vaddr = store_dns(res, port),
-                        Err(err) => debug!("failed to resolve A records, error: {}", err),
+                        Err(err) => debug!("failed to resolve AAAA records, error: {}", err),
                     }
                 }
 


### PR DESCRIPTION
I was testing ss-rust, and somehow it prints 2 error with the exact same message, turns out it's a typo, so I made a fix.