### PR TITLE
chore: suppress a clippy warning

### DIFF
--- a/crates/shadowsocks-service/src/local/redir/sys/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/sys/mod.rs
@@ -21,7 +21,7 @@ where
     let fd = socket.as_raw_fd();
     let sock = unsafe { Socket::from_raw_fd(fd) };
     let result = sock.set_only_v6(ipv6_only);
-    sock.into_raw_fd();
+    let _ = sock.into_raw_fd();
     result
 }
 


### PR DESCRIPTION
Suppress the `unused_must_use` clippy warning that showed up in https://github.com/shadowsocks/shadowsocks-rust/pull/1718/files.