### PR TITLE
fix(net) losing the raw file descriptor may leak resources

### DIFF
--- a/crates/shadowsocks/src/net/sys/mod.rs
+++ b/crates/shadowsocks/src/net/sys/mod.rs
@@ -68,7 +68,7 @@ where
 
     let sock = unsafe { Socket::from_raw_fd(fd) };
     let result = socket_bind_dual_stack_inner(&sock, addr, ipv6_only);
-    sock.into_raw_fd();
+    let _ = sock.into_raw_fd();
 
     result
 }


### PR DESCRIPTION
```
warning: unused return value of `into_raw_fd` that must be used
  --> crates/shadowsocks/src/net/sys/mod.rs:71:5
   |
71 |     sock.into_raw_fd();
   |     ^^^^^^^^^^^^^^^^^^
   |
   = note: losing the raw file descriptor may leak resources
   = note: `#[warn(unused_must_use)]` on by default
```