### PR TITLE
set nonblocking for launch_activate_socket

### DIFF
--- a/crates/shadowsocks-service/src/sys/unix/macos.rs
+++ b/crates/shadowsocks-service/src/sys/unix/macos.rs
@@ -74,6 +74,8 @@ pub fn get_launch_activate_socket(name: &str) -> io::Result<RawFd> {
     } else {
         // Take fds[0] as the result
         let fd = unsafe { *fds };
+        let mut nonblocking = true as libc::c_int;
+        unsafe { libc::ioctl(fd, libc::FIONBIO, &mut nonblocking) };
         Ok(fd as RawFd)
     };
 


### PR DESCRIPTION
In https://github.com/shadowsocks/shadowsocks-rust/issues/1330 , shadowsocks-rust introduces `launch_activate_socket` for the request of https://github.com/shadowsocks/shadowsocks-rust/issues/1330 .
However, #1330 seems forget to set nonblocking as similiar pr in https://github.com/shadowsocks/shadowsocks-rust/pull/1331 .