### PR TITLE
feat(shadowsocks): add more Debug implementations

### DIFF
--- a/crates/shadowsocks/src/context.rs
+++ b/crates/shadowsocks/src/context.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 /// Service context
+#[derive(Debug)]
 pub struct Context {
     // Protector against replay attack
     // The actual replay detection behavior is implemented in ReplayProtector

--- a/crates/shadowsocks/src/dns_resolver/resolver.rs
+++ b/crates/shadowsocks/src/dns_resolver/resolver.rs
@@ -38,6 +38,7 @@ pub trait DnsResolve {
 }
 
 #[cfg(feature = "hickory-dns")]
+#[derive(Debug)]
 pub struct HickoryDnsSystemResolver {
     resolver: ArcSwap<HickoryDnsResolver>,
     #[cfg_attr(any(windows, target_os = "android"), allow(dead_code))]

--- a/crates/shadowsocks/src/manager/datagram.rs
+++ b/crates/shadowsocks/src/manager/datagram.rs
@@ -46,6 +46,7 @@ impl fmt::Display for ManagerSocketAddr {
 /// Datagram socket for manager
 ///
 /// For *nix system, this is a wrapper for both UDP socket and Unix socket
+#[derive(Debug)]
 pub enum ManagerDatagram {
     UdpDatagram(UdpSocket),
     #[cfg(unix)]

--- a/crates/shadowsocks/src/manager/listener.rs
+++ b/crates/shadowsocks/src/manager/listener.rs
@@ -13,6 +13,7 @@ use super::{
 };
 
 /// Manager server Listener
+#[derive(Debug)]
 pub struct ManagerListener {
     socket: ManagerDatagram,
 }

--- a/crates/shadowsocks/src/net/tcp.rs
+++ b/crates/shadowsocks/src/net/tcp.rs
@@ -121,6 +121,7 @@ impl AsyncWrite for TcpStream {
 }
 
 /// `TcpListener` for accepting inbound connections
+#[derive(Debug)]
 pub struct TcpListener {
     inner: TokioTcpListener,
     accept_opts: AcceptOpts,

--- a/crates/shadowsocks/src/net/udp.rs
+++ b/crates/shadowsocks/src/net/udp.rs
@@ -85,6 +85,7 @@ fn make_mtu_error(packet_size: usize, mtu: usize) -> io::Error {
 }
 
 /// Wrappers for outbound `UdpSocket`
+#[derive(Debug)]
 #[pin_project]
 pub struct UdpSocket {
     #[pin]

--- a/crates/shadowsocks/src/plugin/mod.rs
+++ b/crates/shadowsocks/src/plugin/mod.rs
@@ -58,6 +58,7 @@ pub enum PluginMode {
 }
 
 /// A shadowsocks SIP004 Plugin
+#[derive(Debug)]
 pub struct Plugin {
     process: Child,
     local_addr: SocketAddr,

--- a/crates/shadowsocks/src/relay/tcprelay/aead.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/aead.rs
@@ -80,6 +80,7 @@ impl From<ProtocolError> for io::Error {
     }
 }
 
+#[derive(Debug)]
 enum DecryptReadState {
     WaitSalt { key: Bytes },
     ReadLength,
@@ -320,6 +321,7 @@ impl DecryptedReader {
     }
 }
 
+#[derive(Debug)]
 enum EncryptWriteState {
     AssemblePacket,
     Writing { pos: usize },

--- a/crates/shadowsocks/src/relay/tcprelay/crypto_io.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/crypto_io.rs
@@ -1,7 +1,7 @@
 //! IO facilities for TCP relay
 
 use std::{
-    io,
+    fmt, io,
     marker::Unpin,
     pin::Pin,
     sync::Arc,
@@ -311,6 +311,15 @@ pub struct CryptoStream<S> {
     enc: EncryptedWriter,
     method: CipherKind,
     has_handshaked: bool,
+}
+
+impl<S> fmt::Debug for CryptoStream<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CryptoStream")
+            .field("method", &self.method)
+            .field("has_handshaked", &self.has_handshaked)
+            .finish()
+    }
 }
 
 impl<S> CryptoStream<S> {

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_listener.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_listener.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 /// A TCP listener for accepting shadowsocks' client connection
+#[derive(Debug)]
 pub struct ProxyListener {
     listener: TcpListener,
     method: CipherKind,

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/client.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/client.rs
@@ -30,12 +30,14 @@ use crate::{
     },
 };
 
+#[derive(Debug)]
 enum ProxyClientStreamWriteState {
     Connect(Address),
     Connecting(BytesMut),
     Connected,
 }
 
+#[derive(Debug)]
 enum ProxyClientStreamReadState {
     #[cfg(feature = "aead-cipher-2022")]
     CheckRequestNonce,
@@ -43,6 +45,7 @@ enum ProxyClientStreamReadState {
 }
 
 /// A stream for sending / receiving data stream from remote server via shadowsocks' proxy server
+#[derive(Debug)]
 #[pin_project]
 pub struct ProxyClientStream<S> {
     #[pin]

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/mod.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/mod.rs
@@ -18,6 +18,7 @@ pub mod v1;
 #[cfg(feature = "aead-cipher-2022")]
 pub mod v2;
 
+#[derive(Debug)]
 pub enum TcpRequestHeader {
     Stream(StreamTcpRequestHeader),
     #[cfg(feature = "aead-cipher-2022")]
@@ -74,6 +75,7 @@ impl TcpRequestHeader {
     }
 }
 
+#[derive(Debug)]
 pub enum TcpRequestHeaderRef<'a> {
     Stream(StreamTcpRequestHeaderRef<'a>),
     #[cfg(feature = "aead-cipher-2022")]

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v1.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v1.rs
@@ -7,6 +7,7 @@ use tokio::io::AsyncRead;
 
 use crate::relay::socks5::Address;
 
+#[derive(Debug)]
 pub struct StreamTcpRequestHeader {
     pub addr: Address,
 }
@@ -27,6 +28,7 @@ impl StreamTcpRequestHeader {
     }
 }
 
+#[derive(Debug)]
 pub struct StreamTcpRequestHeaderRef<'a> {
     pub addr: &'a Address,
 }

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v2.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v2.rs
@@ -66,6 +66,7 @@ impl Aead2022TcpRequestHeader {
     }
 }
 
+#[derive(Debug)]
 pub struct Aead2022TcpRequestHeaderRef<'a> {
     pub addr: &'a Address,
     pub padding_size: u16,

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/server.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/server.rs
@@ -25,6 +25,7 @@ use crate::{
     },
 };
 
+#[derive(Debug)]
 enum ProxyServerStreamWriteState {
     #[cfg(feature = "aead-cipher-2022")]
     PrepareHeader(Option<std::task::Waker>),
@@ -32,6 +33,7 @@ enum ProxyServerStreamWriteState {
 }
 
 /// A stream for communicating with shadowsocks' proxy client
+#[derive(Debug)]
 #[pin_project]
 pub struct ProxyServerStream<S> {
     #[pin]

--- a/crates/shadowsocks/src/relay/udprelay/proxy_socket.rs
+++ b/crates/shadowsocks/src/relay/udprelay/proxy_socket.rs
@@ -69,6 +69,7 @@ impl From<ProxySocketError> for io::Error {
 pub type ProxySocketResult<T> = Result<T, ProxySocketError>;
 
 /// UDP client for communicating with ShadowSocks' server
+#[derive(Debug)]
 pub struct ProxySocket {
     socket_type: UdpSocketType,
     socket: ShadowUdpSocket,

--- a/crates/shadowsocks/src/security/replay/mod.rs
+++ b/crates/shadowsocks/src/security/replay/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[cfg(feature = "aead-cipher-2022")]
 use std::time::Duration;
 
@@ -27,6 +29,12 @@ pub struct ReplayProtector {
     // so we only need to remember nonce that are in the valid time range
     #[cfg(feature = "aead-cipher-2022")]
     nonce_set: spin::Mutex<LruCache<Vec<u8>, ()>>,
+}
+
+impl fmt::Debug for ReplayProtector {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ReplayProtector").finish()
+    }
 }
 
 impl ReplayProtector {

--- a/crates/shadowsocks/src/security/replay/ppbloom.rs
+++ b/crates/shadowsocks/src/security/replay/ppbloom.rs
@@ -27,6 +27,7 @@ const BF_ERROR_RATE_FOR_CLIENT: f64 = 1e-15;
 //
 // It contains 2 bloom filters and each one holds 1/2 entries.
 // Use them as a ring buffer.
+#[derive(Debug)]
 pub struct PingPongBloom {
     blooms: [Bloom<[u8]>; 2],
     bloom_count: [usize; 2],


### PR DESCRIPTION
Most implementations are derived.

I would like to add `missing_debug_implementations` lint,
but before deriving more Debug implementations
we need to add Debug implementations to types exported
from `shadowsocks-crypto`.

Closes #1647 