### PR TITLE
ssurl: add support for SIP008 links (ssconf links with ss contents)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1074,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1420,12 @@ checksum = "972e5f23f6716f62665760b0f4cbf592576a80c7b879ba9beaafc0e558894127"
 dependencies = [
  "libmimalloc-sys",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1884,6 +1912,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "reqwest"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2382,7 @@ dependencies = [
  "num_cpus",
  "qrcode",
  "rand",
+ "reqwest",
  "rpassword",
  "rpmalloc",
  "serde",
@@ -3023,6 +3089,18 @@ dependencies = [
  "quote",
  "syn 2.0.29",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ tokio = { version = "1", features = ["rt", "signal"] }
 num_cpus = "1.15"
 
 ipnet = { version = "2.7", optional = true }
+reqwest = { version = "0.11", features = ["blocking"] }
 
 mimalloc = { version = "0.1", default-features = false, optional = true }
 tcmalloc = { version = "0.3", optional = true }

--- a/bin/ssurl.rs
+++ b/bin/ssurl.rs
@@ -1,4 +1,5 @@
 //! SIP002 URL Scheme
+//! SIP008 URL can be decoded
 //!
 //! SS-URI = "ss://" userinfo "@" hostname ":" port [ "/" ] [ "?" plugin ] [ "#" tag ]
 //! userinfo = websafe-base64-encode-utf8(method  ":" password)
@@ -60,7 +61,12 @@ fn encode(filename: &str, need_qrcode: bool) {
 }
 
 fn decode(encoded: &str, need_qrcode: bool) {
-    let svrconfig = ServerConfig::from_url(encoded).unwrap();
+    let svrconfig = if encoded.starts_with("ssconf") {
+        let url = encoded.replace("ssconf", "https");
+        ServerConfig::from_url(reqwest::blocking::get(url).unwrap().text().unwrap().as_str()).unwrap()
+    } else {
+        ServerConfig::from_url(encoded).unwrap()
+    };
 
     let mut config = Config::new(ConfigType::Server);
     config.server.push(ServerInstanceConfig::with_server_config(svrconfig));


### PR DESCRIPTION
## What is changed

ssurl now supports parsing ssconf links

## What is ssconf?

This is [outline's](https://github.com/Jigsaw-Code/outline-client) way of [providing dynamic key configuration](https://www.reddit.com/r/outlinevpn/wiki/index/dynamic_access_keys/) which is similar to [SIP008](https://github.com/shadowsocks/shadowsocks-rust/issues/302).

The `ssconf://` link is the same as `https://` link to `ss://` configuration (`json` in this implementation is not supported though it is easy to implement in the future)

## Motivation

Outline is based on shadowsocks protocol but has no official cli interface (for clients). My provider is using dynamic keys and since [shadowsocks-rust#302](https://github.com/shadowsocks/shadowsocks-rust/issues/302) (SIP008) is WIP this "hack" will allow using shadowsocks-rust with dynamic keys at least for now (generating new config easily once in a while).