### PR TITLE
Add IPv6 warning for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Download static-linked build [here](https://github.com/shadowsocks/shadowsocks-r
 
 This project provided Docker images for the `linux/i386` and `linux/amd64` and `linux/arm64/v8` architectures.
 
+> :warning: **Docker containers do not have access to IPv6 by default**: Make sure to disable IPv6 Route in the client or [enable IPv6 access to docker containers](https://docs.docker.com/config/daemon/ipv6/#use-ipv6-for-the-default-bridge-network).
+
 #### Pull from GitHub Container Registry
 
 Docker will pull the image of the appropriate architecture from our [GitHub Packages](https://github.com/orgs/shadowsocks/packages?repo_name=shadowsocks-rust).


### PR DESCRIPTION
Mention IPv6 problem with docker and link to IPv6 documentation for docker.