### PR TITLE
bugfix: salt recheck will cause duplicated iv/salt error

### DIFF
--- a/crates/shadowsocks/src/relay/tcprelay/aead.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/aead.rs
@@ -254,8 +254,9 @@ impl DecryptedReader {
         }
 
         // Check repeated salt after first successful decryption #442
-        if let Some(ref salt) = self.salt {
-            context.check_nonce_replay(self.method, salt)?;
+        if self.salt.is_some() {
+            let salt = self.salt.take().unwrap();
+            context.check_nonce_replay(self.method, &salt)?;
         }
 
         // Remote TAG


### PR DESCRIPTION
in version 1.14.3

```
        // Check repeated salt after first successful decryption #442
        if self.salt.is_some() {
            let salt = self.salt.take().unwrap();
            context.check_nonce_replay(&salt)?;
        }
```

current master version

```
        // Check repeated salt after first successful decryption #442
        if let Some(ref salt) = self.salt {
            context.check_nonce_replay(self.method, salt)?;
        }
```

if enable feature `security-replay-attack-detect`, it causes error `detected repeated nonce (iv/salt)`


