### PR TITLE
fix: flush local-tun tcp writer half before close

### DIFF
--- a/crates/shadowsocks-service/src/local/tun/tcp.rs
+++ b/crates/shadowsocks-service/src/local/tun/tcp.rs
@@ -357,7 +357,7 @@ impl TcpTun {
                             }
 
                             // SHUT_WR
-                            if matches!(control.send_state, TcpSocketState::Close) {
+                            if matches!(control.send_state, TcpSocketState::Close) && socket.send_queue() == 0 && control.send_buffer.is_empty() {
                                 trace!("closing TCP Write Half, {:?}", socket.state());
 
                                 // Close the socket. Set to FIN state


### PR DESCRIPTION
I do not really know if we also need to flush other direction as well... Also not really sure that we should keep it opened after TcpSocketState::Close state - for example when we drop() it this will add unknown delay for writing buffers or failing