### PR TITLE
[Regression fix] local DNS uses mode `tcp_and_udp` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,8 @@ Example configuration:
             // Listen address
             "local_address": "127.0.0.1",
             "local_port": 53,
+            // OPTIONAL. DNS local server uses `tcp_and_udp` mode by default
+            "mode": "udp_only",
             // Local DNS address, DNS queries will be sent directly to this address
             "local_dns_address": "114.114.114.114",
             // OPTIONAL. Local DNS's port, 53 by default

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Related Projects:
 - `local-http` - Allow using HTTP protocol for `sslocal`
 
   - `local-http-native-tls` - Support HTTPS with [`native-tls`](https://crates.io/crates/native-tls)
-  
+
   - `local-http-rustls` - Support HTTPS with [`rustls`](https://crates.io/crates/rustls)
 
 - `local-tunnel` - Allow using tunnel protocol for `sslocal`
@@ -209,7 +209,7 @@ servers:
 # Whether to download v2ray and xray plugin.
 downloadPlugins: false
 
-# Name of the ConfigMap with config.json configuration for shadowsocks-rust. 
+# Name of the ConfigMap with config.json configuration for shadowsocks-rust.
 configMapName: ""
 
 service:
@@ -622,7 +622,7 @@ Example configuration:
     "servers": [
         {
             // Fields are the same as the single server's configuration
-            
+
             // Individual servers can be disabled
             // "disabled": true,
             "address": "0.0.0.0",

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -66,7 +66,14 @@ use serde::{Deserialize, Serialize};
 use shadowsocks::relay::socks5::Address;
 use shadowsocks::{
     config::{
-        ManagerAddr, Mode, ReplayAttackPolicy, ServerAddr, ServerConfig, ServerUser, ServerUserManager, ServerWeight,
+        ManagerAddr,
+        Mode,
+        ReplayAttackPolicy,
+        ServerAddr,
+        ServerConfig,
+        ServerUser,
+        ServerUserManager,
+        ServerWeight,
     },
     crypto::CipherKind,
     plugin::PluginConfig,


### PR DESCRIPTION
- Fixes #1281