### PR TITLE
support launch_activate_socket on macos

### DIFF
--- a/crates/shadowsocks/src/net/sys/unix/bsd/macos.rs
+++ b/crates/shadowsocks/src/net/sys/unix/bsd/macos.rs
@@ -227,15 +227,29 @@ extern "C" {
     fn launch_activate_socket(name: *const libc::c_char, fds: *mut *mut libc::c_int, cnt: *mut libc::size_t) -> libc::c_int;
 }
 
-pub fn get_launchd_socket() -> io::Result<RawFd> {
+fn get_launchd_socket_fd(socktype: libc::c_int) -> io::Result<RawFd> {
     let name = std::ffi::CString::new("Listeners").expect("Listeners");
     let mut fds = ptr::null_mut();
     let mut count = 0;
-    let error =  unsafe { launch_activate_socket(name.as_ptr(), &mut fds, &mut count) };
+    let error = unsafe { launch_activate_socket(name.as_ptr(), &mut fds, &mut count) };
     match error {
         0 => {
             let result = match count {
-                1 => Ok(unsafe { *fds.offset(0) }),
+                1 => {
+                    let socket_fd = unsafe { *fds.offset(0) };
+                    let mut option_value: libc::c_int = 0;
+                    let mut option_len = mem::size_of::<libc::c_int>() as libc::socklen_t;
+                    unsafe { libc::getsockopt(socket_fd, libc::SOL_SOCKET, libc::SO_TYPE, &mut option_value as *mut _ as *mut _, &mut option_len) };
+                    if option_value == socktype {
+                        let mut nonblocking = true as libc::c_int;
+                        unsafe { libc::ioctl(socket_fd, libc::FIONBIO, &mut nonblocking) };
+                        Ok(socket_fd)
+                    } else {
+                        let msg = format!("launch_activate_socket, unexpected socket type: {} (expect {})", option_value, socktype);
+                        warn!("{}", msg);
+                        Err(io::Error::new(ErrorKind::Other, msg))
+                    }
+                }
                 _ => {
                     let msg = format!("launch_activate_socket, unexpected sockets: {}", count);
                     warn!("{}", msg);
@@ -249,13 +263,13 @@ pub fn get_launchd_socket() -> io::Result<RawFd> {
             match error {
                 libc::ENOENT => {
                     warn!("launch_activate_socket: The socket name specified does not exist in the caller's launchd.plist(5).")
-                },
+                }
                 libc::ESRCH => {
                     // debug!("launch_activate_socket: The calling process is not managed by launchd(8).")
-                },
+                }
                 libc::EALREADY => {
                     warn!("launch_activate_socket: The specified socket has already been activated.")
-                },
+                }
                 _ => {
                     warn!("launch_activate_socket: {}", io::Error::from_raw_os_error(error))
                 }
@@ -267,11 +281,9 @@ pub fn get_launchd_socket() -> io::Result<RawFd> {
 
 /// Create a TCP socket for listening
 pub async fn create_inbound_tcp_socket(bind_addr: &SocketAddr, _accept_opts: &AcceptOpts) -> io::Result<TcpSocket> {
-    if let Ok(launchd_socket) = get_launchd_socket() {
-        log::info!("launch_activate_socket, use launched socket for {}", bind_addr);
-        let mut nonblocking = true as libc::c_int;
-        unsafe { libc::ioctl(launchd_socket, libc::FIONBIO, &mut nonblocking) };
-        return Ok(unsafe { TcpSocket::from_raw_fd(launchd_socket) });
+    if let Ok(launchd_socket_fd) = get_launchd_socket_fd(libc::SOCK_STREAM) {
+        log::info!("create_inbound_tcp_socket, use launched socket for {}", bind_addr);
+        return Ok(unsafe { TcpSocket::from_raw_fd(launchd_socket_fd) });
     }
     match bind_addr {
         SocketAddr::V4(..) => TcpSocket::new_v4(),
@@ -412,6 +424,10 @@ pub async fn create_outbound_udp_socket(af: AddrFamily, config: &ConnectOpts) ->
 
 /// Create a `UdpSocket` binded to `bind_addr`
 pub async fn bind_outbound_udp_socket(bind_addr: &SocketAddr, config: &ConnectOpts) -> io::Result<UdpSocket> {
+    if let Ok(launchd_socket_fd) = get_launchd_socket_fd(libc::SOCK_DGRAM) {
+        log::info!("bind_outbound_udp_socket, use launched socket for {}", bind_addr);
+        return Ok(UdpSocket::from_std(unsafe { std::net::UdpSocket::from_raw_fd(launchd_socket_fd) })?);
+    }
     let af = AddrFamily::from(bind_addr);
 
     let socket = if af != AddrFamily::Ipv6 {


### PR DESCRIPTION
In macOS 10.10+, `launch_activate_socket` was introduced.
So whenever the port is requested, the `launchd` can launch the program dynamically. A possible plist may like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Debug</key>
	<true/>
	<key>EnablePressuredExit</key>
	<true/>
	<key>Label</key>
	<string>com.github.shadowsocks-rust</string>
        <key>ProgramArguments</key>
        <array>
                <string>/path/to/sslocal</string>
                <!-- -b can be ommited, as launchd takes over it -->
                <!-- other arguments -->
		<string>-c</string>
		<string>/path/to/config</string>
        </array>
        <key>Sockets</key>
        <dict>
                <!-- the name is hard coded in sslocal -->
                <key>Listeners</key>
                <dict>
                        <key>SockNodeName</key>
                        <string>0.0.0.0</string> <!-- or 127.0.0.1 -->
                        <key>SockServiceName</key>
                        <string>socks</string> <!-- port name (/etc/services) or port number -->
			<key>SockType</key>
			<string>stream</string> <!-- currently, only tcp is supported -->
                </dict>
        </dict>
	<key>StandardErrorPath</key>
	<string>/path/to/stderr</string>
	<key>StandardOutPath</key>
	<string>/path/to/stdout</string>
</dict>
</plist>
```

The magic is `launchd` will listen to the `SockServiceName`, when the port is requested, the `sslocal` will be launched.