### PR TITLE
Allow creating UDP sockets on iOS

### DIFF
--- a/crates/shadowsocks/src/net/udp.rs
+++ b/crates/shadowsocks/src/net/udp.rs
@@ -9,6 +9,7 @@ use std::{
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
+    target_os = "ios",
     target_os = "freebsd"
 ))]
 use std::{
@@ -20,6 +21,7 @@ use std::{
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
+    target_os = "ios",
     target_os = "freebsd"
 ))]
 use futures::{future, ready};
@@ -28,6 +30,7 @@ use pin_project::pin_project;
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
+    target_os = "ios",
     target_os = "freebsd"
 ))]
 use tokio::io::Interest;
@@ -46,6 +49,7 @@ use super::{
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
+    target_os = "ios",
     target_os = "freebsd"
 ))]
 pub struct BatchSendMessage<'a> {
@@ -59,6 +63,7 @@ pub struct BatchSendMessage<'a> {
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
+    target_os = "ios",
     target_os = "freebsd"
 ))]
 pub struct BatchRecvMessage<'a> {
@@ -154,6 +159,7 @@ impl UdpSocket {
         target_os = "linux",
         target_os = "android",
         target_os = "macos",
+        target_os = "ios",
         target_os = "freebsd"
     ))]
     pub fn poll_batch_send(
@@ -179,6 +185,7 @@ impl UdpSocket {
         target_os = "linux",
         target_os = "android",
         target_os = "macos",
+        target_os = "ios",
         target_os = "freebsd"
     ))]
     pub async fn batch_send(&self, msgs: &mut [BatchSendMessage<'_>]) -> io::Result<usize> {
@@ -189,6 +196,7 @@ impl UdpSocket {
     #[cfg(any(
         target_os = "linux",
         target_os = "android",
+        target_os = "ios",
         target_os = "macos",
         target_os = "freebsd"
     ))]
@@ -215,6 +223,7 @@ impl UdpSocket {
         target_os = "linux",
         target_os = "android",
         target_os = "macos",
+        target_os = "ios",
         target_os = "freebsd"
     ))]
     pub async fn batch_recv(&self, msgs: &mut [BatchRecvMessage<'_>]) -> io::Result<usize> {


### PR DESCRIPTION
I've just added support for building and running ShadowSocks on iOS. We've used it as a library, and it works well enough for our usecase. Would be great to see this upstreamed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shadowsocks/shadowsocks-rust/1194)
<!-- Reviewable:end -->
