### PR TITLE
chore: allow to export pub socks handlers

### DIFF
--- a/crates/shadowsocks-service/src/local/socks/server/mod.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/mod.rs
@@ -15,8 +15,8 @@ use super::config::Socks5AuthConfig;
 #[allow(clippy::module_inception)]
 mod server;
 #[cfg(feature = "local-socks4")]
-mod socks4;
-mod socks5;
+pub mod socks4;
+pub mod socks5;
 
 /// SOCKS4/4a, SOCKS5 Local Server builder
 pub struct SocksBuilder {


### PR DESCRIPTION
Hi! It's minor changes to allow wrap tcp stream with socks logic (relay)