### PR TITLE
bugfix: local dns upstream udp packet buffer size 256

### DIFF
--- a/crates/shadowsocks-service/src/local/dns/upstream.rs
+++ b/crates/shadowsocks-service/src/local/dns/upstream.rs
@@ -149,7 +149,7 @@ impl DnsClient {
                 let bytes = msg.to_vec()?;
                 socket.send(&bytes).await?;
 
-                let mut recv_buf = [0u8; 256];
+                let mut recv_buf = [0u8; 512];
                 let n = socket.recv(&mut recv_buf).await?;
 
                 Message::from_vec(&recv_buf[..n])
@@ -171,7 +171,7 @@ impl DnsClient {
                 let bytes = msg.to_vec()?;
                 socket.send_with_ctrl(ns, control, &bytes).await?;
 
-                let mut recv_buf = [0u8; 256];
+                let mut recv_buf = [0u8; 512];
                 let (n, _, recv_control) = socket.recv_with_ctrl(&mut recv_buf).await?;
 
                 if let Some(server_control) = recv_control {


### PR DESCRIPTION
 local dns upstream udp packet buffer size 256 causes socket receive io error.

The DNS packet size is bigger and if it exceeds the buffer size, the socket raise receive error and return Err(ProtoError). 

<img width="681" alt="image" src="https://github.com/user-attachments/assets/5a9e4fbd-baae-4c1f-9657-9f8d75210509" />

