### PR TITLE
Fix per-server outbound options not taking effect (part 1)

### DIFF
--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -226,7 +226,7 @@ impl Server {
             }
 
             for server in config.server {
-                balancer_builder.add_server(server.config);
+                balancer_builder.add_server(server);
             }
 
             balancer_builder.build().await?

--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -991,10 +991,9 @@ fn launch_reload_server_task(config_path: PathBuf, balancer: PingBalancer) {
                 }
             };
 
-            let servers: Vec<ServerConfig> = config.server.into_iter().map(|s| s.config).collect();
-            info!("auto-reload {} with {} servers", config_path.display(), servers.len());
+            info!("auto-reload {} with {} servers", config_path.display(), config.server.len());
 
-            if let Err(err) = balancer.reset_servers(servers).await {
+            if let Err(err) = balancer.reset_servers(config.server).await {
                 error!("auto-reload {} but found error: {}", config_path.display(), err);
             }
         }


### PR DESCRIPTION
This is the first part of #1491.

Symptom: Assume the following config:

```
{
    "servers": [
        {
            "server": "192.0.2.1",
            "server_port": 8388,
            ...
            "outbound_fwmark": 1
        },
        {
            "server": "192.0.2.1",
            "server_port": 8388,
            ...
            "outbound_fwmark": 2
        }
    ]
}
```

The load balancer will ignore the fwmark field. We will see all outbound traffic does not set any fwmark.

Proposed fix:
1. PingBalancer now holds a ServerInstanceConfig which contains the correct information for outbound traffic.
2. The correct ConnectOpts is now built in the constructor of ServerIdent.
3. Now PingBalancer will get ConnectOpts from ServerIdent, instead of from context.