### PR TITLE
feature: support fwmark in server side to split outbound tunnel

### DIFF
--- a/crates/shadowsocks-service/src/manager/server.rs
+++ b/crates/shadowsocks-service/src/manager/server.rs
@@ -408,6 +408,8 @@ impl Manager {
         let server_instance = ServerInstanceConfig {
             config: svr_cfg.clone(),
             acl: None, // Set with --acl command line argument
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            outbound_fwmark: None,
         };
 
         let mut config = Config::new(ConfigType::Server);

--- a/crates/shadowsocks-service/src/server/mod.rs
+++ b/crates/shadowsocks-service/src/server/mod.rs
@@ -111,6 +111,11 @@ pub async fn run(config: Config) -> io::Result<()> {
             server_builder.set_dns_resolver(r.clone());
         }
 
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if let Some(fwmark) = inst.outbound_fwmark {
+            connect_opts.fwmark = Some(fwmark);
+        }
+
         server_builder.set_connect_opts(connect_opts.clone());
         server_builder.set_accept_opts(accept_opts.clone());
 


### PR DESCRIPTION
The PR helps set `outbound_fwmark` in TCP connection options for different server configs.

With this feature, we do not need to start multiple server processes, to support different outbound tunnels. Now many websites forbid access from some VPS IPs. We may need to switch our proxy servers with special browser plugins, for example `OmegaSwitchy`.  

Another solution is to setup split-tunnels after the server, which is already supported by `V2Ray`. The server will choose the right tunnel based on the domain address. 

I think the `fwmark` is the best solution for distinguishing TCP data packages. In my case, I setup `wireguard` and route rules with `fwmark`, to route marked data packages to different servers. It works well. 

Why not `outbound_interface`? I ever had some problem for ipv6 interface binding. 