### PR TITLE
fix(sslocal): disallow HTTP/SOCKS4 proxying when authentication required

### DIFF
--- a/crates/shadowsocks-service/src/local/socks/server/server.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/server.rs
@@ -176,8 +176,13 @@ impl SocksTcpHandler {
         match version_buffer[0] {
             #[cfg(feature = "local-socks4")]
             0x04 => {
-                let handler = Socks4TcpHandler::new(self.context, self.balancer, self.mode);
-                handler.handle_socks4_client(self.stream, self.peer_addr).await
+                if self.socks5_auth.auth_required() {
+                    error!("SOCKS4 disabled when authentication is configured");
+                    Err(io::Error::new(ErrorKind::Other, "SOCKS4 unsupported"))
+                } else {
+                    let handler = Socks4TcpHandler::new(self.context, self.balancer, self.mode);
+                    handler.handle_socks4_client(self.stream, self.peer_addr).await
+                }
             }
 
             0x05 => {
@@ -193,12 +198,17 @@ impl SocksTcpHandler {
 
             #[cfg(feature = "local-http")]
             b'G' | b'g' | b'H' | b'h' | b'P' | b'p' | b'D' | b'd' | b'C' | b'c' | b'O' | b'o' | b'T' | b't' => {
-                // GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH
-                match self.http_handler.serve_connection(self.stream, self.peer_addr).await {
-                    Ok(..) => Ok(()),
-                    Err(err) => {
-                        error!("HTTP connection {} handler failed with error: {}", self.peer_addr, err);
-                        Err(io::Error::new(ErrorKind::Other, err))
+                if self.socks5_auth.auth_required() {
+                    error!("HTTP disabled when authentication is configured");
+                    Err(io::Error::new(ErrorKind::Other, "HTTP unsupported"))
+                } else {
+                    // GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH
+                    match self.http_handler.serve_connection(self.stream, self.peer_addr).await {
+                        Ok(..) => Ok(()),
+                        Err(err) => {
+                            error!("HTTP connection {} handler failed with error: {}", self.peer_addr, err);
+                            Err(io::Error::new(ErrorKind::Other, err))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Testing

The same set of tests as in #1764

`config.json`

```json
{
    "locals": [
        {
            "protocol": "socks",
            "local_address": "127.0.0.1",
            "local_port": 9090,
            "socks5_auth_config_path": "auth.json"
        }
    ],

    "servers": [
            {...}
    ],
}
```

`auth.json`:

```json
{
    "password": {
        "users": [
            {
                "user_name": "user",
                "password": "password"
            }
        ]
    }
}
```

Tests:

```sh
$ curl -si --proxy socks5://127.0.0.1:9090 -U user:password https://api.seeip.org | head -4
HTTP/1.1 200 OK
Server: nginx/1.18.0 (Ubuntu)
Date: Mon, 11 Nov 2024 17:38:29 GMT
Content-Type: text/plain
```

```sh
$ curl -i --proxy socks5://127.0.0.1:9090 -U user:pass https://api.seeip.org 
curl: (97) User was rejected by the SOCKS5 server (1 255).
```

```sh
$ curl -i --proxy http://127.0.0.1:9090 -U us:pass https://api.seeip.org 
curl: (56) Recv failure: Connection reset by peer
```