### PR TITLE
added v2ray-plugin to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,3 +50,9 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version `git describe --tags --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'`
+
+  v2ray-plugin:
+    plugin: go
+    source: https://github.com/teddysun/v2ray-plugin.git
+    source-tag: v5.7.0
+    go-channel: stable


### PR DESCRIPTION
Now it's possible to run the following, without need to install v2ray-plugin separately:
```bash
shadowsocks-rust.ssserver --plugin v2ray-plugin --plugin-opts "server" --password "password" --server-addr 0.0.0.0:11111 --encrypt-method chacha20-ietf-poly1305
```

I don't know how to make snapcraft checkout the latest tagged commit, so I had to hard-code it.