### PR TITLE
bugfix: fix missed client_cache_size config item in SSLocalExtConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ Example configuration:
             "remote_dns_address": "8.8.8.8",
             // OPTIONAL. Remote DNS's port, 53 by default
             "remote_dns_port": 53,
+            // OPTIONAL. dns client cache size for fetching dns queries.
+            "client_cache_size": 5
         },
         {
             // Tun local server (feature = "local-tun")

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -260,6 +260,9 @@ struct SSLocalExtConfig {
     #[cfg(feature = "local-dns")]
     #[serde(skip_serializing_if = "Option::is_none")]
     remote_dns_port: Option<u16>,
+    #[cfg(feature = "local-dns")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_cache_size: Option<usize>,
 
     /// Tunnel
     #[cfg(feature = "local-tunnel")]
@@ -1538,6 +1541,11 @@ impl Config {
                         }
 
                         #[cfg(feature = "local-dns")]
+                        if let Some(client_cache_size) = local.client_cache_size {
+                            local_config.client_cache_size = Some(client_cache_size);
+                        }
+
+                        #[cfg(feature = "local-dns")]
                         if let Some(remote_dns_address) = local.remote_dns_address {
                             let remote_dns_port = local.remote_dns_port.unwrap_or(53);
                             local_config.remote_dns_addr = Some(match remote_dns_address.parse::<IpAddr>() {
@@ -2457,6 +2465,8 @@ impl fmt::Display for Config {
                                 Address::DomainNameAddress(.., port) => Some(*port),
                             },
                         },
+                        #[cfg(feature = "local-dns")]
+                        client_cache_size: local.client_cache_size,
                         #[cfg(feature = "local-tun")]
                         tun_interface_name: local.tun_interface_name.clone(),
                         #[cfg(feature = "local-tun")]


### PR DESCRIPTION
the config item client_cache_size is missed in SSLocalExtConfig, which is to parse the config.json file.

This PR fixed it and updated README file