### PR TITLE
fix: file path in powershell script

### DIFF
--- a/build/build-host-release.ps1
+++ b/build/build-host-release.ps1
@@ -34,13 +34,15 @@ $Version = $Version -replace '"'
 $PackageReleasePath = "${PSScriptRoot}\release"
 $PackageName = "shadowsocks-v${Version}.${TargetTriple}.zip"
 $PackagePath = "${PackageReleasePath}\${PackageName}"
+$ReleaseBuildPath = "${PSScriptRoot}\..\target\release"
 
 Write-Host $Version
 Write-Host $PackageReleasePath
 Write-Host $PackageName
 Write-Host $PackagePath
+Write-Host $ReleaseBuildPath
 
-Push-Location "${PSScriptRoot}\..\target\release"
+Push-Location $ReleaseBuildPath
 
 $ProgressPreference = "SilentlyContinue"
 New-Item "${PackageReleasePath}" -ItemType Directory -ErrorAction SilentlyContinue
@@ -48,7 +50,7 @@ $CompressParam = @{
     LiteralPath     = "sslocal.exe", "ssserver.exe", "ssurl.exe", "ssmanager.exe", "ssservice.exe"
     DestinationPath = "${PackagePath}"
 }
-if ([System.IO.File]::Exists("sswinservice.exe")) {
+if ([System.IO.File]::Exists("$ReleaseBuildPath\sswinservice.exe")) {
     $CompressParam.LiteralPath += "sswinservice.exe"
 }
 Compress-Archive @CompressParam
@@ -60,3 +62,5 @@ $PackageHash = (Get-FileHash -Path "${PackagePath}" -Algorithm SHA256).Hash
 "${PackageHash}  ${PackageName}" | Out-File -FilePath "${PackageChecksumPath}"
 
 Write-Host "Created release packet checksum ${PackageChecksumPath}"
+
+Pop-Location


### PR DESCRIPTION
Change location inside powershell does not affect the working dir saw by .NET functions. Thus absolute path is needed.