### PR TITLE
Deal with API change when bumping base64 to 0.21

### DIFF
--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -41,6 +41,7 @@
 //!
 //! These defined server will be used with a load balancing algorithm.
 
+use base64::{Engine as _};
 use std::{
     borrow::Cow,
     convert::{From, Infallible},
@@ -1709,7 +1710,7 @@ impl Config {
                     let mut user_manager = ServerUserManager::new();
 
                     for user in users {
-                        let key = match base64::decode_config(&user.password, base64::STANDARD) {
+                        let key = match base64::engine::general_purpose::STANDARD.decode(&user.password) {
                             Ok(k) => k,
                             Err(..) => {
                                 let err = Error::new(
@@ -2480,7 +2481,7 @@ impl fmt::Display for Config {
                             for u in m.users_iter() {
                                 vu.push(SSServerUserConfig {
                                     name: u.name().to_owned(),
-                                    password: base64::encode(u.key()),
+                                    password: base64::engine::general_purpose::STANDARD.encode(u.key()),
                                 });
                             }
                             vu

--- a/crates/shadowsocks-service/src/manager/server.rs
+++ b/crates/shadowsocks-service/src/manager/server.rs
@@ -1,5 +1,7 @@
 //! Shadowsocks Manager server
 
+use base64::{Engine as _};
+
 #[cfg(unix)]
 use std::path::PathBuf;
 use std::{collections::HashMap, io, net::SocketAddr, sync::Arc, time::Duration};
@@ -469,7 +471,7 @@ impl Manager {
             let mut user_manager = ServerUserManager::new();
 
             for user in users.iter() {
-                let key = match base64::decode_config(&user.password, base64::STANDARD) {
+                let key = match base64::engine::general_purpose::STANDARD.decode(&user.password) {
                     Ok(key) => key,
                     Err(..) => {
                         error!(
@@ -522,7 +524,7 @@ impl Manager {
                 for user in user_manager.users_iter() {
                     vu.push(ServerUserConfig {
                         name: user.name().to_owned(),
-                        password: base64::encode(user.key()),
+                        password: base64::engine::general_purpose::STANDARD.encode(user.key()),
                     });
                 }
 

--- a/crates/shadowsocks/src/config.rs
+++ b/crates/shadowsocks/src/config.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use base64::{decode_config, encode_config, URL_SAFE, URL_SAFE_NO_PAD};
+use base64::{Engine as _, engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD}};
 use byte_string::ByteStr;
 use bytes::Bytes;
 use cfg_if::cfg_if;
@@ -161,7 +161,7 @@ impl Debug for ServerUser {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("ServerUser")
             .field("name", &self.name)
-            .field("key", &base64::encode(&self.key))
+            .field("key", &base64::engine::general_purpose::STANDARD.encode(&self.key))
             .field("identity_hash", &ByteStr::new(&self.identity_hash))
             .finish()
     }
@@ -302,7 +302,7 @@ pub struct ServerConfig {
 fn make_derived_key(method: CipherKind, password: &str, enc_key: &mut [u8]) {
     if method.is_aead_2022() {
         // AEAD 2022 password is a base64 form of enc_key
-        match base64::decode_config(password, base64::STANDARD) {
+        match base64::engine::general_purpose::STANDARD.decode(password) {
             Ok(v) => {
                 if v.len() != enc_key.len() {
                     panic!(
@@ -363,7 +363,7 @@ where
         make_derived_key(method, upsk, &mut enc_key);
 
         for ipsk in split_iter {
-            match base64::decode_config(ipsk, base64::STANDARD) {
+            match base64::engine::general_purpose::STANDARD.decode(ipsk) {
                 Ok(v) => {
                     identity_keys.push(Bytes::from(v));
                 }
@@ -564,7 +564,7 @@ impl ServerConfig {
     /// ```
     pub fn to_qrcode_url(&self) -> String {
         let param = format!("{}:{}@{}", self.method(), self.password(), self.addr());
-        format!("ss://{}", encode_config(param, URL_SAFE_NO_PAD))
+        format!("ss://{}", URL_SAFE_NO_PAD.encode(param))
     }
 
     /// Get [SIP002](https://github.com/shadowsocks/shadowsocks-org/issues/27) URL
@@ -573,7 +573,7 @@ impl ServerConfig {
             if #[cfg(feature = "aead-cipher-2022")] {
                 let user_info = if !self.method().is_aead_2022() {
                     let user_info = format!("{}:{}", self.method(), self.password());
-                    encode_config(&user_info, URL_SAFE_NO_PAD)
+                    URL_SAFE_NO_PAD.encode(&user_info)
                 } else {
                     format!("{}:{}", self.method(), percent_encoding::utf8_percent_encode(self.password(), percent_encoding::NON_ALPHANUMERIC))
                 };
@@ -629,7 +629,7 @@ impl ServerConfig {
                 None => return Err(UrlParseError::MissingHost),
             };
 
-            let mut decoded_body = match decode_config(encoded, URL_SAFE_NO_PAD) {
+            let mut decoded_body = match URL_SAFE_NO_PAD.decode(encoded) {
                 Ok(b) => match String::from_utf8(b) {
                     Ok(b) => b,
                     Err(..) => return Err(UrlParseError::InvalidServerAddr),
@@ -690,7 +690,7 @@ impl ServerConfig {
                     URL_SAFE_NO_PAD
                 };
 
-                let account = match decode_config(decoded_user_info, base64_config) {
+                let account = match base64_config.decode(decoded_user_info) {
                     Ok(account) => match String::from_utf8(account) {
                         Ok(ac) => ac,
                         Err(..) => return Err(UrlParseError::InvalidAuthInfo),

--- a/src/service/genkey.rs
+++ b/src/service/genkey.rs
@@ -2,6 +2,7 @@
 
 use std::process::ExitCode;
 
+use base64::{Engine as _};
 use clap::{builder::PossibleValuesParser, Arg, ArgAction, ArgMatches, Command};
 use rand::RngCore;
 
@@ -36,7 +37,7 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut key);
 
-        let encoded_key = base64::encode(&key);
+        let encoded_key = base64::engine::general_purpose::STANDARD.encode(&key);
         println!("{encoded_key}");
     }
 


### PR DESCRIPTION
This PR tries to deal with API change when bumping base64 to 0.21.

- base64 v0.21.0 docs: https://docs.rs/base64/0.21.0/base64/index.html
- base64 v0.13.1 docs: https://docs.rs/base64/0.13.1/base64/index.html
