### PR TITLE
Helm: add service annotations

### DIFF
--- a/k8s/chart/templates/service.yaml
+++ b/k8s/chart/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "shadowsocks-rust.fullname" . }}
   labels:
     {{- include "shadowsocks-rust.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -18,12 +18,14 @@ servers:
 # Whether to download v2ray and xray plugin.
 downloadPlugins: false
 
-# Name of the ConfigMap with config.json configuration for shadowsocks-rust. 
+# Name of the ConfigMap with config.json configuration for shadowsocks-rust.
 configMapName: ""
 
 service:
   # Change to LoadBalancer if you are behind a cloud provider like aws, gce, or tke.
   type: ClusterIP
+  # external-dns.alpha.kubernetes.io/hostname: socks.example.com
+  annotations: {}
 
 # Bind shadowsocks port port to host, i.e., we can use host:port to access shawdowsocks server.
 hostPort: false


### PR DESCRIPTION
Useful feature for k8s-guys (for example, external-dns needs service annotations)