### PR TITLE
Added configs for snap daemons

### DIFF
--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -500,7 +500,7 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
     let (config, runtime) = {
         let config_path_opt = matches.get_one::<PathBuf>("CONFIG").cloned().or_else(|| {
             if !matches.contains_id("SERVER_CONFIG") {
-                match crate::config::get_default_config_path() {
+                match crate::config::get_default_config_path("local.json") {
                     None => None,
                     Some(p) => {
                         println!("loading default config {p:?}");

--- a/src/service/manager.rs
+++ b/src/service/manager.rs
@@ -260,7 +260,7 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
     let (config, runtime) = {
         let config_path_opt = matches.get_one::<PathBuf>("CONFIG").cloned().or_else(|| {
             if !matches.contains_id("SERVER_CONFIG") {
-                match crate::config::get_default_config_path() {
+                match crate::config::get_default_config_path("manager.json") {
                     None => None,
                     Some(p) => {
                         println!("loading default config {p:?}");

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -272,7 +272,7 @@ pub fn main(matches: &ArgMatches) -> ExitCode {
     let (config, runtime) = {
         let config_path_opt = matches.get_one::<PathBuf>("CONFIG").cloned().or_else(|| {
             if !matches.contains_id("SERVER_CONFIG") {
-                match crate::config::get_default_config_path() {
+                match crate::config::get_default_config_path("server.json") {
                     None => None,
                     Some(p) => {
                         println!("loading default config {p:?}");


### PR DESCRIPTION
Currently if you run `snap start shadowsocks-rust.ssserver-daemon` it will fail because of the missing config.

This patch adds paths to config files. All a user needs to do is to add desired local/server configs to $SNAP_COMMON directory.

Still there's a problem, that only one `sslocal`/`ssserver` daemon instance is allowed.
With `ssserver` you can work around this by runing multiple servers in one process (shadowsocks config allows it).
But with `sslocal` this is, alas, impossible.