### PR TITLE
Add `UdpSocket::bind`

### DIFF
--- a/crates/shadowsocks/src/net/udp.rs
+++ b/crates/shadowsocks/src/net/udp.rs
@@ -166,6 +166,12 @@ impl UdpSocket {
             })
     }
 
+    /// Binds to a specific address as an outbound socket
+    #[inline]
+    pub async fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
+        UdpSocket::bind_with_opts(addr, &ConnectOpts::default()).await
+    }
+
     /// Binds to a specific address with opts as an outbound socket
     pub async fn bind_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<UdpSocket> {
         bind_outbound_udp_socket(addr, opts).await.map(|socket| UdpSocket {


### PR DESCRIPTION
This PR adds `UdpSocket::bind`, which is exactly `UdpSocket::bind_with_opts` with default `ConnectOpts`.

This adds a symmetry with the `UdpSocket::listen` and `UdpSocket::listen_with_opts` functions.