### PR TITLE
fix: mips-* reenabled, moka automatically switches to a fallback impl for AtomicU64

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,16 +46,13 @@ jobs:
             toolchain: stable
           - target: aarch64-unknown-linux-musl
             toolchain: stable
-          # FIXME: moka uses atomic64 by default
-          # - target: mips-unknown-linux-gnu
-          #   toolchain: nightly
+          - target: mips-unknown-linux-gnu
+            toolchain: nightly
           # cross mips-*-musl images are disabled
           # - target: mips-unknown-linux-musl
           #   toolchain: nightly
-          # FIXME: moka uses atomic64 by default
-          # - target: mipsel-unknown-linux-gnu
-          #   toolchain: nightly
-          # cross mips-*-musl images are disabled
+          - target: mipsel-unknown-linux-gnu
+            toolchain: nightly
           # - target: mipsel-unknown-linux-musl
           #   toolchain: nightly
           # FIXME: ring doesn't support mips64 CPU
@@ -63,8 +60,8 @@ jobs:
           #   toolchain: nightly
           # - target: mips64-unknown-linux-muslabi64
           #   toolchain: nightly
-          # - target: mips64el-unknown-linux-gnuabi64
-          #   toolchain: nightly
+          - target: mips64el-unknown-linux-gnuabi64
+            toolchain: nightly
           # FIXME: Link Error. 
           #   = note: mips64el-linux-muslsf-gcc: error: crt1.o: No such file or directory
           #           mips64el-linux-muslsf-gcc: error: crti.o: No such file or directory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,16 +2076,16 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.9"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23db87a7f248211f6a7c8644a1b750541f8a4c68ae7de0f908860e44c0c201f6"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "loom",
  "parking_lot 0.12.3",
- "quanta",
+ "portable-atomic",
  "rustc_version",
  "smallvec",
  "tagptr",
@@ -2489,6 +2489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,21 +2554,6 @@ name = "qrcode"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
-
-[[package]]
-name = "quanta"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
-]
 
 [[package]]
 name = "quick-error"
@@ -2666,15 +2657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
-dependencies = [
- "bitflags 2.6.0",
 ]
 
 [[package]]


### PR DESCRIPTION
- Updated `moka` to `v0.12.10` by running `cargo update -p moka`.
- Reenable mips-* builds as `moka@v0.12.10` automatically switches to a fallback implementation for `AtomicU64` when necessary. (It uses [portable-atomic](https://crates.io/crates/portable-atomic) crate)

https://github.com/moka-rs/moka/blob/main/CHANGELOG.md#version-01210

Tested locally by running the following command and confirming that the build succeeded:

```console
$ cross +nightly build --target mips-unknown-linux-gnu -Z build-std=std,panic_abort,proc_macro
```
