### PR TITLE
[snap] Add aliases for all the non-daemon apps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,7 @@ apps:
   sslocal:
     command: bin/sslocal
     plugs: [network, network-bind, network-control, home]
+    aliases: [sslocal]
 
   sslocal-daemon:
     command: bin/sslocal
@@ -30,6 +31,7 @@ apps:
   ssserver:
     command: bin/ssserver
     plugs: [network, network-bind, home]
+    aliases: [ssserver]
 
   ssserver-daemon:
     command: bin/ssserver
@@ -39,10 +41,12 @@ apps:
 
   ssurl:
     command: bin/ssurl
+    aliases: [ssurl]
 
   ssmanager:
     command: bin/ssmanager
     plugs: [network, home]
+    aliases: [ssmanager]
 
 passthrough:
   layout:


### PR DESCRIPTION
This way we can call the applications without having to use the snap name before it's name. Eg: now: `shadowsocks-rust.sslocal` after applying `sslocal`