### PR TITLE
chore: clippy fix

### DIFF
--- a/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/freebsd.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/freebsd.rs
@@ -55,16 +55,8 @@ impl UdpRedirSocket {
         socket.set_reuse_address(true)?;
         if reuse_port {
             if let Err(err) = socket.set_reuse_port(true) {
-                if let Some(errno) = err.raw_os_error() {
-                    match errno {
-                        libc::ENOPROTOOPT => {
-                            trace!("failed to set SO_REUSEPORT, error: {}", err);
-                        }
-                        _ => {
-                            error!("failed to set SO_REUSEPORT, error: {}", err);
-                            return Err(err);
-                        }
-                    }
+                if let Some(libc::ENOPROTOOPT) = err.raw_os_error() {
+                    trace!("failed to set SO_REUSEPORT, error: {}", err);
                 } else {
                     error!("failed to set SO_REUSEPORT, error: {}", err);
                     return Err(err);

--- a/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/macos.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/macos.rs
@@ -54,16 +54,8 @@ impl UdpRedirSocket {
         socket.set_reuse_address(true)?;
         if reuse_port {
             if let Err(err) = socket.set_reuse_port(true) {
-                if let Some(errno) = err.raw_os_error() {
-                    match errno {
-                        libc::ENOPROTOOPT => {
-                            trace!("failed to set SO_REUSEPORT, error: {}", err);
-                        }
-                        _ => {
-                            error!("failed to set SO_REUSEPORT, error: {}", err);
-                            return Err(err);
-                        }
-                    }
+                if let Some(libc::ENOPROTOOPT) = err.raw_os_error() {
+                    trace!("failed to set SO_REUSEPORT, error: {}", err);
                 } else {
                     error!("failed to set SO_REUSEPORT, error: {}", err);
                     return Err(err);

--- a/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/openbsd.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/openbsd.rs
@@ -57,16 +57,8 @@ impl UdpRedirSocket {
         socket.set_reuse_address(true)?;
         if reuse_port {
             if let Err(err) = socket.set_reuse_port(true) {
-                if let Some(errno) = err.raw_os_error() {
-                    match errno {
-                        libc::ENOPROTOOPT => {
-                            trace!("failed to set SO_REUSEPORT, error: {}", err);
-                        }
-                        _ => {
-                            error!("failed to set SO_REUSEPORT, error: {}", err);
-                            return Err(err);
-                        }
-                    }
+                if let Some(libc::ENOPROTOOPT) = err.raw_os_error() {
+                    trace!("failed to set SO_REUSEPORT, error: {}", err);
                 } else {
                     error!("failed to set SO_REUSEPORT, error: {}", err);
                     return Err(err);

--- a/crates/shadowsocks/src/relay/udprelay/compat.rs
+++ b/crates/shadowsocks/src/relay/udprelay/compat.rs
@@ -181,8 +181,7 @@ pub trait DatagramReceiveExt: DatagramReceive {
     }
 
     /// Async method for `poll_recv_ready`
-    #[allow(clippy::needless_lifetimes)]
-    fn recv_ready<'a>(&'a self) -> RecvReadyFut<'a, Self> {
+    fn recv_ready(&self) -> RecvReadyFut<'_, Self> {
         RecvReadyFut { io: self }
     }
 }
@@ -202,8 +201,7 @@ pub trait DatagramSendExt: DatagramSend {
     }
 
     /// Async method for `poll_send_ready`
-    #[allow(clippy::needless_lifetimes)]
-    fn send_ready<'a>(&'a self) -> SendReadyFut<'a, Self> {
+    fn send_ready(&self) -> SendReadyFut<'_, Self> {
         SendReadyFut { io: self }
     }
 }


### PR DESCRIPTION
Fix a clippy warning that still shows up in https://github.com/shadowsocks/shadowsocks-rust/pull/1701/files.
And apply what clippy suggests for clippy::needless_lifetimes.