### PR TITLE
Revert "⛔ config: deny unknown fields"

### DIFF
--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -119,7 +119,6 @@ struct SSBalancerConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
-#[serde(deny_unknown_fields)]
 struct SSConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     server: Option<String>,


### PR DESCRIPTION
Reverts shadowsocks/shadowsocks-rust#1106

There are some fields only for binaries: https://github.com/shadowsocks/shadowsocks-rust/blob/a9601f30f9f083e59dd4f2a964092cfa601eab75/src/config.rs#L260-L265 .