### PR TITLE
Enable tun destination configuration

### DIFF
--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -275,6 +275,9 @@ struct SSLocalExtConfig {
     #[cfg(feature = "local-tun")]
     #[serde(skip_serializing_if = "Option::is_none")]
     tun_interface_address: Option<String>,
+    #[cfg(feature = "local-tun")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tun_interface_destination: Option<String>,
     #[cfg(all(feature = "local-tun", unix))]
     #[serde(skip_serializing_if = "Option::is_none")]
     tun_device_fd_from_path: Option<String>,
@@ -867,6 +870,9 @@ pub struct LocalConfig {
     /// Tun interface's address and netmask
     #[cfg(feature = "local-tun")]
     pub tun_interface_address: Option<IpNet>,
+    /// Tun interface's destination address and netmask
+    #[cfg(feature = "local-tun")]
+    pub tun_interface_destination: Option<IpNet>,
     /// Tun interface's file descriptor
     #[cfg(all(feature = "local-tun", unix))]
     pub tun_device_fd: Option<std::os::unix::io::RawFd>,
@@ -910,6 +916,8 @@ impl LocalConfig {
             tun_interface_name: None,
             #[cfg(feature = "local-tun")]
             tun_interface_address: None,
+            #[cfg(feature = "local-tun")]
+            tun_interface_destination: None,
             #[cfg(all(feature = "local-tun", unix))]
             tun_device_fd: None,
             #[cfg(all(feature = "local-tun", unix))]
@@ -2403,6 +2411,8 @@ impl fmt::Display for Config {
                         tun_interface_name: local.tun_interface_name.clone(),
                         #[cfg(feature = "local-tun")]
                         tun_interface_address: local.tun_interface_address.as_ref().map(ToString::to_string),
+                        #[cfg(feature = "local-tun")]
+                        tun_interface_destination: local.tun_interface_destination.as_ref().map(ToString::to_string),
                         #[cfg(all(feature = "local-tun", unix))]
                         tun_device_fd_from_path: local
                             .tun_device_fd_from_path

--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -356,6 +356,9 @@ pub async fn create(config: Config) -> io::Result<Server> {
                 if let Some(address) = local_config.tun_interface_address {
                     builder = builder.address(address);
                 }
+                if let Some(address) = local_config.tun_interface_destination {
+                    builder = builder.destination(address);
+                }
                 if let Some(name) = local_config.tun_interface_name {
                     builder = builder.name(&name);
                 }

--- a/crates/shadowsocks-service/src/local/tun/mod.rs
+++ b/crates/shadowsocks-service/src/local/tun/mod.rs
@@ -58,6 +58,11 @@ impl TunBuilder {
         self
     }
 
+    pub fn destination(mut self, addr: IpNet) -> TunBuilder {
+        self.tun_config.destination(addr.addr());
+        self
+    }
+
     pub fn name(mut self, name: &str) -> TunBuilder {
         self.tun_config.name(name);
         self

--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -415,6 +415,14 @@ pub fn define_command_line_options(mut app: Command) -> Command {
                     .action(ArgAction::Set)
                     .value_parser(vparser::parse_ipnet)
                     .help("Tun interface address (network)"),
+            )
+            .arg(
+                Arg::new("TUN_INTERFACE_DESTINATION")
+                    .long("tun-interface-destination")
+                    .num_args(1)
+                    .action(ArgAction::Set)
+                    .value_parser(vparser::parse_ipnet)
+                    .help("Tun interface destination address (network)"),
             );
 
         #[cfg(unix)]
@@ -701,6 +709,9 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
 
                 if let Some(tun_address) = matches.get_one::<IpNet>("TUN_INTERFACE_ADDRESS").cloned() {
                     local_config.tun_interface_address = Some(tun_address);
+                }
+                if let Some(tun_address) = matches.get_one::<IpNet>("TUN_INTERFACE_DESTINATION").cloned() {
+                    local_config.tun_interface_destination = Some(tun_address);
                 }
                 if let Some(tun_name) = matches.get_one::<String>("TUN_INTERFACE_NAME").cloned() {
                     local_config.tun_interface_name = Some(tun_name);

--- a/src/vparser/mod.rs
+++ b/src/vparser/mod.rs
@@ -61,11 +61,7 @@ pub fn parse_ipnet(v: &str) -> Result<IpNet, String> {
     match v.parse::<IpNet>() {
         Err(..) => Err("should be a CIDR address like 10.1.2.3/24".to_owned()),
         Ok(n) => {
-            if n.trunc() == n {
-                Err("should be a valid CIDR address with a host like 10.1.2.3/24".to_owned())
-            } else {
-                Ok(n)
-            }
+            Ok(n)
         }
     }
 }


### PR DESCRIPTION
This PR adds a new argument `--tun-interface-destination` to the `tun` mode. Also, it enables the address format with full 32 bit mask like `10.250.0.1/32`, though seems the package `tun` has a bit problem supporting that for macos.

```
utun10: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500
        inet 10.175.0.8 --> 10.175.0.7 netmask 0xff000000
```