### PR TITLE
macOS fix netmask API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,9 +2706,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tun"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad14dc69c82f850bc4c0dc6e7c902893b72827fb34d256fa78e81630a5da86c"
+checksum = "cbc25e23adc6cac7dd895ce2780f255902290fc39b00e1ae3c33e89f3d20fa66"
 dependencies = [
  "byteorder",
  "bytes",

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -114,7 +114,7 @@ ipnet = "2.7"
 iprange = "0.6"
 regex = "1.4"
 
-tun = { version = "0.5.3", optional = true, features = ["async"] }
+tun = { version = "0.5.5", optional = true, features = ["async"] }
 etherparse = { version = "0.13", optional = true }
 smoltcp = { version = "0.8", optional = true, default-features = false, features = ["std", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-icmp", "socket-udp", "socket-tcp"] }
 


### PR DESCRIPTION
related https://github.com/meh/rust-tun/pull/56

Not meant to merge this patch directly, just want to raise the netmask problem from dependency `rust-tun`. Seems that package is not actively maintained.