### PR TITLE
debian: fixup changelog format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-shadosocks-rust (1.17.0) unstable; urgency=medium
+shadowsocks-rust (1.17.0) unstable; urgency=medium
 
   ## Features
 


### PR DESCRIPTION
debian build reports error:

```
dpkg-gencontrol: error: source package has two conflicting values - shadowsocks-rust and shadosocks-rustdh_gencontrol: error: dpkg-gencontrol -pshadowsocks-rust -ldebian/changelog -Tdebian/shadowsocks-rust.substvars -Pdebian/shadowsocks-rust returned exit code 255
```

we should use `dch -i` which is from devscripts to update changelog.