### PR TITLE
bugfix: acl rule pattern match error for tree rule

### DIFF
--- a/crates/shadowsocks-service/src/acl/mod.rs
+++ b/crates/shadowsocks-service/src/acl/mod.rs
@@ -192,7 +192,7 @@ impl ParsingRules {
     fn add_regex_rule(&mut self, mut rule: String) {
         static TREE_SET_RULE_EQUIV: Lazy<Regex> = Lazy::new(|| {
             RegexBuilder::new(
-                r#"^(?:(?:\((?:\?:)?\^\|\\\.\)|(?:\^\.(?:\+|\*))?\\\.)((?:[\w-]+(?:\\\.)?)+)|\^((?:[\w-]+(?:\\\.)?)+))\$$"#,
+                r#"^(?:(?:\((?:\?:)?\^\|\\\.\)|(?:\^\.(?:\+|\*))?\\\.)((?:[\w-]+(?:\\\.)?)+)|\^((?:[\w-]+(?:\\\.)?)+))\$?$"#,
             )
             .unicode(false)
             .build()


### PR DESCRIPTION
the generated acl file by running `genacl_proxy_gfw_bypass_china_ip.py` does not correctly match the pattern in `src/acl/mod.rs`.

the old version will use heavy regex set rules and it will compile all patterns when the first time used. Instead of using tree subdomain methods. 

Actually, most rules are generated for subdomain tree. By removing the last duplicated `\$`, we can make it right.

If it is not right or has some problem, please comment here. 