### PR TITLE
Fix: FreeBSD Building

### DIFF
--- a/crates/shadowsocks-service/src/local/redir/sys/unix/bsd_pf.rs
+++ b/crates/shadowsocks-service/src/local/redir/sys/unix/bsd_pf.rs
@@ -2,28 +2,39 @@
 
 use std::{
     io::{self, Error, ErrorKind},
-    mem,
     net::SocketAddr,
-    ptr,
 };
 
 use cfg_if::cfg_if;
-use log::trace;
 use nix::ioctl_readwrite;
 use once_cell::sync::Lazy;
-use socket2::{Protocol, SockAddr};
+use socket2::Protocol;
 
 use super::pfvar::{
-    in6_addr,
-    in_addr,
-    pf_addr,
     pfioc_natlook,
-    pfioc_states,
-    pfsync_state,
-    sockaddr_in,
-    sockaddr_in6,
-    PF_OUT,
+    pfioc_states
 };
+
+cfg_if! {
+    if #[cfg(not(target_os = "freebsd"))] {
+        use log::trace;
+
+        use super::pfvar::{
+            in6_addr,
+            in_addr,
+            pf_addr,
+            sockaddr_in,
+            sockaddr_in6,
+            PF_OUT,
+            pfsync_state
+        };
+        use std::{
+            ptr,
+            mem
+        };
+        use socket2::{Protocol, SockAddr};
+    }
+}
 
 ioctl_readwrite!(ioc_natlook, 'D', 23, pfioc_natlook);
 ioctl_readwrite!(ioc_getstates, 'D', 25, pfioc_states);
@@ -56,311 +67,318 @@ impl PacketFilter {
             Ok(PacketFilter { fd })
         }
     }
-
-    pub fn natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, proto: Protocol) -> io::Result<SocketAddr> {
-        match proto {
-            Protocol::TCP => self.tcp_natlook(bind_addr, peer_addr, proto),
-            Protocol::UDP => self.udp_natlook(bind_addr, peer_addr, proto),
-            _ => Err(io::ErrorKind::InvalidInput.into()),
-        }
-    }
-
-    fn tcp_natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, proto: Protocol) -> io::Result<SocketAddr> {
-        trace!("PF natlook peer: {}, bind: {}", peer_addr, bind_addr);
-
-        unsafe {
-            let mut pnl: pfioc_natlook = mem::zeroed();
-
-            match *bind_addr {
-                SocketAddr::V4(ref v4) => {
-                    pnl.af = libc::AF_INET as libc::sa_family_t;
-
-                    let sockaddr = SockAddr::from(*v4);
-                    let sockaddr = sockaddr.as_ptr() as *const sockaddr_in;
-
-                    let addr: *const in_addr = ptr::addr_of!((*sockaddr).sin_addr) as *const _;
-                    let port: libc::in_port_t = (*sockaddr).sin_port;
-
-                    ptr::write_unaligned::<in_addr>(ptr::addr_of_mut!(pnl.daddr.pfa) as *mut _, *addr);
-
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            pnl.dxport.port = port;
-                        } else {
-                            pnl.dport = port;
-                        }
-                    }
-                }
-                SocketAddr::V6(ref v6) => {
-                    pnl.af = libc::AF_INET6 as libc::sa_family_t;
-
-                    let sockaddr = SockAddr::from(*v6);
-                    let sockaddr = sockaddr.as_ptr() as *const sockaddr_in6;
-
-                    let addr: *const in6_addr = ptr::addr_of!((*sockaddr).sin6_addr) as *const _;
-                    let port: libc::in_port_t = (*sockaddr).sin6_port;
-
-                    ptr::write_unaligned::<in6_addr>(ptr::addr_of_mut!(pnl.daddr.pfa) as *mut _, *addr);
-
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            pnl.dxport.port = port;
-                        } else {
-                            pnl.dport = port;
-                        }
-                    }
+    cfg_if! {
+        if #[cfg(target_os = "freebsd")] {
+            pub fn natlook(&self, _bind_addr: &SocketAddr, _peer_addr: &SocketAddr, _proto: Protocol) -> io::Result<SocketAddr> {
+                Err(io::ErrorKind::InvalidInput.into())
+            }
+        } else {
+            pub fn natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, proto: Protocol) -> io::Result<SocketAddr> {
+                match proto {
+                    Protocol::TCP => self.tcp_natlook(bind_addr, peer_addr, proto),
+                    Protocol::UDP => self.udp_natlook(bind_addr, peer_addr, proto),
+                    _ => Err(io::ErrorKind::InvalidInput.into()),
                 }
             }
 
-            match *peer_addr {
-                SocketAddr::V4(ref v4) => {
-                    if pnl.af != libc::AF_INET as libc::sa_family_t {
-                        return Err(Error::new(ErrorKind::InvalidInput, "client addr must be ipv4"));
-                    }
+            fn tcp_natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, proto: Protocol) -> io::Result<SocketAddr> {
+                trace!("PF natlook peer: {}, bind: {}", peer_addr, bind_addr);
 
-                    let sockaddr = SockAddr::from(*v4);
-                    let sockaddr = sockaddr.as_ptr() as *const sockaddr_in;
+                unsafe {
+                    let mut pnl: pfioc_natlook = mem::zeroed();
 
-                    let addr: *const in_addr = ptr::addr_of!((*sockaddr).sin_addr) as *const _;
-                    let port: libc::in_port_t = (*sockaddr).sin_port;
+                    match *bind_addr {
+                        SocketAddr::V4(ref v4) => {
+                            pnl.af = libc::AF_INET as libc::sa_family_t;
 
-                    ptr::write_unaligned::<in_addr>(ptr::addr_of_mut!(pnl.saddr.pfa) as *mut _, *addr);
+                            let sockaddr = SockAddr::from(*v4);
+                            let sockaddr = sockaddr.as_ptr() as *const sockaddr_in;
 
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            pnl.sxport.port = port;
-                        } else {
-                            pnl.sport = port;
-                        }
-                    }
-                }
-                SocketAddr::V6(ref v6) => {
-                    if pnl.af != libc::AF_INET6 as libc::sa_family_t {
-                        return Err(Error::new(ErrorKind::InvalidInput, "client addr must be ipv6"));
-                    }
+                            let addr: *const in_addr = ptr::addr_of!((*sockaddr).sin_addr) as *const _;
+                            let port: libc::in_port_t = (*sockaddr).sin_port;
 
-                    let sockaddr = SockAddr::from(*v6);
-                    let sockaddr = sockaddr.as_ptr() as *const sockaddr_in6;
+                            ptr::write_unaligned::<in_addr>(ptr::addr_of_mut!(pnl.daddr.pfa) as *mut _, *addr);
 
-                    let addr: *const in6_addr = ptr::addr_of!((*sockaddr).sin6_addr) as *const _;
-                    let port: libc::in_port_t = (*sockaddr).sin6_port;
-
-                    ptr::write_unaligned::<in6_addr>(ptr::addr_of_mut!(pnl.saddr.pfa) as *mut _, *addr);
-
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            pnl.sxport.port = port;
-                        } else {
-                            pnl.sport = port;
-                        }
-                    }
-                }
-            }
-
-            pnl.proto = i32::from(proto) as u8;
-            pnl.direction = PF_OUT as u8;
-
-            if let Err(err) = ioc_natlook(self.fd, &mut pnl) {
-                return Err(Error::from_raw_os_error(err as i32));
-            }
-
-            let (_, dst_addr) = SockAddr::try_init(|dst_addr, addr_len| {
-                if pnl.af == libc::AF_INET as libc::sa_family_t {
-                    let dst_addr: &mut sockaddr_in = &mut *(dst_addr as *mut _);
-                    dst_addr.sin_family = pnl.af;
-
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            dst_addr.sin_port = pnl.rdxport.port;
-                        } else {
-                            dst_addr.sin_port = pnl.rdport;
-                        }
-                    }
-
-                    ptr::write_unaligned::<in_addr>(
-                        ptr::addr_of_mut!(dst_addr.sin_addr),
-                        ptr::read::<in_addr>(ptr::addr_of!(pnl.rdaddr.pfa) as *const _),
-                    );
-                    *addr_len = mem::size_of_val(&dst_addr.sin_addr) as libc::socklen_t;
-                } else if pnl.af == libc::AF_INET6 as libc::sa_family_t {
-                    let dst_addr: &mut sockaddr_in6 = &mut *(dst_addr as *mut _);
-                    dst_addr.sin6_family = pnl.af;
-
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            dst_addr.sin6_port = pnl.rdxport.port;
-                        } else {
-                            dst_addr.sin6_port = pnl.rdport;
-                        }
-                    }
-
-                    ptr::write_unaligned::<in6_addr>(
-                        ptr::addr_of_mut!(dst_addr.sin6_addr),
-                        ptr::read::<in6_addr>(ptr::addr_of!(pnl.rdaddr.pfa) as *const _),
-                    );
-                    *addr_len = mem::size_of_val(&dst_addr.sin6_addr) as libc::socklen_t;
-                } else {
-                    unreachable!("sockaddr should be either ipv4 or ipv6");
-                }
-
-                Ok(())
-            })?;
-
-            Ok(dst_addr.as_socket().expect("SocketAddr"))
-        }
-    }
-
-    fn udp_natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, _proto: Protocol) -> io::Result<SocketAddr> {
-        unsafe {
-            // Get all states
-            // https://man.freebsd.org/cgi/man.cgi?query=pf&sektion=4&manpath=OpenBSD
-            // DIOCGETSTATES
-
-            let mut states: pfioc_states = mem::zeroed();
-            let mut states_buffer = vec![0u8; 8192];
-
-            loop {
-                states.ps_len = states_buffer.len() as _;
-                states.ps_u.psu_buf = states_buffer.as_mut_ptr() as *mut _;
-
-                if let Err(err) = ioc_getstates(self.fd, &mut states) {
-                    return Err(Error::from_raw_os_error(err as i32));
-                }
-
-                if states.ps_len as usize <= states_buffer.len() {
-                    break;
-                }
-
-                // Resize to fit all states
-                // > On exit, ps_len is always set to the total size re-
-                // > quired to hold all state table entries
-                states_buffer.resize(states.ps_len as usize, 0);
-            }
-
-            let bind_addr_sockaddr = SockAddr::from(*bind_addr);
-            let peer_addr_sockaddr = SockAddr::from(*peer_addr);
-
-            let mut bind_addr_pfaddr: pf_addr = mem::zeroed();
-            let mut peer_addr_pfaddr: pf_addr = mem::zeroed();
-
-            match bind_addr_sockaddr.family() as libc::c_int {
-                libc::AF_INET => {
-                    let sockaddr: *const sockaddr_in = bind_addr_sockaddr.as_ptr() as *const _;
-                    ptr::write_unaligned::<in_addr>(
-                        ptr::addr_of_mut!(bind_addr_pfaddr.pfa) as *mut _,
-                        (*sockaddr).sin_addr,
-                    );
-                }
-                libc::AF_INET6 => {
-                    let sockaddr: *const sockaddr_in6 = bind_addr_sockaddr.as_ptr() as *const _;
-                    ptr::write_unaligned::<in6_addr>(
-                        ptr::addr_of_mut!(bind_addr_pfaddr.pfa) as *mut _,
-                        (*sockaddr).sin6_addr,
-                    );
-                }
-                _ => unreachable!("bind_addr family = {}", bind_addr_sockaddr.family()),
-            }
-
-            match peer_addr_sockaddr.family() as libc::c_int {
-                libc::AF_INET => {
-                    let sockaddr: *const sockaddr_in = peer_addr_sockaddr.as_ptr() as *const _;
-                    ptr::write_unaligned::<in_addr>(
-                        ptr::addr_of_mut!(peer_addr_pfaddr.pfa) as *mut _,
-                        (*sockaddr).sin_addr,
-                    );
-                }
-                libc::AF_INET6 => {
-                    let sockaddr: *const sockaddr_in6 = peer_addr_sockaddr.as_ptr() as *const _;
-                    ptr::write_unaligned::<in6_addr>(
-                        ptr::addr_of_mut!(peer_addr_pfaddr.pfa) as *mut _,
-                        (*sockaddr).sin6_addr,
-                    );
-                }
-                _ => unreachable!("peer_addr family = {}", peer_addr_sockaddr.family()),
-            }
-
-            let states_count = states.ps_len as usize / mem::size_of::<pfsync_state>();
-            for i in 0..states_count {
-                let state = &*(states.ps_u.psu_states.add(i));
-
-                if state.proto == libc::IPPROTO_UDP as u8 {
-                    cfg_if! {
-                        if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-                            let dst_port = state.lan.xport.port;
-                            let src_port = state.ext_gwy.xport.port;
-                            let actual_dst_port = state.gwy.xport.port;
-                        } else {
-                            let dst_port = state.lan.port;
-                            let src_port = state.ext_gwy.port;
-                            let actual_dst_port = state.gwy.port;
-                        }
-                    }
-
-                    let dst_addr_eq = libc::memcmp(
-                        &bind_addr_pfaddr as *const _ as *const _,
-                        ptr::addr_of!(state.lan.addr.pfa) as *const _,
-                        mem::size_of::<pf_addr>(),
-                    ) == 0;
-                    let src_addr_eq = libc::memcmp(
-                        &peer_addr_pfaddr as *const _ as *const _,
-                        ptr::addr_of!(state.ext_gwy.addr.pfa) as *const _,
-                        mem::size_of::<pf_addr>(),
-                    ) == 0;
-
-                    if src_addr_eq && src_port == peer_addr.port() && dst_addr_eq && dst_port == bind_addr.port() {
-                        let actual_dst_addr = match state.af_gwy as libc::c_int {
-                            libc::AF_INET => {
-                                let (_, actual_dst_addr) = SockAddr::try_init(|sockaddr, len| {
-                                    let addr = &mut *(sockaddr as *mut sockaddr_in);
-                                    addr.sin_family = libc::AF_INET as libc::sa_family_t;
-                                    ptr::write_unaligned::<in_addr>(
-                                        ptr::addr_of_mut!(addr.sin_addr),
-                                        ptr::read_unaligned::<in_addr>(ptr::addr_of!(state.gwy.addr.pfa) as *const _),
-                                    );
-                                    addr.sin_port = actual_dst_port as libc::in_port_t;
-
-                                    ptr::write(len, mem::size_of::<sockaddr_in>() as libc::socklen_t);
-                                    Ok(())
-                                })
-                                .unwrap();
-
-                                actual_dst_addr
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    pnl.dxport.port = port;
+                                } else {
+                                    pnl.dport = port;
+                                }
                             }
-                            libc::AF_INET6 => {
-                                let (_, actual_dst_addr) = SockAddr::try_init(|sockaddr, len| {
-                                    let addr = &mut *(sockaddr as *mut sockaddr_in6);
-                                    addr.sin6_family = libc::AF_INET6 as libc::sa_family_t;
-                                    ptr::write_unaligned::<in6_addr>(
-                                        ptr::addr_of_mut!(addr.sin6_addr),
-                                        ptr::read_unaligned::<in6_addr>(ptr::addr_of!(state.gwy.addr.pfa) as *const _),
-                                    );
-                                    addr.sin6_port = actual_dst_port as libc::in_port_t;
+                        }
+                        SocketAddr::V6(ref v6) => {
+                            pnl.af = libc::AF_INET6 as libc::sa_family_t;
 
-                                    ptr::write(len, mem::size_of::<sockaddr_in6>() as libc::socklen_t);
-                                    Ok(())
-                                })
-                                .unwrap();
+                            let sockaddr = SockAddr::from(*v6);
+                            let sockaddr = sockaddr.as_ptr() as *const sockaddr_in6;
 
-                                actual_dst_addr
+                            let addr: *const in6_addr = ptr::addr_of!((*sockaddr).sin6_addr) as *const _;
+                            let port: libc::in_port_t = (*sockaddr).sin6_port;
+
+                            ptr::write_unaligned::<in6_addr>(ptr::addr_of_mut!(pnl.daddr.pfa) as *mut _, *addr);
+
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    pnl.dxport.port = port;
+                                } else {
+                                    pnl.dport = port;
+                                }
                             }
-                            _ => {
-                                return Err(io::Error::new(
-                                    ErrorKind::Other,
-                                    format!("state.af_gwy {} is not a valid address family", state.af_gwy),
-                                ));
-                            }
-                        };
-
-                        return Ok(actual_dst_addr.as_socket().expect("SocketAddr"));
+                        }
                     }
+
+                    match *peer_addr {
+                        SocketAddr::V4(ref v4) => {
+                            if pnl.af != libc::AF_INET as libc::sa_family_t {
+                                return Err(Error::new(ErrorKind::InvalidInput, "client addr must be ipv4"));
+                            }
+
+                            let sockaddr = SockAddr::from(*v4);
+                            let sockaddr = sockaddr.as_ptr() as *const sockaddr_in;
+
+                            let addr: *const in_addr = ptr::addr_of!((*sockaddr).sin_addr) as *const _;
+                            let port: libc::in_port_t = (*sockaddr).sin_port;
+
+                            ptr::write_unaligned::<in_addr>(ptr::addr_of_mut!(pnl.saddr.pfa) as *mut _, *addr);
+
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    pnl.sxport.port = port;
+                                } else {
+                                    pnl.sport = port;
+                                }
+                            }
+                        }
+                        SocketAddr::V6(ref v6) => {
+                            if pnl.af != libc::AF_INET6 as libc::sa_family_t {
+                                return Err(Error::new(ErrorKind::InvalidInput, "client addr must be ipv6"));
+                            }
+
+                            let sockaddr = SockAddr::from(*v6);
+                            let sockaddr = sockaddr.as_ptr() as *const sockaddr_in6;
+
+                            let addr: *const in6_addr = ptr::addr_of!((*sockaddr).sin6_addr) as *const _;
+                            let port: libc::in_port_t = (*sockaddr).sin6_port;
+
+                            ptr::write_unaligned::<in6_addr>(ptr::addr_of_mut!(pnl.saddr.pfa) as *mut _, *addr);
+
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    pnl.sxport.port = port;
+                                } else {
+                                    pnl.sport = port;
+                                }
+                            }
+                        }
+                    }
+
+                    pnl.proto = i32::from(proto) as u8;
+                    pnl.direction = PF_OUT as u8;
+
+                    if let Err(err) = ioc_natlook(self.fd, &mut pnl) {
+                        return Err(Error::from_raw_os_error(err as i32));
+                    }
+
+                    let (_, dst_addr) = SockAddr::try_init(|dst_addr, addr_len| {
+                        if pnl.af == libc::AF_INET as libc::sa_family_t {
+                            let dst_addr: &mut sockaddr_in = &mut *(dst_addr as *mut _);
+                            dst_addr.sin_family = pnl.af;
+
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    dst_addr.sin_port = pnl.rdxport.port;
+                                } else {
+                                    dst_addr.sin_port = pnl.rdport;
+                                }
+                            }
+
+                            ptr::write_unaligned::<in_addr>(
+                                ptr::addr_of_mut!(dst_addr.sin_addr),
+                                ptr::read::<in_addr>(ptr::addr_of!(pnl.rdaddr.pfa) as *const _),
+                            );
+                            *addr_len = mem::size_of_val(&dst_addr.sin_addr) as libc::socklen_t;
+                        } else if pnl.af == libc::AF_INET6 as libc::sa_family_t {
+                            let dst_addr: &mut sockaddr_in6 = &mut *(dst_addr as *mut _);
+                            dst_addr.sin6_family = pnl.af;
+
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    dst_addr.sin6_port = pnl.rdxport.port;
+                                } else {
+                                    dst_addr.sin6_port = pnl.rdport;
+                                }
+                            }
+
+                            ptr::write_unaligned::<in6_addr>(
+                                ptr::addr_of_mut!(dst_addr.sin6_addr),
+                                ptr::read::<in6_addr>(ptr::addr_of!(pnl.rdaddr.pfa) as *const _),
+                            );
+                            *addr_len = mem::size_of_val(&dst_addr.sin6_addr) as libc::socklen_t;
+                        } else {
+                            unreachable!("sockaddr should be either ipv4 or ipv6");
+                        }
+
+                        Ok(())
+                    })?;
+
+                    Ok(dst_addr.as_socket().expect("SocketAddr"))
                 }
             }
-        }
 
-        Err(io::Error::new(
-            ErrorKind::Other,
-            format!("natlook UDP binding {}, {} not found", bind_addr, peer_addr),
-        ))
+            fn udp_natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, _proto: Protocol) -> io::Result<SocketAddr> {
+                unsafe {
+                    // Get all states
+                    // https://man.freebsd.org/cgi/man.cgi?query=pf&sektion=4&manpath=OpenBSD
+                    // DIOCGETSTATES
+
+                    let mut states: pfioc_states = mem::zeroed();
+                    let mut states_buffer = vec![0u8; 8192];
+
+                    loop {
+                        states.ps_len = states_buffer.len() as _;
+                        states.ps_u.psu_buf = states_buffer.as_mut_ptr() as *mut _;
+
+                        if let Err(err) = ioc_getstates(self.fd, &mut states) {
+                            return Err(Error::from_raw_os_error(err as i32));
+                        }
+
+                        if states.ps_len as usize <= states_buffer.len() {
+                            break;
+                        }
+
+                        // Resize to fit all states
+                        // > On exit, ps_len is always set to the total size re-
+                        // > quired to hold all state table entries
+                        states_buffer.resize(states.ps_len as usize, 0);
+                    }
+
+                    let bind_addr_sockaddr = SockAddr::from(*bind_addr);
+                    let peer_addr_sockaddr = SockAddr::from(*peer_addr);
+
+                    let mut bind_addr_pfaddr: pf_addr = mem::zeroed();
+                    let mut peer_addr_pfaddr: pf_addr = mem::zeroed();
+
+                    match bind_addr_sockaddr.family() as libc::c_int {
+                        libc::AF_INET => {
+                            let sockaddr: *const sockaddr_in = bind_addr_sockaddr.as_ptr() as *const _;
+                            ptr::write_unaligned::<in_addr>(
+                                ptr::addr_of_mut!(bind_addr_pfaddr.pfa) as *mut _,
+                                (*sockaddr).sin_addr,
+                            );
+                        }
+                        libc::AF_INET6 => {
+                            let sockaddr: *const sockaddr_in6 = bind_addr_sockaddr.as_ptr() as *const _;
+                            ptr::write_unaligned::<in6_addr>(
+                                ptr::addr_of_mut!(bind_addr_pfaddr.pfa) as *mut _,
+                                (*sockaddr).sin6_addr,
+                            );
+                        }
+                        _ => unreachable!("bind_addr family = {}", bind_addr_sockaddr.family()),
+                    }
+
+                    match peer_addr_sockaddr.family() as libc::c_int {
+                        libc::AF_INET => {
+                            let sockaddr: *const sockaddr_in = peer_addr_sockaddr.as_ptr() as *const _;
+                            ptr::write_unaligned::<in_addr>(
+                                ptr::addr_of_mut!(peer_addr_pfaddr.pfa) as *mut _,
+                                (*sockaddr).sin_addr,
+                            );
+                        }
+                        libc::AF_INET6 => {
+                            let sockaddr: *const sockaddr_in6 = peer_addr_sockaddr.as_ptr() as *const _;
+                            ptr::write_unaligned::<in6_addr>(
+                                ptr::addr_of_mut!(peer_addr_pfaddr.pfa) as *mut _,
+                                (*sockaddr).sin6_addr,
+                            );
+                        }
+                        _ => unreachable!("peer_addr family = {}", peer_addr_sockaddr.family()),
+                    }
+
+                    let states_count = states.ps_len as usize / mem::size_of::<pfsync_state>();
+                    for i in 0..states_count {
+                        let state = &*(states.ps_u.psu_states.add(i));
+
+                        if state.proto == libc::IPPROTO_UDP as u8 {
+                            cfg_if! {
+                                if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+                                    let dst_port = state.lan.xport.port;
+                                    let src_port = state.ext_gwy.xport.port;
+                                    let actual_dst_port = state.gwy.xport.port;
+                                } else {
+                                    let dst_port = state.lan.port;
+                                    let src_port = state.ext_gwy.port;
+                                    let actual_dst_port = state.gwy.port;
+                                }
+                            }
+
+                            let dst_addr_eq = libc::memcmp(
+                                &bind_addr_pfaddr as *const _ as *const _,
+                                ptr::addr_of!(state.lan.addr.pfa) as *const _,
+                                mem::size_of::<pf_addr>(),
+                            ) == 0;
+                            let src_addr_eq = libc::memcmp(
+                                &peer_addr_pfaddr as *const _ as *const _,
+                                ptr::addr_of!(state.ext_gwy.addr.pfa) as *const _,
+                                mem::size_of::<pf_addr>(),
+                            ) == 0;
+
+                            if src_addr_eq && src_port == peer_addr.port() && dst_addr_eq && dst_port == bind_addr.port() {
+                                let actual_dst_addr = match state.af_gwy as libc::c_int {
+                                    libc::AF_INET => {
+                                        let (_, actual_dst_addr) = SockAddr::try_init(|sockaddr, len| {
+                                            let addr = &mut *(sockaddr as *mut sockaddr_in);
+                                            addr.sin_family = libc::AF_INET as libc::sa_family_t;
+                                            ptr::write_unaligned::<in_addr>(
+                                                ptr::addr_of_mut!(addr.sin_addr),
+                                                ptr::read_unaligned::<in_addr>(ptr::addr_of!(state.gwy.addr.pfa) as *const _),
+                                            );
+                                            addr.sin_port = actual_dst_port as libc::in_port_t;
+
+                                            ptr::write(len, mem::size_of::<sockaddr_in>() as libc::socklen_t);
+                                            Ok(())
+                                        })
+                                        .unwrap();
+
+                                        actual_dst_addr
+                                    }
+                                    libc::AF_INET6 => {
+                                        let (_, actual_dst_addr) = SockAddr::try_init(|sockaddr, len| {
+                                            let addr = &mut *(sockaddr as *mut sockaddr_in6);
+                                            addr.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+                                            ptr::write_unaligned::<in6_addr>(
+                                                ptr::addr_of_mut!(addr.sin6_addr),
+                                                ptr::read_unaligned::<in6_addr>(ptr::addr_of!(state.gwy.addr.pfa) as *const _),
+                                            );
+                                            addr.sin6_port = actual_dst_port as libc::in_port_t;
+
+                                            ptr::write(len, mem::size_of::<sockaddr_in6>() as libc::socklen_t);
+                                            Ok(())
+                                        })
+                                        .unwrap();
+
+                                        actual_dst_addr
+                                    }
+                                    _ => {
+                                        return Err(io::Error::new(
+                                            ErrorKind::Other,
+                                            format!("state.af_gwy {} is not a valid address family", state.af_gwy),
+                                        ));
+                                    }
+                                };
+
+                                return Ok(actual_dst_addr.as_socket().expect("SocketAddr"));
+                            }
+                        }
+                    }
+                }
+
+                Err(io::Error::new(
+                    ErrorKind::Other,
+                    format!("natlook UDP binding {}, {} not found", bind_addr, peer_addr),
+                ))
+            }
+        }
     }
 }
 

--- a/crates/shadowsocks-service/src/local/redir/sys/unix/bsd_pf.rs
+++ b/crates/shadowsocks-service/src/local/redir/sys/unix/bsd_pf.rs
@@ -233,13 +233,6 @@ impl PacketFilter {
     cfg_if! {
         if #[cfg(not(target_os = "freebsd"))] {
             fn udp_natlook(&self, bind_addr: &SocketAddr, peer_addr: &SocketAddr, _proto: Protocol) -> io::Result<SocketAddr> {
-                match recv_dest_from(self.io.get_ref(), buf) {
-                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                        read_guard.clear_ready();
-                    }
-                    x => return Poll::Ready(x),
-                }
-
                 unsafe {
                     // Get all states
                     // https://man.freebsd.org/cgi/man.cgi?query=pf&sektion=4&manpath=OpenBSD

--- a/crates/shadowsocks-service/src/local/redir/sys/unix/pfvar_bindgen_freebsd.rs
+++ b/crates/shadowsocks-service/src/local/redir/sys/unix/pfvar_bindgen_freebsd.rs
@@ -11945,7 +11945,7 @@ fn bindgen_test_layout_pf_status() {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct pf_addr {
-    pub __bindgen_anon_1: pf_addr__bindgen_ty_1,
+    pub pfa: pf_addr__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This pull request will fix this building errors on FreeBSD 14:
```
$> cargo build --features local-redir,local-socks4

Compiling shadowsocks-service v1.18.5 (shadowsocks-rust/crates/shadowsocks-service)
error[E0432]: unresolved import `super::pfvar::pfsync_state`
  --> crates/shadowsocks-service/src/local/redir/sys/unix/bsd_pf.rs:22:5
   |
22 |     pfsync_state,
   |     ^^^^^^^^^^^^
   |     |
   |     no `pfsync_state` in `local::redir::sys::unix::pfvar`
   |     help: a similar name exists in the module: `pfioc_state`

error[E0405]: cannot find trait `UdpSocketRedir` in this scope
   --> crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/bsd.rs:147:6
    |
147 | impl UdpSocketRedir for UdpRedirSocket {
    |      ^^^^^^^^^^^^^^
    |
   ::: crates/shadowsocks-service/src/local/redir/redir_ext.rs:49:1
    |
49  | pub trait UdpSocketRedirExt {
    | --------------------------- similarly named trait `UdpSocketRedirExt` defined here
    |
help: a trait with a similar name exists
    |
147 | impl UdpSocketRedirExt for UdpRedirSocket {
    |      ~~~~~~~~~~~~~~~~~
help: consider importing this trait
    |
1   + use crate::local::redir::redir_ext::UdpSocketRedir;
    |

error[E0425]: cannot find value `enable` in this scope
   --> crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/bsd.rs:287:14
    |
287 |             &enable as *const _ as *const _,
    |              ^^^^^^ not found in this scope

error[E0425]: cannot find value `enable` in this scope
   --> crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/bsd.rs:288:31
    |
288 |             mem::size_of_val(&enable) as libc::socklen_t,
    |                               ^^^^^^ not found in this scope

warning: unused import: `async_trait::async_trait`
  --> crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/bsd.rs:10:5
   |
10 | use async_trait::async_trait;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `UdpSocketRedirExt`
  --> crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/bsd.rs:21:38
   |
21 |         redir_ext::{RedirSocketOpts, UdpSocketRedirExt},
   |                                      ^^^^^^^^^^^^^^^^^

error[E0599]: the method `recv_dest_from` exists for struct `UdpRedirSocket`, but its trait bounds were not satisfied
   --> crates/shadowsocks-service/src/local/redir/udprelay/mod.rs:294:45
    |
294 |                 recv_result = self.listener.recv_dest_from(&mut pkt_buf) => {
    |                                             ^^^^^^^^^^^^^^ method cannot be called on `UdpRedirSocket` due to unsatisfied trait bounds
    |
   ::: crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/bsd.rs:30:1
    |
30  | pub struct UdpRedirSocket {
    | ------------------------- method `recv_dest_from` not found for this struct because it doesn't satisfy `_: UdpSocketRedirExt` or `_: UdpSocketRedir`
    |
note: trait bound `redir::udprelay::sys::unix::bsd::UdpRedirSocket: UdpSocketRedir` was not satisfied
   --> crates/shadowsocks-service/src/local/redir/redir_ext.rs:58:42
    |
58  | impl<S> UdpSocketRedirExt for S where S: UdpSocketRedir {}
    |         -----------------     -          ^^^^^^^^^^^^^^ unsatisfied trait bound introduced here
note: the trait `UdpSocketRedir` must be implemented
   --> crates/shadowsocks-service/src/local/redir/redir_ext.rs:35:1
    |
35  | pub trait UdpSocketRedir {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
note: `UdpSocketRedirExt` defines an item `recv_dest_from`, perhaps you need to implement it
   --> crates/shadowsocks-service/src/local/redir/redir_ext.rs:49:1
    |
49  | pub trait UdpSocketRedirExt {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0405, E0425, E0432, E0599.
For more information about an error, try `rustc --explain E0405`.
warning: `shadowsocks-service` (lib) generated 2 warnings
error: could not compile `shadowsocks-service` (lib) due to 5 previous errors; 2 warnings emitted
```