### PR TITLE
update shadowsocks-crypto to latest

### DIFF
--- a/crates/shadowsocks/Cargo.toml
+++ b/crates/shadowsocks/Cargo.toml
@@ -90,7 +90,7 @@ aes = { version = "0.8", optional = true }
 blake3 = "1.4"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-shadowsocks-crypto = { version = "0.5.2", features = ["ring"] }
+shadowsocks-crypto = { version = "0.5.4", features = ["ring"] }
 
 [target.'cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 shadowsocks-crypto = { version = "0.5.1", features = [] }

--- a/crates/shadowsocks/Cargo.toml
+++ b/crates/shadowsocks/Cargo.toml
@@ -93,7 +93,7 @@ blake3 = "1.4"
 shadowsocks-crypto = { version = "0.5.4", features = ["ring"] }
 
 [target.'cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
-shadowsocks-crypto = { version = "0.5.1", features = [] }
+shadowsocks-crypto = { version = "0.5.4", features = [] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = [


### PR DESCRIPTION
so that it doesn't rely on older version of ring-compat which adds ring 0.16 to graphs