### PR TITLE
chore: clippy fix

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -21,10 +21,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - if: ${{ runner.os == 'Windows' }}
         uses: ilammy/setup-nasm@v1
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         run: |
           rustup set profile minimal

--- a/crates/shadowsocks/src/relay/socks5.rs
+++ b/crates/shadowsocks/src/relay/socks5.rs
@@ -478,7 +478,7 @@ fn write_domain_name_address<B: BufMut>(dnaddr: &str, port: u16, buf: &mut B) {
         "domain name length must be smaller than 256"
     );
     buf.put_u8(dnaddr.len() as u8);
-    buf.put_slice(dnaddr[..].as_bytes());
+    buf.put_slice(dnaddr.as_bytes());
     buf.put_u16(port);
 }
 
@@ -837,7 +837,7 @@ impl UdpAssociateHeader {
     }
 }
 
-/// Username/Password Authentication Inittial Negociation
+/// Username/Password Authentication Initial Negotiation
 ///
 /// https://datatracker.ietf.org/doc/html/rfc1929
 ///
@@ -880,7 +880,7 @@ impl PasswdAuthRequest {
         let mut ver_buf = [0u8; 1];
         let _ = r.read_exact(&mut ver_buf).await?;
 
-        // The only valid subnegociation version
+        // The only valid subnegotiation version
         if ver_buf[0] != 0x01 {
             return Err(Error::UnsupportedPasswdAuthVersion(ver_buf[0]));
         }


### PR DESCRIPTION
* Remove `setup-protoc` from `clippy-check`,
reference https://github.com/shadowsocks/shadowsocks-rust/commit/c4b8fdd4f0ee3f819d0850ee722aa9e37b11df3f.
* Fix a clippy warning `sliced_string_as_bytes`,
reference https://rust-lang.github.io/rust-clippy/master/index.html#sliced_string_as_bytes .