### PR TITLE
chore: use Self where applicable

### DIFF
--- a/crates/shadowsocks-service/src/acl/mod.rs
+++ b/crates/shadowsocks-service/src/acl/mod.rs
@@ -91,12 +91,12 @@ impl Rules {
         rule_regex: RegexSet,
         rule_set: HashSet<String>,
         rule_tree: SubDomainsTree,
-    ) -> Rules {
+    ) -> Self {
         // Optimization, merging networks
         ipv4.simplify();
         ipv6.simplify();
 
-        Rules {
+        Self {
             ipv4,
             ipv6,
             rule_regex,
@@ -167,7 +167,7 @@ struct ParsingRules {
 
 impl ParsingRules {
     fn new(name: &'static str) -> Self {
-        ParsingRules {
+        Self {
             name,
             ipv4: IpRange::new(),
             ipv6: IpRange::new(),
@@ -342,7 +342,7 @@ pub struct AccessControl {
 
 impl AccessControl {
     /// Load ACL rules from a file
-    pub fn load_from_file<P: AsRef<Path>>(p: P) -> io::Result<AccessControl> {
+    pub fn load_from_file<P: AsRef<Path>>(p: P) -> io::Result<Self> {
         trace!("ACL loading from {:?}", p.as_ref());
 
         let file_path_ref = p.as_ref();
@@ -436,7 +436,7 @@ impl AccessControl {
             }
         }
 
-        Ok(AccessControl {
+        Ok(Self {
             outbound_block: outbound_block.into_rules()?,
             black_list: bypass.into_rules()?,
             white_list: proxy.into_rules()?,

--- a/crates/shadowsocks-service/src/acl/sub_domains_tree.rs
+++ b/crates/shadowsocks-service/src/acl/sub_domains_tree.rs
@@ -11,7 +11,7 @@ struct DomainPart {
 
 impl DomainPart {
     fn new() -> Self {
-        DomainPart {
+        Self {
             included: false,
             children: HashMap::new(),
         }
@@ -29,7 +29,7 @@ impl Debug for SubDomainsTree {
 
 impl SubDomainsTree {
     pub fn new() -> Self {
-        SubDomainsTree(HashMap::new())
+        Self(HashMap::new())
     }
 
     pub fn insert(&mut self, value: &str) {

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -444,23 +444,23 @@ pub enum ConfigType {
 impl ConfigType {
     /// Check if it is local server type
     pub fn is_local(self) -> bool {
-        self == ConfigType::Local
+        self == Self::Local
     }
 
     /// Check if it is remote server type
     pub fn is_server(self) -> bool {
-        self == ConfigType::Server
+        self == Self::Server
     }
 
     /// Check if it is manager server type
     pub fn is_manager(self) -> bool {
-        self == ConfigType::Manager
+        self == Self::Manager
     }
 
     /// Check if it is online config type (SIP008)
     #[cfg(feature = "local-online-config")]
     pub fn is_online_config(self) -> bool {
-        self == ConfigType::OnlineConfig
+        self == Self::OnlineConfig
     }
 }
 
@@ -512,8 +512,8 @@ cfg_if! {
             cfg_if! {
                 if #[cfg(any(target_os = "linux", target_os = "android"))] {
                     /// Default TCP transparent proxy solution on this platform
-                    pub const fn tcp_default() -> RedirType {
-                        RedirType::Redirect
+                    pub const fn tcp_default() -> Self {
+                        Self::Redirect
                     }
 
                     /// Available TCP transparent proxy types
@@ -524,8 +524,8 @@ cfg_if! {
                     }
 
                     /// Default UDP transparent proxy solution on this platform
-                    pub const fn udp_default() -> RedirType {
-                        RedirType::TProxy
+                    pub const fn udp_default() -> Self {
+                        Self::TProxy
                     }
 
                     /// Available UDP transparent proxy types
@@ -635,20 +635,20 @@ cfg_if! {
 
             /// Check if transparent proxy is supported on this platform
             pub fn is_supported(self) -> bool {
-                self != RedirType::NotSupported
+                self != Self::NotSupported
             }
 
             /// Name of redirect type (transparent proxy type)
             pub const fn name(self) -> &'static str {
                 match self {
                     // Dummy, shouldn't be used in any useful situations
-                    RedirType::NotSupported => "not_supported",
+                    Self::NotSupported => "not_supported",
 
                     #[cfg(any(target_os = "linux", target_os = "android"))]
-                    RedirType::Redirect => "redirect",
+                    Self::Redirect => "redirect",
 
                     #[cfg(any(target_os = "linux", target_os = "android"))]
-                    RedirType::TProxy => "tproxy",
+                    Self::TProxy => "tproxy",
 
                     #[cfg(any(
                         target_os = "freebsd",
@@ -683,13 +683,13 @@ cfg_if! {
         impl FromStr for RedirType {
             type Err = InvalidRedirType;
 
-            fn from_str(s: &str) -> Result<RedirType, InvalidRedirType> {
+            fn from_str(s: &str) -> Result<Self, InvalidRedirType> {
                 match s {
                     #[cfg(any(target_os = "linux", target_os = "android"))]
-                    "redirect" => Ok(RedirType::Redirect),
+                    "redirect" => Ok(Self::Redirect),
 
                     #[cfg(any(target_os = "linux", target_os = "android"))]
-                    "tproxy" => Ok(RedirType::TProxy),
+                    "tproxy" => Ok(Self::TProxy),
 
                     #[cfg(any(
                         target_os = "freebsd",
@@ -725,8 +725,8 @@ pub enum ManagerServerHost {
 }
 
 impl Default for ManagerServerHost {
-    fn default() -> ManagerServerHost {
-        ManagerServerHost::Ip(Ipv4Addr::UNSPECIFIED.into())
+    fn default() -> Self {
+        Self::Ip(Ipv4Addr::UNSPECIFIED.into())
     }
 }
 
@@ -735,8 +735,8 @@ impl FromStr for ManagerServerHost {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.parse::<IpAddr>() {
-            Ok(s) => Ok(ManagerServerHost::Ip(s)),
-            Err(..) => Ok(ManagerServerHost::Domain(s.to_owned())),
+            Ok(s) => Ok(Self::Ip(s)),
+            Err(..) => Ok(Self::Domain(s.to_owned())),
         }
     }
 }
@@ -766,11 +766,11 @@ impl Display for ManagerServerModeError {
 impl FromStr for ManagerServerMode {
     type Err = ManagerServerModeError;
 
-    fn from_str(s: &str) -> Result<ManagerServerMode, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "builtin" => Ok(ManagerServerMode::Builtin),
+            "builtin" => Ok(Self::Builtin),
             #[cfg(unix)]
-            "standalone" => Ok(ManagerServerMode::Standalone),
+            "standalone" => Ok(Self::Standalone),
             _ => Err(ManagerServerModeError),
         }
     }
@@ -779,9 +779,9 @@ impl FromStr for ManagerServerMode {
 impl Display for ManagerServerMode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ManagerServerMode::Builtin => f.write_str("builtin"),
+            Self::Builtin => f.write_str("builtin"),
             #[cfg(unix)]
-            ManagerServerMode::Standalone => f.write_str("standalone"),
+            Self::Standalone => f.write_str("standalone"),
         }
     }
 }
@@ -815,8 +815,8 @@ pub struct ManagerConfig {
 
 impl ManagerConfig {
     /// Create a ManagerConfig with default options
-    pub fn new(addr: ManagerAddr) -> ManagerConfig {
-        ManagerConfig {
+    pub fn new(addr: ManagerAddr) -> Self {
+        Self {
             addr,
             method: None,
             plugin: None,
@@ -858,19 +858,19 @@ impl ProtocolType {
     /// As string representation
     pub fn as_str(&self) -> &'static str {
         match *self {
-            ProtocolType::Socks => "socks",
+            Self::Socks => "socks",
             #[cfg(feature = "local-http")]
-            ProtocolType::Http => "http",
+            Self::Http => "http",
             #[cfg(feature = "local-tunnel")]
-            ProtocolType::Tunnel => "tunnel",
+            Self::Tunnel => "tunnel",
             #[cfg(feature = "local-redir")]
-            ProtocolType::Redir => "redir",
+            Self::Redir => "redir",
             #[cfg(feature = "local-dns")]
-            ProtocolType::Dns => "dns",
+            Self::Dns => "dns",
             #[cfg(feature = "local-tun")]
-            ProtocolType::Tun => "tun",
+            Self::Tun => "tun",
             #[cfg(feature = "local-fake-dns")]
-            ProtocolType::FakeDns => "fake-dns",
+            Self::FakeDns => "fake-dns",
         }
     }
 
@@ -909,19 +909,19 @@ impl FromStr for ProtocolType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "socks" => Ok(ProtocolType::Socks),
+            "socks" => Ok(Self::Socks),
             #[cfg(feature = "local-http")]
-            "http" => Ok(ProtocolType::Http),
+            "http" => Ok(Self::Http),
             #[cfg(feature = "local-tunnel")]
-            "tunnel" => Ok(ProtocolType::Tunnel),
+            "tunnel" => Ok(Self::Tunnel),
             #[cfg(feature = "local-redir")]
-            "redir" => Ok(ProtocolType::Redir),
+            "redir" => Ok(Self::Redir),
             #[cfg(feature = "local-dns")]
-            "dns" => Ok(ProtocolType::Dns),
+            "dns" => Ok(Self::Dns),
             #[cfg(feature = "local-tun")]
-            "tun" => Ok(ProtocolType::Tun),
+            "tun" => Ok(Self::Tun),
             #[cfg(feature = "local-fake-dns")]
-            "fake-dns" => Ok(ProtocolType::FakeDns),
+            "fake-dns" => Ok(Self::FakeDns),
             _ => Err(ProtocolTypeError),
         }
     }
@@ -1054,7 +1054,7 @@ pub struct LocalConfig {
 
 impl LocalConfig {
     /// Create a new `LocalConfig`
-    pub fn new(protocol: ProtocolType) -> LocalConfig {
+    pub fn new(protocol: ProtocolType) -> Self {
         // DNS server runs in `TcpAndUdp` mode by default to maintain backwards compatibility
         // see https://github.com/shadowsocks/shadowsocks-rust/issues/1281
         let mode = match protocol {
@@ -1063,7 +1063,7 @@ impl LocalConfig {
             _ => Mode::TcpOnly,
         };
 
-        LocalConfig {
+        Self {
             addr: None,
 
             protocol,
@@ -1120,8 +1120,8 @@ impl LocalConfig {
     }
 
     /// Create a new `LocalConfig` with listen address
-    pub fn new_with_addr(addr: ServerAddr, protocol: ProtocolType) -> LocalConfig {
-        let mut config = LocalConfig::new(protocol);
+    pub fn new_with_addr(addr: ServerAddr, protocol: ProtocolType) -> Self {
+        let mut config = Self::new(protocol);
         config.addr = Some(addr);
         config
     }
@@ -1260,8 +1260,8 @@ pub struct ServerInstanceConfig {
 
 impl ServerInstanceConfig {
     /// Create with `ServerConfig`
-    pub fn with_server_config(config: ServerConfig) -> ServerInstanceConfig {
-        ServerInstanceConfig {
+    pub fn with_server_config(config: ServerConfig) -> Self {
+        Self {
             config,
             acl: None,
             #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -1286,8 +1286,8 @@ pub struct LocalInstanceConfig {
 
 impl LocalInstanceConfig {
     /// Create with `LocalConfig`
-    pub fn with_local_config(config: LocalConfig) -> LocalInstanceConfig {
-        LocalInstanceConfig { config, acl: None }
+    pub fn with_local_config(config: LocalConfig) -> Self {
+        Self { config, acl: None }
     }
 }
 
@@ -1435,8 +1435,8 @@ pub struct Error {
 }
 
 impl Error {
-    pub fn new(kind: ErrorKind, desc: &'static str, detail: Option<String>) -> Error {
-        Error { kind, desc, detail }
+    pub fn new(kind: ErrorKind, desc: &'static str, detail: Option<String>) -> Self {
+        Self { kind, desc, detail }
     }
 }
 
@@ -1479,8 +1479,8 @@ impl Display for Error {
 
 impl Config {
     /// Creates an empty configuration
-    pub fn new(config_type: ConfigType) -> Config {
-        Config {
+    pub fn new(config_type: ConfigType) -> Self {
+        Self {
             server: Vec::new(),
             local: Vec::new(),
 
@@ -1536,8 +1536,8 @@ impl Config {
         }
     }
 
-    fn load_from_ssconfig(config: SSConfig, config_type: ConfigType) -> Result<Config, Error> {
-        let mut nconfig = Config::new(config_type);
+    fn load_from_ssconfig(config: SSConfig, config_type: ConfigType) -> Result<Self, Error> {
+        let mut nconfig = Self::new(config_type);
 
         // Client
         //
@@ -2495,11 +2495,11 @@ impl Config {
 
         impl DnsProtocol {
             fn enable_tcp(&self) -> bool {
-                matches!(*self, DnsProtocol::Tcp | DnsProtocol::Both)
+                matches!(*self, Self::Tcp | Self::Both)
             }
 
             fn enable_udp(&self) -> bool {
-                matches!(*self, DnsProtocol::Udp | DnsProtocol::Both)
+                matches!(*self, Self::Udp | Self::Both)
             }
         }
 
@@ -2563,20 +2563,20 @@ impl Config {
     }
 
     /// Load Config from a `str`
-    pub fn load_from_str(s: &str, config_type: ConfigType) -> Result<Config, Error> {
+    pub fn load_from_str(s: &str, config_type: ConfigType) -> Result<Self, Error> {
         let c = json5::from_str::<SSConfig>(s)?;
-        Config::load_from_ssconfig(c, config_type)
+        Self::load_from_ssconfig(c, config_type)
     }
 
     /// Load Config from a File
-    pub fn load_from_file<P: AsRef<Path>>(filename: P, config_type: ConfigType) -> Result<Config, Error> {
+    pub fn load_from_file<P: AsRef<Path>>(filename: P, config_type: ConfigType) -> Result<Self, Error> {
         let filename = filename.as_ref();
 
         let mut reader = OpenOptions::new().read(true).open(filename)?;
         let mut content = String::new();
         reader.read_to_string(&mut content)?;
 
-        let mut config = Config::load_from_str(&content[..], config_type)?;
+        let mut config = Self::load_from_str(&content[..], config_type)?;
 
         // Record the path of the configuration for auto-reloading
         config.config_path = Some(filename.to_owned());

--- a/crates/shadowsocks-service/src/local/context.rs
+++ b/crates/shadowsocks-service/src/local/context.rs
@@ -46,14 +46,14 @@ pub struct ServiceContext {
 
 impl Default for ServiceContext {
     fn default() -> Self {
-        ServiceContext::new()
+        Self::new()
     }
 }
 
 impl ServiceContext {
     /// Create a new `ServiceContext`
-    pub fn new() -> ServiceContext {
-        ServiceContext {
+    pub fn new() -> Self {
+        Self {
             context: Context::new_shared(ServerType::Local),
             connect_opts: ConnectOpts::default(),
             accept_opts: AcceptOpts::default(),

--- a/crates/shadowsocks-service/src/local/dns/client_cache.rs
+++ b/crates/shadowsocks-service/src/local/dns/client_cache.rs
@@ -36,8 +36,8 @@ pub struct DnsClientCache {
 }
 
 impl DnsClientCache {
-    pub fn new(max_client_per_addr: usize) -> DnsClientCache {
-        DnsClientCache {
+    pub fn new(max_client_per_addr: usize) -> Self {
+        Self {
             cache: Mutex::new(HashMap::new()),
             timeout: Duration::from_secs(5),
             retry_count: 1,

--- a/crates/shadowsocks-service/src/local/dns/config.rs
+++ b/crates/shadowsocks-service/src/local/dns/config.rs
@@ -32,13 +32,13 @@ impl FromStr for NameServerAddr {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(ip) = s.parse::<IpAddr>() {
-            return Ok(NameServerAddr::SocketAddr(SocketAddr::new(ip, 53)));
+            return Ok(Self::SocketAddr(SocketAddr::new(ip, 53)));
         }
 
         match s.parse::<SocketAddr>() {
-            Ok(addr) => Ok(NameServerAddr::SocketAddr(addr)),
+            Ok(addr) => Ok(Self::SocketAddr(addr)),
             #[cfg(unix)]
-            Err(..) => Ok(NameServerAddr::UnixSocketAddr(PathBuf::from(s))),
+            Err(..) => Ok(Self::UnixSocketAddr(PathBuf::from(s))),
             #[cfg(not(unix))]
             Err(err) => Err(err),
         }
@@ -48,9 +48,9 @@ impl FromStr for NameServerAddr {
 impl Display for NameServerAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            NameServerAddr::SocketAddr(ref sa) => Display::fmt(sa, f),
+            Self::SocketAddr(ref sa) => Display::fmt(sa, f),
             #[cfg(unix)]
-            NameServerAddr::UnixSocketAddr(ref p) => write!(f, "{}", p.display()),
+            Self::UnixSocketAddr(ref p) => write!(f, "{}", p.display()),
         }
     }
 }

--- a/crates/shadowsocks-service/src/local/dns/dns_resolver.rs
+++ b/crates/shadowsocks-service/src/local/dns/dns_resolver.rs
@@ -26,8 +26,8 @@ pub struct DnsResolver {
 }
 
 impl DnsResolver {
-    pub fn new(ns: NameServerAddr) -> DnsResolver {
-        DnsResolver {
+    pub fn new(ns: NameServerAddr) -> Self {
+        Self {
             ns,
             client_cache: DnsClientCache::new(5),
             mode: Mode::UdpOnly,

--- a/crates/shadowsocks-service/src/local/dns/server.rs
+++ b/crates/shadowsocks-service/src/local/dns/server.rs
@@ -70,9 +70,9 @@ impl DnsBuilder {
         remote_addr: Address,
         balancer: PingBalancer,
         client_cache_size: usize,
-    ) -> DnsBuilder {
+    ) -> Self {
         let context = ServiceContext::new();
-        DnsBuilder::with_context(
+        Self::with_context(
             Arc::new(context),
             bind_addr,
             local_addr,
@@ -90,8 +90,8 @@ impl DnsBuilder {
         remote_addr: Address,
         balancer: PingBalancer,
         client_cache_size: usize,
-    ) -> DnsBuilder {
-        DnsBuilder {
+    ) -> Self {
+        Self {
             context,
             mode: Mode::UdpOnly,
             local_addr,
@@ -190,8 +190,8 @@ impl DnsTcpServerBuilder {
         local_addr: Arc<NameServerAddr>,
         remote_addr: Arc<Address>,
         client: Arc<DnsClient>,
-    ) -> DnsTcpServerBuilder {
-        DnsTcpServerBuilder {
+    ) -> Self {
+        Self {
             context,
             bind_addr,
             local_addr,
@@ -270,7 +270,7 @@ impl DnsTcpServer {
                 }
             };
 
-            tokio::spawn(DnsTcpServer::handle_tcp_stream(
+            tokio::spawn(Self::handle_tcp_stream(
                 self.client.clone(),
                 stream,
                 peer_addr,
@@ -365,8 +365,8 @@ impl DnsUdpServerBuilder {
         local_addr: Arc<NameServerAddr>,
         remote_addr: Arc<Address>,
         client: Arc<DnsClient>,
-    ) -> DnsUdpServerBuilder {
-        DnsUdpServerBuilder {
+    ) -> Self {
+        Self {
             context,
             bind_addr,
             local_addr,
@@ -453,7 +453,7 @@ impl DnsUdpServer {
                 }
             };
 
-            tokio::spawn(DnsUdpServer::handle_udp_packet(
+            tokio::spawn(Self::handle_udp_packet(
                 self.client.clone(),
                 self.listener.clone(),
                 peer_addr,
@@ -720,8 +720,8 @@ struct DnsClient {
 }
 
 impl DnsClient {
-    fn new(context: Arc<ServiceContext>, balancer: PingBalancer, mode: Mode, client_cache_size: usize) -> DnsClient {
-        DnsClient {
+    fn new(context: Arc<ServiceContext>, balancer: PingBalancer, mode: Mode, client_cache_size: usize) -> Self {
+        Self {
             context,
             client_cache: DnsClientCache::new(client_cache_size),
             mode,

--- a/crates/shadowsocks-service/src/local/fake_dns/proto.rs
+++ b/crates/shadowsocks-service/src/local/fake_dns/proto.rs
@@ -12,7 +12,7 @@ pub struct StorageMeta {
 }
 
 impl StorageMeta {
-    pub fn decode(v: &[u8]) -> io::Result<StorageMeta> {
+    pub fn decode(v: &[u8]) -> io::Result<Self> {
         bson::from_slice(v).map_err(io::Error::other)
     }
 
@@ -28,7 +28,7 @@ pub struct IpAddrMapping {
 }
 
 impl IpAddrMapping {
-    pub fn decode(v: &[u8]) -> io::Result<IpAddrMapping> {
+    pub fn decode(v: &[u8]) -> io::Result<Self> {
         bson::from_slice(v).map_err(io::Error::other)
     }
 
@@ -45,7 +45,7 @@ pub struct DomainNameMapping {
 }
 
 impl DomainNameMapping {
-    pub fn decode(v: &[u8]) -> io::Result<DomainNameMapping> {
+    pub fn decode(v: &[u8]) -> io::Result<Self> {
         bson::from_slice(v).map_err(io::Error::other)
     }
 

--- a/crates/shadowsocks-service/src/local/fake_dns/server.rs
+++ b/crates/shadowsocks-service/src/local/fake_dns/server.rs
@@ -29,14 +29,14 @@ pub struct FakeDnsBuilder {
 
 impl FakeDnsBuilder {
     /// Create a new Fake DNS server
-    pub fn new(client_addr: ServerAddr) -> FakeDnsBuilder {
+    pub fn new(client_addr: ServerAddr) -> Self {
         let context = ServiceContext::new();
-        FakeDnsBuilder::with_context(Arc::new(context), client_addr)
+        Self::with_context(Arc::new(context), client_addr)
     }
 
     /// Create a new Fake DNS server with context
-    pub fn with_context(context: Arc<ServiceContext>, client_addr: ServerAddr) -> FakeDnsBuilder {
-        FakeDnsBuilder {
+    pub fn with_context(context: Arc<ServiceContext>, client_addr: ServerAddr) -> Self {
+        Self {
             context,
             mode: Mode::TcpAndUdp,
             client_addr,

--- a/crates/shadowsocks-service/src/local/fake_dns/tcp_server.rs
+++ b/crates/shadowsocks-service/src/local/fake_dns/tcp_server.rs
@@ -37,7 +37,7 @@ impl FakeDnsTcpServer {
         context: Arc<ServiceContext>,
         client_config: &ServerAddr,
         manager: Arc<FakeDnsManager>,
-    ) -> io::Result<FakeDnsTcpServer> {
+    ) -> io::Result<Self> {
         let listener = match *client_config {
             ServerAddr::SocketAddr(ref saddr) => {
                 ShadowTcpListener::bind_with_opts(saddr, context.accept_opts()).await?
@@ -50,7 +50,7 @@ impl FakeDnsTcpServer {
             }
         };
 
-        Ok(FakeDnsTcpServer {
+        Ok(Self {
             context,
             listener,
             manager,
@@ -79,7 +79,7 @@ impl FakeDnsTcpServer {
             let context = self.context.clone();
             let manager = self.manager.clone();
             tokio::spawn(async move {
-                if let Err(err) = FakeDnsTcpServer::handle_client(context, peer_addr, stream, manager).await {
+                if let Err(err) = Self::handle_client(context, peer_addr, stream, manager).await {
                     error!(
                         "failed to handle Fake DNS tcp client, peer: {}, err: {}",
                         peer_addr, err

--- a/crates/shadowsocks-service/src/local/fake_dns/udp_server.rs
+++ b/crates/shadowsocks-service/src/local/fake_dns/udp_server.rs
@@ -22,7 +22,7 @@ impl FakeDnsUdpServer {
         context: Arc<ServiceContext>,
         client_config: &ServerAddr,
         manager: Arc<FakeDnsManager>,
-    ) -> io::Result<FakeDnsUdpServer> {
+    ) -> io::Result<Self> {
         let listener = match *client_config {
             ServerAddr::SocketAddr(ref saddr) => {
                 ShadowUdpSocket::listen_with_opts(saddr, context.accept_opts()).await?
@@ -35,7 +35,7 @@ impl FakeDnsUdpServer {
             }
         };
 
-        Ok(FakeDnsUdpServer { listener, manager })
+        Ok(Self { listener, manager })
     }
 
     /// Get UDP local address

--- a/crates/shadowsocks-service/src/local/http/http_service.rs
+++ b/crates/shadowsocks-service/src/local/http/http_service.rs
@@ -38,8 +38,8 @@ impl HttpService {
         peer_addr: SocketAddr,
         http_client: HttpClient<body::Incoming>,
         balancer: PingBalancer,
-    ) -> HttpService {
-        HttpService {
+    ) -> Self {
+        Self {
             context,
             peer_addr,
             http_client,

--- a/crates/shadowsocks-service/src/local/http/http_stream.rs
+++ b/crates/shadowsocks-service/src/local/http/http_stream.rs
@@ -22,8 +22,8 @@ pub enum ProxyHttpStream {
 }
 
 impl ProxyHttpStream {
-    pub fn connect_http(stream: AutoProxyClientStream) -> ProxyHttpStream {
-        ProxyHttpStream::Http(stream)
+    pub fn connect_http(stream: AutoProxyClientStream) -> Self {
+        Self::Http(stream)
     }
 
     #[cfg(feature = "local-http-native-tls")]
@@ -59,7 +59,7 @@ impl ProxyHttpStream {
     }
 
     #[cfg(feature = "local-http-rustls")]
-    pub async fn connect_https(stream: AutoProxyClientStream, domain: &str) -> io::Result<ProxyHttpStream> {
+    pub async fn connect_https(stream: AutoProxyClientStream, domain: &str) -> io::Result<Self> {
         use log::warn;
         use rustls_native_certs::CertificateResult;
         use std::sync::{Arc, LazyLock};
@@ -114,7 +114,7 @@ impl ProxyHttpStream {
         let (_, session) = tls_stream.get_ref();
         let negotiated_http2 = matches!(session.alpn_protocol(), Some(b"h2"));
 
-        Ok(ProxyHttpStream::Https(tls_stream, negotiated_http2))
+        Ok(Self::Https(tls_stream, negotiated_http2))
     }
 
     #[cfg(not(any(feature = "local-http-native-tls", feature = "local-http-rustls")))]
@@ -127,9 +127,9 @@ impl ProxyHttpStream {
 
     pub fn negotiated_http2(&self) -> bool {
         match *self {
-            ProxyHttpStream::Http(..) => false,
+            Self::Http(..) => false,
             #[cfg(any(feature = "local-http-native-tls", feature = "local-http-rustls"))]
-            ProxyHttpStream::Https(_, n) => n,
+            Self::Https(_, n) => n,
         }
     }
 }

--- a/crates/shadowsocks-service/src/local/http/server.rs
+++ b/crates/shadowsocks-service/src/local/http/server.rs
@@ -29,9 +29,9 @@ pub struct HttpBuilder {
 
 impl HttpBuilder {
     /// Create a new HTTP Local server builder
-    pub fn new(client_config: ServerAddr, balancer: PingBalancer) -> HttpBuilder {
+    pub fn new(client_config: ServerAddr, balancer: PingBalancer) -> Self {
         let context = ServiceContext::new();
-        HttpBuilder::with_context(Arc::new(context), client_config, balancer)
+        Self::with_context(Arc::new(context), client_config, balancer)
     }
 
     /// Create with an existed context
@@ -39,8 +39,8 @@ impl HttpBuilder {
         context: Arc<ServiceContext>,
         client_config: ServerAddr,
         balancer: PingBalancer,
-    ) -> HttpBuilder {
-        HttpBuilder {
+    ) -> Self {
+        Self {
             context,
             client_config,
             balancer,
@@ -143,8 +143,8 @@ pub struct HttpConnectionHandler {
 
 impl HttpConnectionHandler {
     /// Create a new Handler
-    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer) -> HttpConnectionHandler {
-        HttpConnectionHandler {
+    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer) -> Self {
+        Self {
             context,
             balancer,
             http_client: HttpClient::new(),
@@ -156,7 +156,7 @@ impl HttpConnectionHandler {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        let HttpConnectionHandler {
+        let Self {
             context,
             balancer,
             http_client,

--- a/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
@@ -54,8 +54,8 @@ pub enum ServerType {
 impl fmt::Display for ServerType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ServerType::Tcp => f.write_str("TCP"),
-            ServerType::Udp => f.write_str("UDP"),
+            Self::Tcp => f.write_str("TCP"),
+            Self::Udp => f.write_str("UDP"),
         }
     }
 }
@@ -71,8 +71,8 @@ pub struct PingBalancerBuilder {
 }
 
 impl PingBalancerBuilder {
-    pub fn new(context: Arc<ServiceContext>, mode: Mode) -> PingBalancerBuilder {
-        PingBalancerBuilder {
+    pub fn new(context: Arc<ServiceContext>, mode: Mode) -> Self {
+        Self {
             servers: Vec::new(),
             context,
             mode,
@@ -241,7 +241,7 @@ impl PingBalancerContext {
         max_server_rtt: Duration,
         check_interval: Duration,
         check_best_interval: Option<Duration>,
-    ) -> io::Result<(Arc<PingBalancerContext>, PingBalancerContextTask)> {
+    ) -> io::Result<(Arc<Self>, PingBalancerContextTask)> {
         let plugin_abortable = {
             // Start plugins for TCP proxies
 
@@ -305,7 +305,7 @@ impl PingBalancerContext {
 
         let (best_tcp_idx, best_udp_idx) = PingBalancerBuilder::find_best_idx(&servers, mode);
 
-        let balancer_context = PingBalancerContext {
+        let balancer_context = Self {
             servers,
             best_tcp_idx: AtomicUsize::new(best_tcp_idx),
             best_udp_idx: AtomicUsize::new(best_udp_idx),
@@ -360,10 +360,10 @@ impl PingBalancerContext {
 
         for server in self.servers.iter() {
             let svr_cfg = server.server_config();
-            if self.mode.enable_tcp() && PingBalancerContext::check_server_tcp_enabled(svr_cfg) {
+            if self.mode.enable_tcp() && Self::check_server_tcp_enabled(svr_cfg) {
                 tcp_count += 1;
             }
-            if self.mode.enable_udp() && PingBalancerContext::check_server_udp_enabled(svr_cfg) {
+            if self.mode.enable_udp() && Self::check_server_udp_enabled(svr_cfg) {
                 udp_count += 1;
             }
         }
@@ -397,7 +397,7 @@ impl PingBalancerContext {
         for server in servers.iter() {
             let svr_cfg = server.server_config();
 
-            if self.mode.enable_tcp() && PingBalancerContext::check_server_tcp_enabled(svr_cfg) {
+            if self.mode.enable_tcp() && Self::check_server_tcp_enabled(svr_cfg) {
                 let checker = PingChecker {
                     server: server.clone(),
                     server_type: ServerType::Tcp,
@@ -407,7 +407,7 @@ impl PingBalancerContext {
                 vfut_tcp.push(checker.check_update_score());
             }
 
-            if self.mode.enable_udp() && PingBalancerContext::check_server_udp_enabled(svr_cfg) {
+            if self.mode.enable_udp() && Self::check_server_udp_enabled(svr_cfg) {
                 let checker = PingChecker {
                     server: server.clone(),
                     server_type: ServerType::Udp,
@@ -523,7 +523,7 @@ impl PingBalancerContext {
         let mut check_tcp = false;
         let mut check_udp = false;
 
-        if self.mode.enable_tcp() && PingBalancerContext::check_server_tcp_enabled(best_tcp_svr_cfg) {
+        if self.mode.enable_tcp() && Self::check_server_tcp_enabled(best_tcp_svr_cfg) {
             let checker = PingChecker {
                 server: best_tcp_server.clone(),
                 server_type: ServerType::Tcp,
@@ -534,7 +534,7 @@ impl PingBalancerContext {
             check_tcp = true;
         }
 
-        if self.mode.enable_udp() && PingBalancerContext::check_server_udp_enabled(best_udp_svr_cfg) {
+        if self.mode.enable_udp() && Self::check_server_udp_enabled(best_udp_svr_cfg) {
             let checker = PingChecker {
                 server: best_udp_server.clone(),
                 server_type: ServerType::Udp,
@@ -1032,7 +1032,7 @@ struct ServerConfigFormatter<'a> {
 }
 
 impl<'a> ServerConfigFormatter<'a> {
-    fn new(server_config: &'a ServerConfig) -> ServerConfigFormatter<'a> {
+    fn new(server_config: &'a ServerConfig) -> Self {
         ServerConfigFormatter { server_config }
     }
 }

--- a/crates/shadowsocks-service/src/local/loadbalancing/server_data.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/server_data.rs
@@ -25,11 +25,11 @@ pub struct ServerScore {
 
 impl ServerScore {
     /// Create a `ServerScore`
-    pub fn new(user_weight: f32, max_server_rtt: Duration, check_window: Duration) -> ServerScore {
+    pub fn new(user_weight: f32, max_server_rtt: Duration, check_window: Duration) -> Self {
         let max_server_rtt = max_server_rtt.as_millis() as u32;
         assert!(max_server_rtt > 0);
 
-        ServerScore {
+        Self {
             stat_data: Mutex::new(ServerStat::new(user_weight, max_server_rtt, check_window)),
             score: AtomicU32::new(u32::MAX),
         }
@@ -93,7 +93,7 @@ impl ServerIdent {
         svr_cfg: ServerInstanceConfig,
         max_server_rtt: Duration,
         check_window: Duration,
-    ) -> ServerIdent {
+    ) -> Self {
         let mut connect_opts = context.connect_opts_ref().clone();
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -114,7 +114,7 @@ impl ServerIdent {
             connect_opts.bind_interface = Some(bind_interface.clone());
         }
 
-        ServerIdent {
+        Self {
             tcp_score: ServerScore::new(svr_cfg.config.weight().tcp_weight(), max_server_rtt, check_window),
             udp_score: ServerScore::new(svr_cfg.config.weight().udp_weight(), max_server_rtt, check_window),
             svr_cfg,

--- a/crates/shadowsocks-service/src/local/loadbalancing/server_stat.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/server_stat.rs
@@ -64,11 +64,11 @@ fn max_latency_stdev(max_server_rtt: u32) -> f64 {
 }
 
 impl ServerStat {
-    pub fn new(user_weight: f32, max_server_rtt: u32, check_window: Duration) -> ServerStat {
+    pub fn new(user_weight: f32, max_server_rtt: u32, check_window: Duration) -> Self {
         assert!((0.0..=1.0).contains(&user_weight));
 
         let max_latency_stdev = max_latency_stdev(max_server_rtt);
-        ServerStat {
+        Self {
             max_server_rtt,
             latency_queue: VecDeque::new(),
             max_latency_stdev,

--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -94,7 +94,7 @@ pub struct Server {
 
 impl Server {
     /// Create a shadowsocks local server
-    pub async fn new(config: Config) -> io::Result<Server> {
+    pub async fn new(config: Config) -> io::Result<Self> {
         assert!(config.config_type == ConfigType::Local && !config.local.is_empty());
 
         trace!("{:?}", config);
@@ -223,7 +223,7 @@ impl Server {
             balancer_builder.build().await?
         };
 
-        let mut local_server = Server {
+        let mut local_server = Self {
             balancer: balancer.clone(),
             socks_servers: Vec::new(),
             #[cfg(feature = "local-tunnel")]

--- a/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
+++ b/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
@@ -36,11 +36,11 @@ impl AutoProxyClientStream {
         context: Arc<ServiceContext>,
         server: &ServerIdent,
         addr: A,
-    ) -> io::Result<AutoProxyClientStream>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
-        AutoProxyClientStream::connect_with_opts(context.clone(), server, addr, context.connect_opts_ref()).await
+        Self::connect_with_opts(context.clone(), server, addr, context.connect_opts_ref()).await
     }
 
     /// Connect to target `addr` via shadowsocks' server configured by `svr_cfg`
@@ -49,24 +49,24 @@ impl AutoProxyClientStream {
         server: &ServerIdent,
         addr: A,
         opts: &ConnectOpts,
-    ) -> io::Result<AutoProxyClientStream>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
         let addr = addr.into();
         if context.check_target_bypassed(&addr).await {
-            AutoProxyClientStream::connect_bypassed_with_opts(context, addr, opts).await
+            Self::connect_bypassed_with_opts(context, addr, opts).await
         } else {
-            AutoProxyClientStream::connect_proxied_with_opts(context, server, addr, opts).await
+            Self::connect_proxied_with_opts(context, server, addr, opts).await
         }
     }
 
     /// Connect directly to target `addr`
-    pub async fn connect_bypassed<A>(context: Arc<ServiceContext>, addr: A) -> io::Result<AutoProxyClientStream>
+    pub async fn connect_bypassed<A>(context: Arc<ServiceContext>, addr: A) -> io::Result<Self>
     where
         A: Into<Address>,
     {
-        AutoProxyClientStream::connect_bypassed_with_opts(context.clone(), addr, context.connect_opts_ref()).await
+        Self::connect_bypassed_with_opts(context.clone(), addr, context.connect_opts_ref()).await
     }
 
     /// Connect directly to target `addr`
@@ -74,7 +74,7 @@ impl AutoProxyClientStream {
         context: Arc<ServiceContext>,
         addr: A,
         connect_opts: &ConnectOpts,
-    ) -> io::Result<AutoProxyClientStream>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
@@ -86,7 +86,7 @@ impl AutoProxyClientStream {
             addr = mapped_addr;
         }
         let stream = TcpStream::connect_remote_with_opts(context.context_ref(), &addr, connect_opts).await?;
-        Ok(AutoProxyClientStream::Bypassed(stream))
+        Ok(Self::Bypassed(stream))
     }
 
     /// Connect to target `addr` via shadowsocks' server configured by `svr_cfg`
@@ -94,11 +94,11 @@ impl AutoProxyClientStream {
         context: Arc<ServiceContext>,
         server: &ServerIdent,
         addr: A,
-    ) -> io::Result<AutoProxyClientStream>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
-        AutoProxyClientStream::connect_proxied_with_opts(context.clone(), server, addr, context.connect_opts_ref())
+        Self::connect_proxied_with_opts(context.clone(), server, addr, context.connect_opts_ref())
             .await
     }
 
@@ -108,7 +108,7 @@ impl AutoProxyClientStream {
         server: &ServerIdent,
         addr: A,
         connect_opts: &ConnectOpts,
-    ) -> io::Result<AutoProxyClientStream>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
@@ -134,27 +134,27 @@ impl AutoProxyClientStream {
                 return Err(err);
             }
         };
-        Ok(AutoProxyClientStream::Proxied(stream))
+        Ok(Self::Proxied(stream))
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match *self {
-            AutoProxyClientStream::Proxied(ref s) => s.get_ref().get_ref().local_addr(),
-            AutoProxyClientStream::Bypassed(ref s) => s.local_addr(),
+            Self::Proxied(ref s) => s.get_ref().get_ref().local_addr(),
+            Self::Bypassed(ref s) => s.local_addr(),
         }
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         match *self {
-            AutoProxyClientStream::Proxied(ref s) => s.get_ref().get_ref().set_nodelay(nodelay),
-            AutoProxyClientStream::Bypassed(ref s) => s.set_nodelay(nodelay),
+            Self::Proxied(ref s) => s.get_ref().get_ref().set_nodelay(nodelay),
+            Self::Bypassed(ref s) => s.set_nodelay(nodelay),
         }
     }
 }
 
 impl AutoProxyIo for AutoProxyClientStream {
     fn is_proxied(&self) -> bool {
-        matches!(*self, AutoProxyClientStream::Proxied(..))
+        matches!(*self, Self::Proxied(..))
     }
 }
 
@@ -203,6 +203,6 @@ impl AsyncWrite for AutoProxyClientStream {
 
 impl From<ProxyClientStream<MonProxyStream<TcpStream>>> for AutoProxyClientStream {
     fn from(s: ProxyClientStream<MonProxyStream<TcpStream>>) -> Self {
-        AutoProxyClientStream::Proxied(s)
+        Self::Proxied(s)
     }
 }

--- a/crates/shadowsocks-service/src/local/net/udp/association.rs
+++ b/crates/shadowsocks-service/src/local/net/udp/association.rs
@@ -68,7 +68,7 @@ where
         time_to_live: Option<Duration>,
         capacity: Option<usize>,
         balancer: PingBalancer,
-    ) -> (UdpAssociationManager<W>, Duration, mpsc::Receiver<SocketAddr>) {
+    ) -> (Self, Duration, mpsc::Receiver<SocketAddr>) {
         let time_to_live = time_to_live.unwrap_or(crate::DEFAULT_UDP_EXPIRY_DURATION);
         let assoc_map = match capacity {
             Some(capacity) => LruCache::with_expiry_duration_and_capacity(time_to_live, capacity),
@@ -78,7 +78,7 @@ where
         let (keepalive_tx, keepalive_rx) = mpsc::channel(UDP_ASSOCIATION_KEEP_ALIVE_CHANNEL_SIZE);
 
         (
-            UdpAssociationManager {
+            Self {
                 respond_writer,
                 context,
                 assoc_map,
@@ -162,7 +162,7 @@ where
         balancer: PingBalancer,
         respond_writer: W,
         server_session_expire_duration: Duration,
-    ) -> UdpAssociation<W> {
+    ) -> Self {
         let (assoc_handle, sender) = UdpAssociationContext::create(
             context,
             peer_addr,
@@ -171,7 +171,7 @@ where
             respond_writer,
             server_session_expire_duration,
         );
-        UdpAssociation {
+        Self {
             assoc_handle,
             sender,
             writer: PhantomData,
@@ -198,8 +198,8 @@ struct ServerSessionContext {
 }
 
 impl ServerSessionContext {
-    fn new(session_expire_duration: Duration) -> ServerSessionContext {
-        ServerSessionContext {
+    fn new(session_expire_duration: Duration) -> Self {
+        Self {
             server_session_map: LruCache::with_expiry_duration(session_expire_duration),
         }
     }
@@ -265,7 +265,7 @@ where
         // being OOM.
         let (sender, receiver) = mpsc::channel(UDP_ASSOCIATION_SEND_CHANNEL_SIZE);
 
-        let mut assoc = UdpAssociationContext {
+        let mut assoc = Self {
             context,
             peer_addr,
             bypassed_ipv4_socket: None,

--- a/crates/shadowsocks-service/src/local/online_config/content_encoding.rs
+++ b/crates/shadowsocks-service/src/local/online_config/content_encoding.rs
@@ -26,15 +26,15 @@ impl<'a> TryFrom<&'a HeaderValue> for ContentEncoding {
 
     fn try_from(value: &'a HeaderValue) -> Result<Self, Self::Error> {
         if value == HeaderValue::from_static("identity") {
-            Ok(ContentEncoding::Identity)
+            Ok(Self::Identity)
         } else if value == HeaderValue::from_static("deflate") {
-            Ok(ContentEncoding::Deflate)
+            Ok(Self::Deflate)
         } else if value == HeaderValue::from_static("gzip") {
-            Ok(ContentEncoding::Gzip)
+            Ok(Self::Gzip)
         } else if value == HeaderValue::from_static("br") {
-            Ok(ContentEncoding::Br)
+            Ok(Self::Br)
         } else if value == HeaderValue::from_static("zstd") {
-            Ok(ContentEncoding::Zstd)
+            Ok(Self::Zstd)
         } else {
             Err(ContentEncodingError)
         }

--- a/crates/shadowsocks-service/src/local/online_config/mod.rs
+++ b/crates/shadowsocks-service/src/local/online_config/mod.rs
@@ -35,8 +35,8 @@ pub struct OnlineConfigServiceBuilder {
 
 impl OnlineConfigServiceBuilder {
     /// Create a Builder
-    pub fn new(context: Arc<ServiceContext>, config_url: String, balancer: PingBalancer) -> OnlineConfigServiceBuilder {
-        OnlineConfigServiceBuilder {
+    pub fn new(context: Arc<ServiceContext>, config_url: String, balancer: PingBalancer) -> Self {
+        Self {
             context,
             config_url,
             balancer,

--- a/crates/shadowsocks-service/src/local/redir/server.rs
+++ b/crates/shadowsocks-service/src/local/redir/server.rs
@@ -27,14 +27,14 @@ pub struct RedirBuilder {
 
 impl RedirBuilder {
     /// Create a new transparent proxy server with default configuration
-    pub fn new(client_addr: ServerAddr, balancer: PingBalancer) -> RedirBuilder {
+    pub fn new(client_addr: ServerAddr, balancer: PingBalancer) -> Self {
         let context = ServiceContext::new();
-        RedirBuilder::with_context(Arc::new(context), client_addr, balancer)
+        Self::with_context(Arc::new(context), client_addr, balancer)
     }
 
     /// Create a new transparent proxy server with context
-    pub fn with_context(context: Arc<ServiceContext>, client_addr: ServerAddr, balancer: PingBalancer) -> RedirBuilder {
-        RedirBuilder {
+    pub fn with_context(context: Arc<ServiceContext>, client_addr: ServerAddr, balancer: PingBalancer) -> Self {
+        Self {
             context,
             mode: Mode::TcpOnly,
             udp_expiry_duration: None,

--- a/crates/shadowsocks-service/src/local/redir/tcprelay/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/tcprelay/mod.rs
@@ -86,7 +86,7 @@ impl RedirTcpServer {
         client_config: &ServerAddr,
         balancer: PingBalancer,
         redir_ty: RedirType,
-    ) -> io::Result<RedirTcpServer> {
+    ) -> io::Result<Self> {
         let listener = match *client_config {
             ServerAddr::SocketAddr(ref saddr) => {
                 TcpListener::bind_redir(redir_ty, *saddr, context.accept_opts()).await?
@@ -99,7 +99,7 @@ impl RedirTcpServer {
             }
         };
 
-        Ok(RedirTcpServer {
+        Ok(Self {
             context,
             listener,
             balancer,

--- a/crates/shadowsocks-service/src/local/redir/tcprelay/sys/unix/linux.rs
+++ b/crates/shadowsocks-service/src/local/redir/tcprelay/sys/unix/linux.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl TcpListenerRedirExt for TcpListener {
-    async fn bind_redir(ty: RedirType, addr: SocketAddr, accept_opts: AcceptOpts) -> io::Result<TcpListener> {
+    async fn bind_redir(ty: RedirType, addr: SocketAddr, accept_opts: AcceptOpts) -> io::Result<Self> {
         match ty {
             RedirType::Redirect => {
                 // REDIRECT rule doesn't need to set IP_TRANSPARENT

--- a/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/mod.rs
@@ -46,7 +46,7 @@ impl Drop for UdpRedirInboundCache {
 }
 
 impl UdpRedirInboundCache {
-    fn new() -> UdpRedirInboundCache {
+    fn new() -> Self {
         let cache = Arc::new(Mutex::new(LruCache::with_expiry_duration_and_capacity(
             INBOUND_SOCKET_CACHE_EXPIRATION,
             INBOUND_SOCKET_CACHE_CAPACITY,
@@ -62,7 +62,7 @@ impl UdpRedirInboundCache {
             })
         };
 
-        UdpRedirInboundCache { cache, watcher }
+        Self { cache, watcher }
     }
 }
 
@@ -75,8 +75,8 @@ struct UdpRedirInboundWriter {
 
 impl UdpRedirInboundWriter {
     #[allow(unused_variables, clippy::needless_update)]
-    fn new(redir_ty: RedirType, opts: &ConnectOpts) -> UdpRedirInboundWriter {
-        UdpRedirInboundWriter {
+    fn new(redir_ty: RedirType, opts: &ConnectOpts) -> Self {
+        Self {
             redir_ty,
             socket_opts: RedirSocketOpts {
                 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -212,7 +212,7 @@ impl RedirUdpServer {
         time_to_live: Option<Duration>,
         capacity: Option<usize>,
         balancer: PingBalancer,
-    ) -> io::Result<RedirUdpServer> {
+    ) -> io::Result<Self> {
         let listener = match *client_config {
             ServerAddr::SocketAddr(ref saddr) => UdpRedirSocket::listen(redir_ty, *saddr)?,
             ServerAddr::DomainName(ref dname, port) => {
@@ -223,7 +223,7 @@ impl RedirUdpServer {
             }
         };
 
-        Ok(RedirUdpServer {
+        Ok(Self {
             context,
             redir_ty,
             time_to_live,

--- a/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/linux.rs
+++ b/crates/shadowsocks-service/src/local/redir/udprelay/sys/unix/linux.rs
@@ -30,15 +30,15 @@ impl UdpRedirSocket {
     /// Create a new UDP socket binded to `addr`
     ///
     /// This will allow listening to `addr` that is not in local host
-    pub fn listen(ty: RedirType, addr: SocketAddr) -> io::Result<UdpRedirSocket> {
-        UdpRedirSocket::bind(ty, addr, false)
+    pub fn listen(ty: RedirType, addr: SocketAddr) -> io::Result<Self> {
+        Self::bind(ty, addr, false)
     }
 
     /// Create a new UDP socket binded to `addr`
     ///
     /// This will allow binding to `addr` that is not in local host
-    pub fn bind_nonlocal(ty: RedirType, addr: SocketAddr, redir_opts: &RedirSocketOpts) -> io::Result<UdpRedirSocket> {
-        let socket = UdpRedirSocket::bind(ty, addr, true)?;
+    pub fn bind_nonlocal(ty: RedirType, addr: SocketAddr, redir_opts: &RedirSocketOpts) -> io::Result<Self> {
+        let socket = Self::bind(ty, addr, true)?;
 
         if let Some(mark) = redir_opts.fwmark {
             let ret = unsafe {
@@ -58,7 +58,7 @@ impl UdpRedirSocket {
         Ok(socket)
     }
 
-    fn bind(ty: RedirType, addr: SocketAddr, reuse_port: bool) -> io::Result<UdpRedirSocket> {
+    fn bind(ty: RedirType, addr: SocketAddr, reuse_port: bool) -> io::Result<Self> {
         if ty != RedirType::TProxy {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
@@ -123,7 +123,7 @@ impl UdpRedirSocket {
         }
 
         let io = AsyncFd::new(socket.into())?;
-        Ok(UdpRedirSocket { io })
+        Ok(Self { io })
     }
 
     /// Send data to the socket to the given target address

--- a/crates/shadowsocks-service/src/local/socks/client/socks4/tcp_client.rs
+++ b/crates/shadowsocks-service/src/local/socks/client/socks4/tcp_client.rs
@@ -24,7 +24,7 @@ pub struct Socks4TcpClient {
 
 impl Socks4TcpClient {
     /// Connects to `addr` via `proxy`
-    pub async fn connect<A, P, U>(addr: A, proxy: P, user_id: U) -> Result<Socks4TcpClient, Error>
+    pub async fn connect<A, P, U>(addr: A, proxy: P, user_id: U) -> Result<Self, Error>
     where
         A: Into<Address>,
         P: ToSocketAddrs,
@@ -51,7 +51,7 @@ impl Socks4TcpClient {
             return Err(Error::Result(hsp.cd));
         }
 
-        Ok(Socks4TcpClient { stream: s })
+        Ok(Self { stream: s })
     }
 }
 

--- a/crates/shadowsocks-service/src/local/socks/client/socks5/tcp_client.rs
+++ b/crates/shadowsocks-service/src/local/socks/client/socks5/tcp_client.rs
@@ -25,7 +25,7 @@ pub struct Socks5TcpClient {
 
 impl Socks5TcpClient {
     /// Connects to `addr` via `proxy`
-    pub async fn connect<A, P>(addr: A, proxy: P) -> Result<Socks5TcpClient, Error>
+    pub async fn connect<A, P>(addr: A, proxy: P) -> Result<Self, Error>
     where
         A: Into<Address>,
         P: ToSocketAddrs,
@@ -56,13 +56,13 @@ impl Socks5TcpClient {
             r => return Err(Error::Reply(r)),
         }
 
-        Ok(Socks5TcpClient { stream: s })
+        Ok(Self { stream: s })
     }
 
     /// UDP Associate `addr` via `proxy`
     ///
     /// According to RFC, `addr` is the address that your UDP socket binds to
-    pub async fn udp_associate<A, P>(addr: A, proxy: P) -> Result<(Socks5TcpClient, Address), Error>
+    pub async fn udp_associate<A, P>(addr: A, proxy: P) -> Result<(Self, Address), Error>
     where
         A: Into<Address>,
         P: ToSocketAddrs,
@@ -93,7 +93,7 @@ impl Socks5TcpClient {
             r => return Err(Error::Reply(r)),
         }
 
-        Ok((Socks5TcpClient { stream: s }, hp.address))
+        Ok((Self { stream: s }, hp.address))
     }
 }
 

--- a/crates/shadowsocks-service/src/local/socks/client/socks5/udp_client.rs
+++ b/crates/shadowsocks-service/src/local/socks/client/socks5/udp_client.rs
@@ -20,11 +20,11 @@ pub struct Socks5UdpClient {
 
 impl Socks5UdpClient {
     /// Create a new UDP associate client binds to a specific address
-    pub async fn bind<A>(addrs: A) -> io::Result<Socks5UdpClient>
+    pub async fn bind<A>(addrs: A) -> io::Result<Self>
     where
         A: ToSocketAddrs,
     {
-        Ok(Socks5UdpClient {
+        Ok(Self {
             socket: UdpSocket::bind(addrs).await?,
             assoc_client: None,
         })

--- a/crates/shadowsocks-service/src/local/socks/config.rs
+++ b/crates/shadowsocks-service/src/local/socks/config.rs
@@ -35,8 +35,8 @@ pub struct Socks5AuthConfig {
 
 impl Socks5AuthConfig {
     /// Create a new SOCKS5 Authentication configuration
-    pub fn new() -> Socks5AuthConfig {
-        Socks5AuthConfig {
+    pub fn new() -> Self {
+        Self {
             passwd: Socks5AuthPasswdConfig::new(),
         }
     }
@@ -54,7 +54,7 @@ impl Socks5AuthConfig {
     ///         ]
     ///      }
     /// }
-    pub fn load_from_file<P: AsRef<Path> + ?Sized>(filename: &P) -> io::Result<Socks5AuthConfig> {
+    pub fn load_from_file<P: AsRef<Path> + ?Sized>(filename: &P) -> io::Result<Self> {
         let filename = filename.as_ref();
 
         trace!(
@@ -78,7 +78,7 @@ impl Socks5AuthConfig {
             }
         }
 
-        Ok(Socks5AuthConfig { passwd })
+        Ok(Self { passwd })
     }
 
     /// Check if authentication is required
@@ -88,8 +88,8 @@ impl Socks5AuthConfig {
 }
 
 impl Default for Socks5AuthConfig {
-    fn default() -> Socks5AuthConfig {
-        Socks5AuthConfig::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -103,8 +103,8 @@ pub struct Socks5AuthPasswdConfig {
 
 impl Socks5AuthPasswdConfig {
     /// Create an empty `Passwd` configuration
-    pub fn new() -> Socks5AuthPasswdConfig {
-        Socks5AuthPasswdConfig { passwd: HashMap::new() }
+    pub fn new() -> Self {
+        Self { passwd: HashMap::new() }
     }
 
     /// Add a user with password
@@ -135,7 +135,7 @@ impl Socks5AuthPasswdConfig {
 }
 
 impl Default for Socks5AuthPasswdConfig {
-    fn default() -> Socks5AuthPasswdConfig {
-        Socks5AuthPasswdConfig::new()
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/shadowsocks-service/src/local/socks/server/mod.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/mod.rs
@@ -37,9 +37,9 @@ pub struct SocksBuilder {
 
 impl SocksBuilder {
     /// Create a new SOCKS server with default configuration
-    pub fn new(client_config: ServerAddr, balancer: PingBalancer) -> SocksBuilder {
+    pub fn new(client_config: ServerAddr, balancer: PingBalancer) -> Self {
         let context = ServiceContext::new();
-        SocksBuilder::with_context(Arc::new(context), client_config, balancer)
+        Self::with_context(Arc::new(context), client_config, balancer)
     }
 
     /// Create a new SOCKS server with context
@@ -47,8 +47,8 @@ impl SocksBuilder {
         context: Arc<ServiceContext>,
         client_config: ServerAddr,
         balancer: PingBalancer,
-    ) -> SocksBuilder {
-        SocksBuilder {
+    ) -> Self {
+        Self {
             context,
             mode: Mode::TcpOnly,
             udp_expiry_duration: None,

--- a/crates/shadowsocks-service/src/local/socks/server/server.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/server.rs
@@ -34,8 +34,8 @@ impl SocksTcpServerBuilder {
         balancer: PingBalancer,
         mode: Mode,
         socks5_auth: Socks5AuthConfig,
-    ) -> SocksTcpServerBuilder {
-        SocksTcpServerBuilder {
+    ) -> Self {
+        Self {
             context,
             client_config,
             udp_associate_addr,

--- a/crates/shadowsocks-service/src/local/socks/server/socks4/tcprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks4/tcprelay.rs
@@ -31,8 +31,8 @@ pub struct Socks4TcpHandler {
 }
 
 impl Socks4TcpHandler {
-    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer, mode: Mode) -> Socks4TcpHandler {
-        Socks4TcpHandler {
+    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer, mode: Mode) -> Self {
+        Self {
             context,
             balancer,
             mode,

--- a/crates/shadowsocks-service/src/local/socks/server/socks5/tcprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks5/tcprelay.rs
@@ -44,8 +44,8 @@ impl Socks5TcpHandler {
         balancer: PingBalancer,
         mode: Mode,
         auth: Arc<Socks5AuthConfig>,
-    ) -> Socks5TcpHandler {
-        Socks5TcpHandler {
+    ) -> Self {
+        Self {
             context,
             udp_associate_addr,
             balancer,

--- a/crates/shadowsocks-service/src/local/socks/server/socks5/udprelay.rs
+++ b/crates/shadowsocks-service/src/local/socks/server/socks5/udprelay.rs
@@ -45,8 +45,8 @@ impl Socks5UdpServerBuilder {
         time_to_live: Option<Duration>,
         capacity: Option<usize>,
         balancer: PingBalancer,
-    ) -> Socks5UdpServerBuilder {
-        Socks5UdpServerBuilder {
+    ) -> Self {
+        Self {
             context,
             client_config,
             time_to_live,

--- a/crates/shadowsocks-service/src/local/socks/socks4.rs
+++ b/crates/shadowsocks-service/src/local/socks/socks4.rs
@@ -43,16 +43,16 @@ impl Command {
     #[inline]
     fn as_u8(self) -> u8 {
         match self {
-            Command::Connect => consts::SOCKS4_COMMAND_CONNECT,
-            Command::Bind => consts::SOCKS4_COMMAND_BIND,
+            Self::Connect => consts::SOCKS4_COMMAND_CONNECT,
+            Self::Bind => consts::SOCKS4_COMMAND_BIND,
         }
     }
 
     #[inline]
-    fn from_u8(code: u8) -> Option<Command> {
+    fn from_u8(code: u8) -> Option<Self> {
         match code {
-            consts::SOCKS4_COMMAND_CONNECT => Some(Command::Connect),
-            consts::SOCKS4_COMMAND_BIND => Some(Command::Bind),
+            consts::SOCKS4_COMMAND_CONNECT => Some(Self::Connect),
+            consts::SOCKS4_COMMAND_BIND => Some(Self::Bind),
             _ => None,
         }
     }
@@ -77,22 +77,22 @@ impl ResultCode {
     #[inline]
     fn as_u8(self) -> u8 {
         match self {
-            ResultCode::RequestGranted => consts::SOCKS4_RESULT_REQUEST_GRANTED,
-            ResultCode::RequestRejectedOrFailed => consts::SOCKS4_RESULT_REQUEST_REJECTED_OR_FAILED,
-            ResultCode::RequestRejectedCannotConnect => consts::SOCKS4_RESULT_REQUEST_REJECTED_CANNOT_CONNECT,
-            ResultCode::RequestRejectedDifferentUserId => consts::SOCKS4_RESULT_REQUEST_REJECTED_DIFFERENT_USER_ID,
-            ResultCode::Other(c) => c,
+            Self::RequestGranted => consts::SOCKS4_RESULT_REQUEST_GRANTED,
+            Self::RequestRejectedOrFailed => consts::SOCKS4_RESULT_REQUEST_REJECTED_OR_FAILED,
+            Self::RequestRejectedCannotConnect => consts::SOCKS4_RESULT_REQUEST_REJECTED_CANNOT_CONNECT,
+            Self::RequestRejectedDifferentUserId => consts::SOCKS4_RESULT_REQUEST_REJECTED_DIFFERENT_USER_ID,
+            Self::Other(c) => c,
         }
     }
 
     #[inline]
-    fn from_u8(code: u8) -> ResultCode {
+    fn from_u8(code: u8) -> Self {
         match code {
-            consts::SOCKS4_RESULT_REQUEST_GRANTED => ResultCode::RequestGranted,
-            consts::SOCKS4_RESULT_REQUEST_REJECTED_OR_FAILED => ResultCode::RequestRejectedOrFailed,
-            consts::SOCKS4_RESULT_REQUEST_REJECTED_CANNOT_CONNECT => ResultCode::RequestRejectedCannotConnect,
-            consts::SOCKS4_RESULT_REQUEST_REJECTED_DIFFERENT_USER_ID => ResultCode::RequestRejectedDifferentUserId,
-            code => ResultCode::Other(code),
+            consts::SOCKS4_RESULT_REQUEST_GRANTED => Self::RequestGranted,
+            consts::SOCKS4_RESULT_REQUEST_REJECTED_OR_FAILED => Self::RequestRejectedOrFailed,
+            consts::SOCKS4_RESULT_REQUEST_REJECTED_CANNOT_CONNECT => Self::RequestRejectedCannotConnect,
+            consts::SOCKS4_RESULT_REQUEST_REJECTED_DIFFERENT_USER_ID => Self::RequestRejectedDifferentUserId,
+            code => Self::Other(code),
         }
     }
 }
@@ -100,15 +100,15 @@ impl ResultCode {
 impl fmt::Display for ResultCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            ResultCode::RequestGranted => f.write_str("request granted"),
-            ResultCode::RequestRejectedOrFailed => f.write_str("request rejected or failed"),
-            ResultCode::RequestRejectedCannotConnect => {
+            Self::RequestGranted => f.write_str("request granted"),
+            Self::RequestRejectedOrFailed => f.write_str("request rejected or failed"),
+            Self::RequestRejectedCannotConnect => {
                 f.write_str("request rejected because SOCKS server cannot connect to identd on the client")
             }
-            ResultCode::RequestRejectedDifferentUserId => {
+            Self::RequestRejectedDifferentUserId => {
                 f.write_str("request rejected because the client program and identd report different user-ids")
             }
-            ResultCode::Other(code) => write!(f, "other result code {code}"),
+            Self::Other(code) => write!(f, "other result code {code}"),
         }
     }
 }
@@ -126,8 +126,8 @@ impl fmt::Debug for Address {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Address::SocketAddress(ref addr) => write!(f, "{addr}"),
-            Address::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
+            Self::SocketAddress(ref addr) => write!(f, "{addr}"),
+            Self::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
         }
     }
 }
@@ -136,41 +136,41 @@ impl fmt::Display for Address {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Address::SocketAddress(ref addr) => write!(f, "{addr}"),
-            Address::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
+            Self::SocketAddress(ref addr) => write!(f, "{addr}"),
+            Self::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
         }
     }
 }
 
 impl From<SocketAddrV4> for Address {
-    fn from(s: SocketAddrV4) -> Address {
-        Address::SocketAddress(s)
+    fn from(s: SocketAddrV4) -> Self {
+        Self::SocketAddress(s)
     }
 }
 
 impl From<(String, u16)> for Address {
-    fn from((dn, port): (String, u16)) -> Address {
-        Address::DomainNameAddress(dn, port)
+    fn from((dn, port): (String, u16)) -> Self {
+        Self::DomainNameAddress(dn, port)
     }
 }
 
 impl From<(&str, u16)> for Address {
-    fn from((dn, port): (&str, u16)) -> Address {
-        Address::DomainNameAddress(dn.to_owned(), port)
+    fn from((dn, port): (&str, u16)) -> Self {
+        Self::DomainNameAddress(dn.to_owned(), port)
     }
 }
 
-impl From<&Address> for Address {
-    fn from(addr: &Address) -> Address {
+impl From<&Self> for Address {
+    fn from(addr: &Self) -> Self {
         addr.clone()
     }
 }
 
 impl From<Address> for socks5::Address {
-    fn from(addr: Address) -> socks5::Address {
+    fn from(addr: Address) -> Self {
         match addr {
-            Address::SocketAddress(a) => socks5::Address::SocketAddress(SocketAddr::V4(a)),
-            Address::DomainNameAddress(d, p) => socks5::Address::DomainNameAddress(d, p),
+            Address::SocketAddress(a) => Self::SocketAddress(SocketAddr::V4(a)),
+            Address::DomainNameAddress(d, p) => Self::DomainNameAddress(d, p),
         }
     }
 }
@@ -201,7 +201,7 @@ pub struct HandshakeRequest {
 
 impl HandshakeRequest {
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<HandshakeRequest, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncBufRead + Unpin,
     {
@@ -250,7 +250,7 @@ impl HandshakeRequest {
             Address::SocketAddress(SocketAddrV4::new(ip, port))
         };
 
-        Ok(HandshakeRequest {
+        Ok(Self {
             cd: command,
             dst,
             user_id,
@@ -327,12 +327,12 @@ pub struct HandshakeResponse {
 
 impl HandshakeResponse {
     /// Create a response with code
-    pub fn new(code: ResultCode) -> HandshakeResponse {
-        HandshakeResponse { cd: code }
+    pub fn new(code: ResultCode) -> Self {
+        Self { cd: code }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<HandshakeResponse, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -349,7 +349,7 @@ impl HandshakeResponse {
 
         // DSTPORT, DSTIP are ignored
 
-        Ok(HandshakeResponse { cd: result_code })
+        Ok(Self { cd: result_code })
     }
 
     /// Write data into a writer
@@ -364,7 +364,7 @@ impl HandshakeResponse {
 
     /// Writes to buffer
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
-        let HandshakeResponse { ref cd } = *self;
+        let Self { ref cd } = *self;
 
         buf.put_slice(&[
             // VN: Result Code's version, must be 0
@@ -406,10 +406,10 @@ pub enum Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
+    fn from(err: Error) -> Self {
         match err {
             Error::IoError(err) => err,
-            e => io::Error::other(e),
+            e => Self::other(e),
         }
     }
 }

--- a/crates/shadowsocks-service/src/local/tun/ip_packet.rs
+++ b/crates/shadowsocks-service/src/local/tun/ip_packet.rs
@@ -11,32 +11,32 @@ pub enum IpPacket<T: AsRef<[u8]>> {
 }
 
 impl<T: AsRef<[u8]> + Copy> IpPacket<T> {
-    pub fn new_checked(packet: T) -> smoltcp::wire::Result<Option<IpPacket<T>>> {
+    pub fn new_checked(packet: T) -> smoltcp::wire::Result<Option<Self>> {
         let buffer = packet.as_ref();
         match IpVersion::of_packet(buffer)? {
-            IpVersion::Ipv4 => Ok(Some(IpPacket::Ipv4(Ipv4Packet::new_checked(packet)?))),
-            IpVersion::Ipv6 => Ok(Some(IpPacket::Ipv6(Ipv6Packet::new_checked(packet)?))),
+            IpVersion::Ipv4 => Ok(Some(Self::Ipv4(Ipv4Packet::new_checked(packet)?))),
+            IpVersion::Ipv6 => Ok(Some(Self::Ipv6(Ipv6Packet::new_checked(packet)?))),
         }
     }
 
     pub fn src_addr(&self) -> IpAddr {
         match *self {
-            IpPacket::Ipv4(ref packet) => IpAddr::from(packet.src_addr()),
-            IpPacket::Ipv6(ref packet) => IpAddr::from(packet.src_addr()),
+            Self::Ipv4(ref packet) => IpAddr::from(packet.src_addr()),
+            Self::Ipv6(ref packet) => IpAddr::from(packet.src_addr()),
         }
     }
 
     pub fn dst_addr(&self) -> IpAddr {
         match *self {
-            IpPacket::Ipv4(ref packet) => IpAddr::from(packet.dst_addr()),
-            IpPacket::Ipv6(ref packet) => IpAddr::from(packet.dst_addr()),
+            Self::Ipv4(ref packet) => IpAddr::from(packet.dst_addr()),
+            Self::Ipv6(ref packet) => IpAddr::from(packet.dst_addr()),
         }
     }
 
     pub fn protocol(&self) -> IpProtocol {
         match *self {
-            IpPacket::Ipv4(ref packet) => packet.next_header(),
-            IpPacket::Ipv6(ref packet) => packet.next_header(),
+            Self::Ipv4(ref packet) => packet.next_header(),
+            Self::Ipv6(ref packet) => packet.next_header(),
         }
     }
 }

--- a/crates/shadowsocks-service/src/local/tun/mod.rs
+++ b/crates/shadowsocks-service/src/local/tun/mod.rs
@@ -64,8 +64,8 @@ unsafe impl Send for TunBuilder {}
 
 impl TunBuilder {
     /// Create a Tun service builder
-    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer) -> TunBuilder {
-        TunBuilder {
+    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer) -> Self {
+        Self {
             context,
             balancer,
             tun_config: TunConfiguration::default(),

--- a/crates/shadowsocks-service/src/local/tun/tcp.rs
+++ b/crates/shadowsocks-service/src/local/tun/tcp.rs
@@ -68,8 +68,8 @@ struct ManagerNotify {
 }
 
 impl ManagerNotify {
-    fn new(thread: Thread) -> ManagerNotify {
-        ManagerNotify { thread }
+    fn new(thread: Thread) -> Self {
+        Self { thread }
     }
 
     fn notify(&self) {
@@ -119,7 +119,7 @@ impl TcpConnection {
         socket_creation_tx: &mpsc::UnboundedSender<TcpSocketCreation>,
         manager_notify: Arc<ManagerNotify>,
         tcp_opts: &TcpSocketOpts,
-    ) -> impl Future<Output = TcpConnection> + use<> {
+    ) -> impl Future<Output = Self> + use<> {
         let send_buffer_size = tcp_opts.send_buffer_size.unwrap_or(DEFAULT_TCP_SEND_BUFFER_SIZE);
         let recv_buffer_size = tcp_opts.recv_buffer_size.unwrap_or(DEFAULT_TCP_RECV_BUFFER_SIZE);
 
@@ -140,7 +140,7 @@ impl TcpConnection {
         async move {
             // waiting socket add to SocketSet
             let _ = rx.await;
-            TcpConnection {
+            Self {
                 control,
                 manager_notify,
             }
@@ -257,7 +257,7 @@ impl Drop for TcpTun {
 }
 
 impl TcpTun {
-    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer, mtu: u32) -> TcpTun {
+    pub fn new(context: Arc<ServiceContext>, balancer: PingBalancer, mtu: u32) -> Self {
         let mut capabilities = DeviceCapabilities::default();
         capabilities.medium = Medium::Ip;
         capabilities.max_transmission_unit = mtu as usize;
@@ -486,7 +486,7 @@ impl TcpTun {
 
         let manager_notify = Arc::new(ManagerNotify::new(manager_handle.thread().clone()));
 
-        TcpTun {
+        Self {
             context,
             manager_handle: Some(manager_handle),
             manager_notify,

--- a/crates/shadowsocks-service/src/local/tun/udp.rs
+++ b/crates/shadowsocks-service/src/local/tun/udp.rs
@@ -31,7 +31,7 @@ impl UdpTun {
         balancer: PingBalancer,
         time_to_live: Option<Duration>,
         capacity: Option<usize>,
-    ) -> (UdpTun, Duration, mpsc::Receiver<SocketAddr>) {
+    ) -> (Self, Duration, mpsc::Receiver<SocketAddr>) {
         let (tun_tx, tun_rx) = mpsc::channel(64);
         let (manager, cleanup_interval, keepalive_rx) = UdpAssociationManager::new(
             context,
@@ -41,7 +41,7 @@ impl UdpTun {
             balancer,
         );
 
-        (UdpTun { tun_rx, manager }, cleanup_interval, keepalive_rx)
+        (Self { tun_rx, manager }, cleanup_interval, keepalive_rx)
     }
 
     pub async fn handle_packet(
@@ -87,8 +87,8 @@ struct UdpTunInboundWriter {
 }
 
 impl UdpTunInboundWriter {
-    fn new(tun_tx: mpsc::Sender<BytesMut>) -> UdpTunInboundWriter {
-        UdpTunInboundWriter { tun_tx }
+    fn new(tun_tx: mpsc::Sender<BytesMut>) -> Self {
+        Self { tun_tx }
     }
 }
 

--- a/crates/shadowsocks-service/src/local/tun/virt_device.rs
+++ b/crates/shadowsocks-service/src/local/tun/virt_device.rs
@@ -141,13 +141,13 @@ impl Drop for TokenBuffer {
 }
 
 impl TokenBuffer {
-    pub fn with_capacity(cap: usize) -> TokenBuffer {
+    pub fn with_capacity(cap: usize) -> Self {
         let mut list = TOKEN_BUFFER_LIST.lock().unwrap();
         if let Some(mut buffer) = list.pop() {
             buffer.reserve(cap);
-            return TokenBuffer { buffer };
+            return Self { buffer };
         }
-        TokenBuffer {
+        Self {
             buffer: BytesMut::with_capacity(cap),
         }
     }

--- a/crates/shadowsocks-service/src/local/tunnel/server.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/server.rs
@@ -29,9 +29,9 @@ pub struct TunnelBuilder {
 
 impl TunnelBuilder {
     /// Create a new Tunnel server forwarding to `forward_addr`
-    pub fn new(forward_addr: Address, client_addr: ServerAddr, balancer: PingBalancer) -> TunnelBuilder {
+    pub fn new(forward_addr: Address, client_addr: ServerAddr, balancer: PingBalancer) -> Self {
         let context = ServiceContext::new();
-        TunnelBuilder::with_context(Arc::new(context), forward_addr, client_addr, balancer)
+        Self::with_context(Arc::new(context), forward_addr, client_addr, balancer)
     }
 
     /// Create a new Tunnel server with context
@@ -40,8 +40,8 @@ impl TunnelBuilder {
         forward_addr: Address,
         client_addr: ServerAddr,
         balancer: PingBalancer,
-    ) -> TunnelBuilder {
-        TunnelBuilder {
+    ) -> Self {
+        Self {
             context,
             forward_addr,
             mode: Mode::TcpOnly,

--- a/crates/shadowsocks-service/src/local/tunnel/tcprelay.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/tcprelay.rs
@@ -28,8 +28,8 @@ impl TunnelTcpServerBuilder {
         client_config: ServerAddr,
         balancer: PingBalancer,
         forward_addr: Address,
-    ) -> TunnelTcpServerBuilder {
-        TunnelTcpServerBuilder {
+    ) -> Self {
+        Self {
             context,
             client_config,
             balancer,

--- a/crates/shadowsocks-service/src/local/tunnel/udprelay.rs
+++ b/crates/shadowsocks-service/src/local/tunnel/udprelay.rs
@@ -34,8 +34,8 @@ impl TunnelUdpServerBuilder {
         capacity: Option<usize>,
         balancer: PingBalancer,
         forward_addr: Address,
-    ) -> TunnelUdpServerBuilder {
-        TunnelUdpServerBuilder {
+    ) -> Self {
+        Self {
             context,
             client_config,
             time_to_live,

--- a/crates/shadowsocks-service/src/manager/server.rs
+++ b/crates/shadowsocks-service/src/manager/server.rs
@@ -79,13 +79,13 @@ pub struct ManagerBuilder {
 
 impl ManagerBuilder {
     /// Create a new manager server builder from configuration
-    pub fn new(svr_cfg: ManagerConfig) -> ManagerBuilder {
-        ManagerBuilder::with_context(svr_cfg, Context::new_shared(ServerType::Server))
+    pub fn new(svr_cfg: ManagerConfig) -> Self {
+        Self::with_context(svr_cfg, Context::new_shared(ServerType::Server))
     }
 
     /// Create a new manager server builder with context and configuration
-    pub(crate) fn with_context(svr_cfg: ManagerConfig, context: SharedContext) -> ManagerBuilder {
-        ManagerBuilder {
+    pub(crate) fn with_context(svr_cfg: ManagerConfig, context: SharedContext) -> Self {
+        Self {
             context,
             svr_cfg,
             connect_opts: ConnectOpts::default(),

--- a/crates/shadowsocks-service/src/net/flow.rs
+++ b/crates/shadowsocks-service/src/net/flow.rs
@@ -15,7 +15,7 @@ pub struct FlowStat {
 
 impl Default for FlowStat {
     fn default() -> Self {
-        FlowStat {
+        Self {
             tx: FlowCounter::new(0),
             rx: FlowCounter::new(0),
         }
@@ -24,8 +24,8 @@ impl Default for FlowStat {
 
 impl FlowStat {
     /// Create an empty flow statistic
-    pub fn new() -> FlowStat {
-        FlowStat::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Transmitted bytes count

--- a/crates/shadowsocks-service/src/net/mon_socket.rs
+++ b/crates/shadowsocks-service/src/net/mon_socket.rs
@@ -20,8 +20,8 @@ pub struct MonProxySocket<S> {
 
 impl<S> MonProxySocket<S> {
     /// Create a new socket with flow monitor
-    pub fn from_socket(socket: ProxySocket<S>, flow_stat: Arc<FlowStat>) -> MonProxySocket<S> {
-        MonProxySocket { socket, flow_stat }
+    pub fn from_socket(socket: ProxySocket<S>, flow_stat: Arc<FlowStat>) -> Self {
+        Self { socket, flow_stat }
     }
 
     /// Get the underlying `ProxySocket<S>` immutable reference

--- a/crates/shadowsocks-service/src/net/mon_stream.rs
+++ b/crates/shadowsocks-service/src/net/mon_stream.rs
@@ -22,8 +22,8 @@ pub struct MonProxyStream<S> {
 
 impl<S> MonProxyStream<S> {
     #[inline]
-    pub fn from_stream(stream: S, flow_stat: Arc<FlowStat>) -> MonProxyStream<S> {
-        MonProxyStream { stream, flow_stat }
+    pub fn from_stream(stream: S, flow_stat: Arc<FlowStat>) -> Self {
+        Self { stream, flow_stat }
     }
 
     #[inline]

--- a/crates/shadowsocks-service/src/net/packet_window.rs
+++ b/crates/shadowsocks-service/src/net/packet_window.rs
@@ -21,15 +21,15 @@ pub struct PacketWindowFilter {
 }
 
 impl Default for PacketWindowFilter {
-    fn default() -> PacketWindowFilter {
-        PacketWindowFilter::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl PacketWindowFilter {
     /// Create an empty filter
-    pub fn new() -> PacketWindowFilter {
-        PacketWindowFilter {
+    pub fn new() -> Self {
+        Self {
             last_packet_id: 0,
             packet_ring: [0u64; RING_BLOCKS as usize],
         }

--- a/crates/shadowsocks-service/src/server/context.rs
+++ b/crates/shadowsocks-service/src/server/context.rs
@@ -27,7 +27,7 @@ pub struct ServiceContext {
 
 impl Default for ServiceContext {
     fn default() -> Self {
-        ServiceContext {
+        Self {
             context: Context::new_shared(ServerType::Server),
             connect_opts: ConnectOpts::default(),
             acl: None,
@@ -38,8 +38,8 @@ impl Default for ServiceContext {
 
 impl ServiceContext {
     /// Create a new `ServiceContext`
-    pub fn new() -> ServiceContext {
-        ServiceContext::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Get cloned `shadowsocks` Context

--- a/crates/shadowsocks-service/src/server/server.rs
+++ b/crates/shadowsocks-service/src/server/server.rs
@@ -34,13 +34,13 @@ pub struct ServerBuilder {
 
 impl ServerBuilder {
     /// Create a new server builder from configuration
-    pub fn new(svr_cfg: ServerConfig) -> ServerBuilder {
-        ServerBuilder::with_context(ServiceContext::new(), svr_cfg)
+    pub fn new(svr_cfg: ServerConfig) -> Self {
+        Self::with_context(ServiceContext::new(), svr_cfg)
     }
 
     /// Create a new server builder with context
-    fn with_context(context: ServiceContext, svr_cfg: ServerConfig) -> ServerBuilder {
-        ServerBuilder {
+    fn with_context(context: ServiceContext, svr_cfg: ServerConfig) -> Self {
+        Self {
             context,
             svr_cfg,
             udp_expiry_duration: None,

--- a/crates/shadowsocks-service/src/server/tcprelay.rs
+++ b/crates/shadowsocks-service/src/server/tcprelay.rs
@@ -37,9 +37,9 @@ impl TcpServer {
         context: Arc<ServiceContext>,
         svr_cfg: ServerConfig,
         accept_opts: AcceptOpts,
-    ) -> io::Result<TcpServer> {
+    ) -> io::Result<Self> {
         let listener = ProxyListener::bind_with_opts(context.context(), &svr_cfg, accept_opts).await?;
-        Ok(TcpServer {
+        Ok(Self {
             context,
             svr_cfg,
             listener,

--- a/crates/shadowsocks/src/context.rs
+++ b/crates/shadowsocks/src/context.rs
@@ -33,8 +33,8 @@ pub type SharedContext = Arc<Context>;
 
 impl Context {
     /// Create a new `Context` for `Client` or `Server`
-    pub fn new(config_type: ServerType) -> Context {
-        Context {
+    pub fn new(config_type: ServerType) -> Self {
+        Self {
             replay_protector: ReplayProtector::new(config_type),
             replay_policy: ReplayAttackPolicy::Default,
             dns_resolver: Arc::new(DnsResolver::system_resolver()),
@@ -44,7 +44,7 @@ impl Context {
 
     /// Create a new `Context` shared
     pub fn new_shared(config_type: ServerType) -> SharedContext {
-        SharedContext::new(Context::new(config_type))
+        SharedContext::new(Self::new(config_type))
     }
 
     /// Check if nonce exist or not

--- a/crates/shadowsocks/src/dns_resolver/hickory_dns_resolver.rs
+++ b/crates/shadowsocks/src/dns_resolver/hickory_dns_resolver.rs
@@ -33,8 +33,8 @@ pub struct ShadowDnsRuntimeProvider {
 }
 
 impl ShadowDnsRuntimeProvider {
-    fn new(connect_opts: ConnectOpts) -> ShadowDnsRuntimeProvider {
-        ShadowDnsRuntimeProvider {
+    fn new(connect_opts: ConnectOpts) -> Self {
+        Self {
             handle: TokioHandle::default(),
             connect_opts,
         }

--- a/crates/shadowsocks/src/manager/client.rs
+++ b/crates/shadowsocks/src/manager/client.rs
@@ -41,10 +41,10 @@ impl ManagerClient {
         context: &Context,
         bind_addr: &ManagerAddr,
         connect_opts: &ConnectOpts,
-    ) -> Result<ManagerClient, Error> {
+    ) -> Result<Self, Error> {
         ManagerDatagram::connect(context, bind_addr, connect_opts)
             .await
-            .map(|socket| ManagerClient { socket })
+            .map(|socket| Self { socket })
             .map_err(Into::into)
     }
 

--- a/crates/shadowsocks/src/manager/error.rs
+++ b/crates/shadowsocks/src/manager/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(e: Error) -> io::Error {
+    fn from(e: Error) -> Self {
         match e {
             Error::IoError(e) => e,
             Error::ProtocolError(e) => From::from(e),

--- a/crates/shadowsocks/src/manager/listener.rs
+++ b/crates/shadowsocks/src/manager/listener.rs
@@ -20,10 +20,10 @@ pub struct ManagerListener {
 
 impl ManagerListener {
     /// Create a `ManagerDatagram` binding to requested `bind_addr`
-    pub async fn bind(context: &Context, bind_addr: &ManagerAddr) -> io::Result<ManagerListener> {
+    pub async fn bind(context: &Context, bind_addr: &ManagerAddr) -> io::Result<Self> {
         ManagerDatagram::bind(context, bind_addr)
             .await
-            .map(|socket| ManagerListener { socket })
+            .map(|socket| Self { socket })
     }
 
     pub async fn recv_from(&mut self) -> Result<(ManagerRequest, ManagerSocketAddr), Error> {

--- a/crates/shadowsocks/src/manager/protocol.rs
+++ b/crates/shadowsocks/src/manager/protocol.rs
@@ -80,7 +80,7 @@ pub struct AddResponse(pub String);
 
 impl ManagerProtocol for AddResponse {
     fn from_bytes(buf: &[u8]) -> Result<Self, Error> {
-        Ok(AddResponse(str::from_utf8(buf)?.trim().to_owned()))
+        Ok(Self(str::from_utf8(buf)?.trim().to_owned()))
     }
 
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
@@ -129,7 +129,7 @@ pub struct RemoveResponse(pub String);
 
 impl ManagerProtocol for RemoveResponse {
     fn from_bytes(buf: &[u8]) -> Result<Self, Error> {
-        Ok(RemoveResponse(str::from_utf8(buf)?.trim().to_owned()))
+        Ok(Self(str::from_utf8(buf)?.trim().to_owned()))
     }
 
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
@@ -150,7 +150,7 @@ impl ManagerProtocol for ListRequest {
             return Err(Error::UnrecognizedCommand(cmd.to_owned()));
         }
 
-        Ok(ListRequest)
+        Ok(Self)
     }
 
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
@@ -189,7 +189,7 @@ impl ManagerProtocol for PingRequest {
             return Err(Error::UnrecognizedCommand(cmd.to_owned()));
         }
 
-        Ok(PingRequest)
+        Ok(Self)
     }
 
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
@@ -295,11 +295,11 @@ impl ManagerRequest {
     /// Command key
     pub fn command(&self) -> &'static str {
         match *self {
-            ManagerRequest::Add(..) => "add",
-            ManagerRequest::Remove(..) => "remove",
-            ManagerRequest::List(..) => "list",
-            ManagerRequest::Ping(..) => "ping",
-            ManagerRequest::Stat(..) => "stat",
+            Self::Add(..) => "add",
+            Self::Remove(..) => "remove",
+            Self::List(..) => "list",
+            Self::Ping(..) => "ping",
+            Self::Stat(..) => "stat",
         }
     }
 }
@@ -307,15 +307,15 @@ impl ManagerRequest {
 impl ManagerProtocol for ManagerRequest {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         match *self {
-            ManagerRequest::Add(ref req) => req.to_bytes(),
-            ManagerRequest::Remove(ref req) => req.to_bytes(),
-            ManagerRequest::List(ref req) => req.to_bytes(),
-            ManagerRequest::Ping(ref req) => req.to_bytes(),
-            ManagerRequest::Stat(ref req) => req.to_bytes(),
+            Self::Add(ref req) => req.to_bytes(),
+            Self::Remove(ref req) => req.to_bytes(),
+            Self::List(ref req) => req.to_bytes(),
+            Self::Ping(ref req) => req.to_bytes(),
+            Self::Stat(ref req) => req.to_bytes(),
         }
     }
 
-    fn from_bytes(buf: &[u8]) -> Result<ManagerRequest, Error> {
+    fn from_bytes(buf: &[u8]) -> Result<Self, Error> {
         let mut nsplit = buf.splitn(2, |b| *b == b':');
 
         let cmd = nsplit.next().expect("first element shouldn't be None");
@@ -324,33 +324,33 @@ impl ManagerProtocol for ManagerRequest {
                 None => Err(Error::MissingParameter),
                 Some(param) => {
                     let req = serde_json::from_slice(param)?;
-                    Ok(ManagerRequest::Add(req))
+                    Ok(Self::Add(req))
                 }
             },
             "remove" => match nsplit.next() {
                 None => Err(Error::MissingParameter),
                 Some(param) => {
                     let req = serde_json::from_slice(param)?;
-                    Ok(ManagerRequest::Remove(req))
+                    Ok(Self::Remove(req))
                 }
             },
             "list" => {
                 if nsplit.next().is_some() {
                     return Err(Error::RedundantParameter);
                 }
-                Ok(ManagerRequest::List(ListRequest))
+                Ok(Self::List(ListRequest))
             }
             "ping" => {
                 if nsplit.next().is_some() {
                     return Err(Error::RedundantParameter);
                 }
-                Ok(ManagerRequest::Ping(PingRequest))
+                Ok(Self::Ping(PingRequest))
             }
             "stat" => match nsplit.next() {
                 None => Err(Error::MissingParameter),
                 Some(param) => {
                     let req = serde_json::from_slice(param)?;
-                    Ok(ManagerRequest::Stat(req))
+                    Ok(Self::Stat(req))
                 }
             },
             cmd => Err(Error::UnrecognizedCommand(cmd.to_owned())),
@@ -374,7 +374,7 @@ pub enum Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        io::Error::other(err.to_string())
+    fn from(err: Error) -> Self {
+        Self::other(err.to_string())
     }
 }

--- a/crates/shadowsocks/src/net/mod.rs
+++ b/crates/shadowsocks/src/net/mod.rs
@@ -26,19 +26,19 @@ pub enum AddrFamily {
 }
 
 impl From<&SocketAddr> for AddrFamily {
-    fn from(addr: &SocketAddr) -> AddrFamily {
+    fn from(addr: &SocketAddr) -> Self {
         match *addr {
-            SocketAddr::V4(..) => AddrFamily::Ipv4,
-            SocketAddr::V6(..) => AddrFamily::Ipv6,
+            SocketAddr::V4(..) => Self::Ipv4,
+            SocketAddr::V6(..) => Self::Ipv6,
         }
     }
 }
 
 impl From<SocketAddr> for AddrFamily {
-    fn from(addr: SocketAddr) -> AddrFamily {
+    fn from(addr: SocketAddr) -> Self {
         match addr {
-            SocketAddr::V4(..) => AddrFamily::Ipv4,
-            SocketAddr::V6(..) => AddrFamily::Ipv6,
+            SocketAddr::V4(..) => Self::Ipv4,
+            SocketAddr::V6(..) => Self::Ipv6,
         }
     }
 }

--- a/crates/shadowsocks/src/net/sys/unix/linux/mod.rs
+++ b/crates/shadowsocks/src/net/sys/unix/linux/mod.rs
@@ -33,9 +33,9 @@ pub enum TcpStream {
 }
 
 impl TcpStream {
-    pub async fn connect(addr: SocketAddr, opts: &ConnectOpts) -> io::Result<TcpStream> {
+    pub async fn connect(addr: SocketAddr, opts: &ConnectOpts) -> io::Result<Self> {
         if opts.tcp.mptcp {
-            return TcpStream::connect_mptcp(addr, opts).await;
+            return Self::connect_mptcp(addr, opts).await;
         }
 
         let socket = match addr {
@@ -43,15 +43,15 @@ impl TcpStream {
             SocketAddr::V6(..) => TcpSocket::new_v6()?,
         };
 
-        TcpStream::connect_with_socket(socket, addr, opts).await
+        Self::connect_with_socket(socket, addr, opts).await
     }
 
-    async fn connect_mptcp(addr: SocketAddr, opts: &ConnectOpts) -> io::Result<TcpStream> {
+    async fn connect_mptcp(addr: SocketAddr, opts: &ConnectOpts) -> io::Result<Self> {
         let socket = create_mptcp_socket(&addr)?;
-        TcpStream::connect_with_socket(socket, addr, opts).await
+        Self::connect_with_socket(socket, addr, opts).await
     }
 
-    async fn connect_with_socket(socket: TcpSocket, addr: SocketAddr, opts: &ConnectOpts) -> io::Result<TcpStream> {
+    async fn connect_with_socket(socket: TcpSocket, addr: SocketAddr, opts: &ConnectOpts) -> io::Result<Self> {
         // Any traffic to localhost should not be protected
         // This is a workaround for VPNService
         #[cfg(target_os = "android")]
@@ -101,40 +101,40 @@ impl TcpStream {
             let stream = socket.connect(addr).await?;
             set_common_sockopt_after_connect(&stream, opts)?;
 
-            return Ok(TcpStream::Standard(stream));
+            return Ok(Self::Standard(stream));
         }
 
         let stream = TfoStream::connect_with_socket(socket, addr).await?;
         set_common_sockopt_after_connect(&stream, opts)?;
 
-        Ok(TcpStream::FastOpen(stream))
+        Ok(Self::FastOpen(stream))
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match *self {
-            TcpStream::Standard(ref s) => s.local_addr(),
-            TcpStream::FastOpen(ref s) => s.local_addr(),
+            Self::Standard(ref s) => s.local_addr(),
+            Self::FastOpen(ref s) => s.local_addr(),
         }
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         match *self {
-            TcpStream::Standard(ref s) => s.peer_addr(),
-            TcpStream::FastOpen(ref s) => s.peer_addr(),
+            Self::Standard(ref s) => s.peer_addr(),
+            Self::FastOpen(ref s) => s.peer_addr(),
         }
     }
 
     pub fn nodelay(&self) -> io::Result<bool> {
         match *self {
-            TcpStream::Standard(ref s) => s.nodelay(),
-            TcpStream::FastOpen(ref s) => s.nodelay(),
+            Self::Standard(ref s) => s.nodelay(),
+            Self::FastOpen(ref s) => s.nodelay(),
         }
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         match *self {
-            TcpStream::Standard(ref s) => s.set_nodelay(nodelay),
-            TcpStream::FastOpen(ref s) => s.set_nodelay(nodelay),
+            Self::Standard(ref s) => s.set_nodelay(nodelay),
+            Self::FastOpen(ref s) => s.set_nodelay(nodelay),
         }
     }
 }
@@ -142,8 +142,8 @@ impl TcpStream {
 impl AsRawFd for TcpStream {
     fn as_raw_fd(&self) -> RawFd {
         match *self {
-            TcpStream::Standard(ref s) => s.as_raw_fd(),
-            TcpStream::FastOpen(ref s) => s.as_raw_fd(),
+            Self::Standard(ref s) => s.as_raw_fd(),
+            Self::FastOpen(ref s) => s.as_raw_fd(),
         }
     }
 }

--- a/crates/shadowsocks/src/net/sys/unix/uds.rs
+++ b/crates/shadowsocks/src/net/sys/unix/uds.rs
@@ -25,8 +25,8 @@ pub struct UnixStream {
 
 impl UnixStream {
     /// Connects to the socket named by `path`.
-    pub async fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
-        TokioUnixStream::connect(path).await.map(|io| UnixStream { io })
+    pub async fn connect<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        TokioUnixStream::connect(path).await.map(|io| Self { io })
     }
 
     fn poll_send_with_fd(&self, cx: &mut Context, buf: &[u8], fds: &[RawFd]) -> Poll<io::Result<usize>> {
@@ -100,8 +100,8 @@ pub struct UnixListener {
 
 impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified socket.
-    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
-        TokioUnixListener::bind(path).map(|io| UnixListener { io })
+    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        TokioUnixListener::bind(path).map(|io| Self { io })
     }
 
     /// Accepts a new incoming connection to this listener.

--- a/crates/shadowsocks/src/net/tcp.rs
+++ b/crates/shadowsocks/src/net/tcp.rs
@@ -35,7 +35,7 @@ pub struct TcpStream(#[pin] SysTcpStream);
 
 impl TcpStream {
     /// Connects to address
-    pub async fn connect_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<TcpStream> {
+    pub async fn connect_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<Self> {
         // tcp_stream_connect(addr, opts).await.map(TcpStream)
         SysTcpStream::connect(*addr, opts).await.map(TcpStream)
     }
@@ -45,7 +45,7 @@ impl TcpStream {
         context: &Context,
         addr: &ServerAddr,
         opts: &ConnectOpts,
-    ) -> io::Result<TcpStream> {
+    ) -> io::Result<Self> {
         let stream = match *addr {
             ServerAddr::SocketAddr(ref addr) => SysTcpStream::connect(*addr, opts).await?,
             ServerAddr::DomainName(ref domain, port) => {
@@ -56,7 +56,7 @@ impl TcpStream {
             }
         };
 
-        Ok(TcpStream(stream))
+        Ok(Self(stream))
     }
 
     /// Connects proxy remote target
@@ -64,7 +64,7 @@ impl TcpStream {
         context: &Context,
         addr: &Address,
         opts: &ConnectOpts,
-    ) -> io::Result<TcpStream> {
+    ) -> io::Result<Self> {
         let stream = match *addr {
             Address::SocketAddress(ref addr) => SysTcpStream::connect(*addr, opts).await?,
             Address::DomainNameAddress(ref domain, port) => {
@@ -75,7 +75,7 @@ impl TcpStream {
             }
         };
 
-        Ok(TcpStream(stream))
+        Ok(Self(stream))
     }
 
     /// Returns the local address that this stream is bound to.
@@ -128,7 +128,7 @@ pub struct TcpListener {
 
 impl TcpListener {
     /// Creates a new TcpListener, which will be bound to the specified address.
-    pub async fn bind_with_opts(addr: &SocketAddr, accept_opts: AcceptOpts) -> io::Result<TcpListener> {
+    pub async fn bind_with_opts(addr: &SocketAddr, accept_opts: AcceptOpts) -> io::Result<Self> {
         let socket = create_inbound_tcp_socket(addr, &accept_opts).await?;
 
         if let Some(size) = accept_opts.tcp.send_buffer_size {
@@ -166,18 +166,18 @@ impl TcpListener {
             set_tcp_fastopen(&inner)?;
         }
 
-        Ok(TcpListener { inner, accept_opts })
+        Ok(Self { inner, accept_opts })
     }
 
     /// Create a `TcpListener` from tokio's `TcpListener`
-    pub fn from_listener(listener: TokioTcpListener, accept_opts: AcceptOpts) -> io::Result<TcpListener> {
+    pub fn from_listener(listener: TokioTcpListener, accept_opts: AcceptOpts) -> io::Result<Self> {
         // Enable TFO if supported
         // macos requires TCP_FASTOPEN to be set after listen(), but other platform doesn't have this constraint
         if accept_opts.tcp.fastopen {
             set_tcp_fastopen(&listener)?;
         }
 
-        Ok(TcpListener {
+        Ok(Self {
             inner: listener,
             accept_opts,
         })
@@ -216,7 +216,7 @@ impl DerefMut for TcpListener {
 }
 
 impl From<TcpListener> for TokioTcpListener {
-    fn from(listener: TcpListener) -> TokioTcpListener {
+    fn from(listener: TcpListener) -> Self {
         listener.inner
     }
 }

--- a/crates/shadowsocks/src/net/udp.rs
+++ b/crates/shadowsocks/src/net/udp.rs
@@ -96,7 +96,7 @@ impl UdpSocket {
         context: &Context,
         addr: &ServerAddr,
         opts: &ConnectOpts,
-    ) -> io::Result<UdpSocket> {
+    ) -> io::Result<Self> {
         let socket = match *addr {
             ServerAddr::SocketAddr(ref remote_addr) => {
                 let socket = create_outbound_udp_socket(From::from(remote_addr), opts).await?;
@@ -112,7 +112,7 @@ impl UdpSocket {
             }
         };
 
-        Ok(UdpSocket {
+        Ok(Self {
             socket,
             mtu: opts.udp.mtu,
         })
@@ -123,7 +123,7 @@ impl UdpSocket {
         context: &Context,
         addr: &Address,
         opts: &ConnectOpts,
-    ) -> io::Result<UdpSocket> {
+    ) -> io::Result<Self> {
         let socket = match *addr {
             Address::SocketAddress(ref remote_addr) => {
                 let socket = create_outbound_udp_socket(From::from(remote_addr), opts).await?;
@@ -139,27 +139,27 @@ impl UdpSocket {
             }
         };
 
-        Ok(UdpSocket {
+        Ok(Self {
             socket,
             mtu: opts.udp.mtu,
         })
     }
 
     /// Connects to shadowsocks server
-    pub async fn connect_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<UdpSocket> {
+    pub async fn connect_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<Self> {
         let socket = create_outbound_udp_socket(From::from(addr), opts).await?;
         socket.connect(addr).await?;
-        Ok(UdpSocket {
+        Ok(Self {
             socket,
             mtu: opts.udp.mtu,
         })
     }
 
     /// Binds to a specific address with opts
-    pub async fn connect_any_with_opts<AF: Into<AddrFamily>>(af: AF, opts: &ConnectOpts) -> io::Result<UdpSocket> {
+    pub async fn connect_any_with_opts<AF: Into<AddrFamily>>(af: AF, opts: &ConnectOpts) -> io::Result<Self> {
         create_outbound_udp_socket(af.into(), opts)
             .await
-            .map(|socket| UdpSocket {
+            .map(|socket| Self {
                 socket,
                 mtu: opts.udp.mtu,
             })
@@ -167,13 +167,13 @@ impl UdpSocket {
 
     /// Binds to a specific address as an outbound socket
     #[inline]
-    pub async fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
-        UdpSocket::bind_with_opts(addr, &ConnectOpts::default()).await
+    pub async fn bind(addr: &SocketAddr) -> io::Result<Self> {
+        Self::bind_with_opts(addr, &ConnectOpts::default()).await
     }
 
     /// Binds to a specific address with opts as an outbound socket
-    pub async fn bind_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<UdpSocket> {
-        bind_outbound_udp_socket(addr, opts).await.map(|socket| UdpSocket {
+    pub async fn bind_with_opts(addr: &SocketAddr, opts: &ConnectOpts) -> io::Result<Self> {
+        bind_outbound_udp_socket(addr, opts).await.map(|socket| Self {
             socket,
             mtu: opts.udp.mtu,
         })
@@ -181,14 +181,14 @@ impl UdpSocket {
 
     /// Binds to a specific address (inbound)
     #[inline]
-    pub async fn listen(addr: &SocketAddr) -> io::Result<UdpSocket> {
-        UdpSocket::listen_with_opts(addr, AcceptOpts::default()).await
+    pub async fn listen(addr: &SocketAddr) -> io::Result<Self> {
+        Self::listen_with_opts(addr, AcceptOpts::default()).await
     }
 
     /// Binds to a specific address (inbound)
-    pub async fn listen_with_opts(addr: &SocketAddr, opts: AcceptOpts) -> io::Result<UdpSocket> {
+    pub async fn listen_with_opts(addr: &SocketAddr, opts: AcceptOpts) -> io::Result<Self> {
         let socket = create_inbound_udp_socket(addr, opts.ipv6_only).await?;
-        Ok(UdpSocket {
+        Ok(Self {
             socket,
             mtu: opts.udp.mtu,
         })
@@ -399,12 +399,12 @@ impl DerefMut for UdpSocket {
 
 impl From<tokio::net::UdpSocket> for UdpSocket {
     fn from(socket: tokio::net::UdpSocket) -> Self {
-        UdpSocket { socket, mtu: None }
+        Self { socket, mtu: None }
     }
 }
 
 impl From<UdpSocket> for tokio::net::UdpSocket {
-    fn from(s: UdpSocket) -> tokio::net::UdpSocket {
+    fn from(s: UdpSocket) -> Self {
         s.socket
     }
 }

--- a/crates/shadowsocks/src/plugin/mod.rs
+++ b/crates/shadowsocks/src/plugin/mod.rs
@@ -70,7 +70,7 @@ impl Plugin {
     ///
     /// `PluginMode::Client`: Plugin listens to `local_addr` and send data to `remote_addr`, client should send data to `local_addr`
     /// `PluginMode::Server`: Plugin listens to `remote_addr` and send data to `local_addr`, server should listen to `local_addr`
-    pub fn start(c: &PluginConfig, remote_addr: &ServerAddr, mode: PluginMode) -> io::Result<Plugin> {
+    pub fn start(c: &PluginConfig, remote_addr: &ServerAddr, mode: PluginMode) -> io::Result<Self> {
         let loop_ip = match remote_addr {
             ServerAddr::SocketAddr(sa) => match sa.ip() {
                 IpAddr::V4(..) => Ipv4Addr::LOCALHOST.into(),
@@ -113,7 +113,7 @@ impl Plugin {
                     }
                 }
 
-                Ok(Plugin {
+                Ok(Self {
                     process,
                     local_addr,
                     mode: c.plugin_mode,

--- a/crates/shadowsocks/src/relay/socks5.rs
+++ b/crates/shadowsocks/src/relay/socks5.rs
@@ -63,19 +63,19 @@ impl Command {
     #[rustfmt::skip]
     fn as_u8(self) -> u8 {
         match self {
-            Command::TcpConnect   => consts::SOCKS5_CMD_TCP_CONNECT,
-            Command::TcpBind      => consts::SOCKS5_CMD_TCP_BIND,
-            Command::UdpAssociate => consts::SOCKS5_CMD_UDP_ASSOCIATE,
+            Self::TcpConnect   => consts::SOCKS5_CMD_TCP_CONNECT,
+            Self::TcpBind      => consts::SOCKS5_CMD_TCP_BIND,
+            Self::UdpAssociate => consts::SOCKS5_CMD_UDP_ASSOCIATE,
         }
     }
 
     #[inline]
     #[rustfmt::skip]
-    fn from_u8(code: u8) -> Option<Command> {
+    fn from_u8(code: u8) -> Option<Self> {
         match code {
-            consts::SOCKS5_CMD_TCP_CONNECT   => Some(Command::TcpConnect),
-            consts::SOCKS5_CMD_TCP_BIND      => Some(Command::TcpBind),
-            consts::SOCKS5_CMD_UDP_ASSOCIATE => Some(Command::UdpAssociate),
+            consts::SOCKS5_CMD_TCP_CONNECT   => Some(Self::TcpConnect),
+            consts::SOCKS5_CMD_TCP_BIND      => Some(Self::TcpBind),
+            consts::SOCKS5_CMD_UDP_ASSOCIATE => Some(Self::UdpAssociate),
             _                                => None,
         }
     }
@@ -102,33 +102,33 @@ impl Reply {
     #[rustfmt::skip]
     pub fn as_u8(self) -> u8 {
         match self {
-            Reply::Succeeded               => consts::SOCKS5_REPLY_SUCCEEDED,
-            Reply::GeneralFailure          => consts::SOCKS5_REPLY_GENERAL_FAILURE,
-            Reply::ConnectionNotAllowed    => consts::SOCKS5_REPLY_CONNECTION_NOT_ALLOWED,
-            Reply::NetworkUnreachable      => consts::SOCKS5_REPLY_NETWORK_UNREACHABLE,
-            Reply::HostUnreachable         => consts::SOCKS5_REPLY_HOST_UNREACHABLE,
-            Reply::ConnectionRefused       => consts::SOCKS5_REPLY_CONNECTION_REFUSED,
-            Reply::TtlExpired              => consts::SOCKS5_REPLY_TTL_EXPIRED,
-            Reply::CommandNotSupported     => consts::SOCKS5_REPLY_COMMAND_NOT_SUPPORTED,
-            Reply::AddressTypeNotSupported => consts::SOCKS5_REPLY_ADDRESS_TYPE_NOT_SUPPORTED,
-            Reply::OtherReply(c)           => c,
+            Self::Succeeded               => consts::SOCKS5_REPLY_SUCCEEDED,
+            Self::GeneralFailure          => consts::SOCKS5_REPLY_GENERAL_FAILURE,
+            Self::ConnectionNotAllowed    => consts::SOCKS5_REPLY_CONNECTION_NOT_ALLOWED,
+            Self::NetworkUnreachable      => consts::SOCKS5_REPLY_NETWORK_UNREACHABLE,
+            Self::HostUnreachable         => consts::SOCKS5_REPLY_HOST_UNREACHABLE,
+            Self::ConnectionRefused       => consts::SOCKS5_REPLY_CONNECTION_REFUSED,
+            Self::TtlExpired              => consts::SOCKS5_REPLY_TTL_EXPIRED,
+            Self::CommandNotSupported     => consts::SOCKS5_REPLY_COMMAND_NOT_SUPPORTED,
+            Self::AddressTypeNotSupported => consts::SOCKS5_REPLY_ADDRESS_TYPE_NOT_SUPPORTED,
+            Self::OtherReply(c)           => c,
         }
     }
 
     #[inline]
     #[rustfmt::skip]
-    pub fn from_u8(code: u8) -> Reply {
+    pub fn from_u8(code: u8) -> Self {
         match code {
-            consts::SOCKS5_REPLY_SUCCEEDED                  => Reply::Succeeded,
-            consts::SOCKS5_REPLY_GENERAL_FAILURE            => Reply::GeneralFailure,
-            consts::SOCKS5_REPLY_CONNECTION_NOT_ALLOWED     => Reply::ConnectionNotAllowed,
-            consts::SOCKS5_REPLY_NETWORK_UNREACHABLE        => Reply::NetworkUnreachable,
-            consts::SOCKS5_REPLY_HOST_UNREACHABLE           => Reply::HostUnreachable,
-            consts::SOCKS5_REPLY_CONNECTION_REFUSED         => Reply::ConnectionRefused,
-            consts::SOCKS5_REPLY_TTL_EXPIRED                => Reply::TtlExpired,
-            consts::SOCKS5_REPLY_COMMAND_NOT_SUPPORTED      => Reply::CommandNotSupported,
-            consts::SOCKS5_REPLY_ADDRESS_TYPE_NOT_SUPPORTED => Reply::AddressTypeNotSupported,
-            _                                               => Reply::OtherReply(code),
+            consts::SOCKS5_REPLY_SUCCEEDED                  => Self::Succeeded,
+            consts::SOCKS5_REPLY_GENERAL_FAILURE            => Self::GeneralFailure,
+            consts::SOCKS5_REPLY_CONNECTION_NOT_ALLOWED     => Self::ConnectionNotAllowed,
+            consts::SOCKS5_REPLY_NETWORK_UNREACHABLE        => Self::NetworkUnreachable,
+            consts::SOCKS5_REPLY_HOST_UNREACHABLE           => Self::HostUnreachable,
+            consts::SOCKS5_REPLY_CONNECTION_REFUSED         => Self::ConnectionRefused,
+            consts::SOCKS5_REPLY_TTL_EXPIRED                => Self::TtlExpired,
+            consts::SOCKS5_REPLY_COMMAND_NOT_SUPPORTED      => Self::CommandNotSupported,
+            consts::SOCKS5_REPLY_ADDRESS_TYPE_NOT_SUPPORTED => Self::AddressTypeNotSupported,
+            _                                               => Self::OtherReply(code),
         }
     }
 }
@@ -137,16 +137,16 @@ impl fmt::Display for Reply {
     #[rustfmt::skip]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Reply::Succeeded               => write!(f, "Succeeded"),
-            Reply::AddressTypeNotSupported => write!(f, "Address type not supported"),
-            Reply::CommandNotSupported     => write!(f, "Command not supported"),
-            Reply::ConnectionNotAllowed    => write!(f, "Connection not allowed"),
-            Reply::ConnectionRefused       => write!(f, "Connection refused"),
-            Reply::GeneralFailure          => write!(f, "General failure"),
-            Reply::HostUnreachable         => write!(f, "Host unreachable"),
-            Reply::NetworkUnreachable      => write!(f, "Network unreachable"),
-            Reply::OtherReply(u)           => write!(f, "Other reply ({u})"),
-            Reply::TtlExpired              => write!(f, "TTL expired"),
+            Self::Succeeded               => write!(f, "Succeeded"),
+            Self::AddressTypeNotSupported => write!(f, "Address type not supported"),
+            Self::CommandNotSupported     => write!(f, "Command not supported"),
+            Self::ConnectionNotAllowed    => write!(f, "Connection not allowed"),
+            Self::ConnectionRefused       => write!(f, "Connection refused"),
+            Self::GeneralFailure          => write!(f, "General failure"),
+            Self::HostUnreachable         => write!(f, "Host unreachable"),
+            Self::NetworkUnreachable      => write!(f, "Network unreachable"),
+            Self::OtherReply(u)           => write!(f, "Other reply ({u})"),
+            Self::TtlExpired              => write!(f, "TTL expired"),
         }
     }
 }
@@ -173,10 +173,10 @@ pub enum Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
+    fn from(err: Error) -> Self {
         match err {
             Error::IoError(err) => err,
-            e => io::Error::other(e),
+            e => Self::other(e),
         }
     }
 }
@@ -185,17 +185,17 @@ impl Error {
     /// Convert to `Reply` for responding
     pub fn as_reply(&self) -> Reply {
         match *self {
-            Error::IoError(ref err) => match err.kind() {
+            Self::IoError(ref err) => match err.kind() {
                 ErrorKind::ConnectionRefused => Reply::ConnectionRefused,
                 _ => Reply::GeneralFailure,
             },
-            Error::AddressTypeNotSupported(..) => Reply::AddressTypeNotSupported,
-            Error::AddressDomainInvalidEncoding => Reply::GeneralFailure,
-            Error::UnsupportedSocksVersion(..) => Reply::GeneralFailure,
-            Error::UnsupportedCommand(..) => Reply::CommandNotSupported,
-            Error::UnsupportedPasswdAuthVersion(..) => Reply::GeneralFailure,
-            Error::PasswdAuthInvalidRequest => Reply::GeneralFailure,
-            Error::Reply(r) => r,
+            Self::AddressTypeNotSupported(..) => Reply::AddressTypeNotSupported,
+            Self::AddressDomainInvalidEncoding => Reply::GeneralFailure,
+            Self::UnsupportedSocksVersion(..) => Reply::GeneralFailure,
+            Self::UnsupportedCommand(..) => Reply::CommandNotSupported,
+            Self::UnsupportedPasswdAuthVersion(..) => Reply::GeneralFailure,
+            Self::PasswdAuthInvalidRequest => Reply::GeneralFailure,
+            Self::Reply(r) => r,
         }
     }
 }
@@ -211,7 +211,7 @@ pub enum Address {
 
 impl Address {
     /// read from a cursor
-    pub fn read_cursor<T: AsRef<[u8]>>(cur: &mut io::Cursor<T>) -> Result<Address, Error> {
+    pub fn read_cursor<T: AsRef<[u8]>>(cur: &mut io::Cursor<T>) -> Result<Self, Error> {
         if cur.remaining() < 2 {
             return Err(io::Error::other("invalid buf").into());
         }
@@ -224,7 +224,7 @@ impl Address {
                 }
                 let addr = Ipv4Addr::from(cur.get_u32());
                 let port = cur.get_u16();
-                Ok(Address::SocketAddress(SocketAddr::V4(SocketAddrV4::new(addr, port))))
+                Ok(Self::SocketAddress(SocketAddr::V4(SocketAddrV4::new(addr, port))))
             }
             consts::SOCKS5_ADDR_TYPE_IPV6 => {
                 if cur.remaining() < 16 + 2 {
@@ -232,7 +232,7 @@ impl Address {
                 }
                 let addr = Ipv6Addr::from(cur.get_u128());
                 let port = cur.get_u16();
-                Ok(Address::SocketAddress(SocketAddr::V6(SocketAddrV6::new(
+                Ok(Self::SocketAddress(SocketAddr::V6(SocketAddrV6::new(
                     addr, port, 0, 0,
                 ))))
             }
@@ -245,14 +245,14 @@ impl Address {
                 cur.copy_to_slice(&mut buf);
                 let port = cur.get_u16();
                 let addr = String::from_utf8(buf).map_err(|_| Error::AddressDomainInvalidEncoding)?;
-                Ok(Address::DomainNameAddress(addr, port))
+                Ok(Self::DomainNameAddress(addr, port))
             }
             _ => Err(Error::AddressTypeNotSupported(atyp)),
         }
     }
 
     /// Parse from a `AsyncRead`
-    pub async fn read_from<R>(stream: &mut R) -> Result<Address, Error>
+    pub async fn read_from<R>(stream: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -267,7 +267,7 @@ impl Address {
 
                 let v4addr = Ipv4Addr::new(buf[0], buf[1], buf[2], buf[3]);
                 let port = u16::from_be_bytes([buf[4], buf[5]]);
-                Ok(Address::SocketAddress(SocketAddr::V4(SocketAddrV4::new(v4addr, port))))
+                Ok(Self::SocketAddress(SocketAddr::V4(SocketAddrV4::new(v4addr, port))))
             }
             consts::SOCKS5_ADDR_TYPE_IPV6 => {
                 let mut buf = [0u16; 9];
@@ -287,7 +287,7 @@ impl Address {
                 );
                 let port = u16::from_be(buf[8]);
 
-                Ok(Address::SocketAddress(SocketAddr::V6(SocketAddrV6::new(
+                Ok(Self::SocketAddress(SocketAddr::V6(SocketAddrV6::new(
                     v6addr, port, 0, 0,
                 ))))
             }
@@ -312,7 +312,7 @@ impl Address {
                     Err(..) => return Err(Error::AddressDomainInvalidEncoding),
                 };
 
-                Ok(Address::DomainNameAddress(addr, port))
+                Ok(Self::DomainNameAddress(addr, port))
             }
             _ => {
                 // Wrong Address Type . Socks5 only supports ipv4, ipv6 and domain name
@@ -356,16 +356,16 @@ impl Address {
     /// Get associated port number
     pub fn port(&self) -> u16 {
         match *self {
-            Address::SocketAddress(addr) => addr.port(),
-            Address::DomainNameAddress(.., port) => port,
+            Self::SocketAddress(addr) => addr.port(),
+            Self::DomainNameAddress(.., port) => port,
         }
     }
 
     /// Get host address string
     pub fn host(&self) -> String {
         match *self {
-            Address::SocketAddress(ref addr) => addr.ip().to_string(),
-            Address::DomainNameAddress(ref domain, ..) => domain.to_owned(),
+            Self::SocketAddress(ref addr) => addr.ip().to_string(),
+            Self::DomainNameAddress(ref domain, ..) => domain.to_owned(),
         }
     }
 }
@@ -374,8 +374,8 @@ impl Debug for Address {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            Address::SocketAddress(ref addr) => write!(f, "{addr}"),
-            Address::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
+            Self::SocketAddress(ref addr) => write!(f, "{addr}"),
+            Self::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
         }
     }
 }
@@ -384,8 +384,8 @@ impl fmt::Display for Address {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            Address::SocketAddress(ref addr) => write!(f, "{addr}"),
-            Address::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
+            Self::SocketAddress(ref addr) => write!(f, "{addr}"),
+            Self::DomainNameAddress(ref addr, ref port) => write!(f, "{addr}:{port}"),
         }
     }
 }
@@ -395,26 +395,26 @@ impl ToSocketAddrs for Address {
 
     fn to_socket_addrs(&self) -> io::Result<vec::IntoIter<SocketAddr>> {
         match self.clone() {
-            Address::SocketAddress(addr) => Ok(vec![addr].into_iter()),
-            Address::DomainNameAddress(addr, port) => (&addr[..], port).to_socket_addrs(),
+            Self::SocketAddress(addr) => Ok(vec![addr].into_iter()),
+            Self::DomainNameAddress(addr, port) => (&addr[..], port).to_socket_addrs(),
         }
     }
 }
 
 impl From<SocketAddr> for Address {
-    fn from(s: SocketAddr) -> Address {
-        Address::SocketAddress(s)
+    fn from(s: SocketAddr) -> Self {
+        Self::SocketAddress(s)
     }
 }
 
 impl From<(String, u16)> for Address {
-    fn from((dn, port): (String, u16)) -> Address {
-        Address::DomainNameAddress(dn, port)
+    fn from((dn, port): (String, u16)) -> Self {
+        Self::DomainNameAddress(dn, port)
     }
 }
 
-impl From<&Address> for Address {
-    fn from(addr: &Address) -> Address {
+impl From<&Self> for Address {
+    fn from(addr: &Self) -> Self {
         addr.clone()
     }
 }
@@ -434,19 +434,19 @@ impl std::error::Error for AddressError {}
 impl FromStr for Address {
     type Err = AddressError;
 
-    fn from_str(s: &str) -> Result<Address, AddressError> {
+    fn from_str(s: &str) -> Result<Self, AddressError> {
         match s.parse::<SocketAddr>() {
-            Ok(addr) => Ok(Address::SocketAddress(addr)),
+            Ok(addr) => Ok(Self::SocketAddress(addr)),
             Err(..) => {
                 let mut sp = s.split(':');
                 match (sp.next(), sp.next()) {
                     (Some(dn), Some(port)) => match port.parse::<u16>() {
-                        Ok(port) => Ok(Address::DomainNameAddress(dn.to_owned(), port)),
+                        Ok(port) => Ok(Self::DomainNameAddress(dn.to_owned(), port)),
                         Err(..) => Err(AddressError),
                     },
                     (Some(dn), None) => {
                         // Assume it is 80 (http's default port)
-                        Ok(Address::DomainNameAddress(dn.to_owned(), 80))
+                        Ok(Self::DomainNameAddress(dn.to_owned(), 80))
                     }
                     _ => Err(AddressError),
                 }
@@ -524,15 +524,15 @@ pub struct TcpRequestHeader {
 
 impl TcpRequestHeader {
     /// Creates a request header
-    pub fn new(cmd: Command, addr: Address) -> TcpRequestHeader {
-        TcpRequestHeader {
+    pub fn new(cmd: Command, addr: Address) -> Self {
+        Self {
             command: cmd,
             address: addr,
         }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<TcpRequestHeader, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -551,7 +551,7 @@ impl TcpRequestHeader {
         };
 
         let address = Address::read_from(r).await?;
-        Ok(TcpRequestHeader { command, address })
+        Ok(Self { command, address })
     }
 
     /// Write data into a writer
@@ -566,7 +566,7 @@ impl TcpRequestHeader {
 
     /// Writes to buffer
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
-        let TcpRequestHeader {
+        let Self {
             ref address,
             ref command,
         } = *self;
@@ -601,12 +601,12 @@ pub struct TcpResponseHeader {
 
 impl TcpResponseHeader {
     /// Creates a response header
-    pub fn new(reply: Reply, address: Address) -> TcpResponseHeader {
-        TcpResponseHeader { reply, address }
+    pub fn new(reply: Reply, address: Address) -> Self {
+        Self { reply, address }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<TcpResponseHeader, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -622,7 +622,7 @@ impl TcpResponseHeader {
 
         let address = Address::read_from(r).await?;
 
-        Ok(TcpResponseHeader {
+        Ok(Self {
             reply: Reply::from_u8(reply_code),
             address,
         })
@@ -640,7 +640,7 @@ impl TcpResponseHeader {
 
     /// Writes to buffer
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
-        let TcpResponseHeader { ref reply, ref address } = *self;
+        let Self { ref reply, ref address } = *self;
         buf.put_slice(&[consts::SOCKS5_VERSION, reply.as_u8(), 0x00]);
         address.write_to_buf(buf);
     }
@@ -668,12 +668,12 @@ pub struct HandshakeRequest {
 
 impl HandshakeRequest {
     /// Creates a handshake request
-    pub fn new(methods: Vec<u8>) -> HandshakeRequest {
-        HandshakeRequest { methods }
+    pub fn new(methods: Vec<u8>) -> Self {
+        Self { methods }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<HandshakeRequest, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -690,7 +690,7 @@ impl HandshakeRequest {
         let mut methods = vec![0u8; nmet as usize];
         let _ = r.read_exact(&mut methods).await?;
 
-        Ok(HandshakeRequest { methods })
+        Ok(Self { methods })
     }
 
     /// Write to a writer
@@ -705,7 +705,7 @@ impl HandshakeRequest {
 
     /// Write to buffer
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
-        let HandshakeRequest { ref methods } = *self;
+        let Self { ref methods } = *self;
         buf.put_slice(&[consts::SOCKS5_VERSION, methods.len() as u8]);
         buf.put_slice(methods);
     }
@@ -732,12 +732,12 @@ pub struct HandshakeResponse {
 
 impl HandshakeResponse {
     /// Creates a handshake response
-    pub fn new(cm: u8) -> HandshakeResponse {
-        HandshakeResponse { chosen_method: cm }
+    pub fn new(cm: u8) -> Self {
+        Self { chosen_method: cm }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<HandshakeResponse, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -750,7 +750,7 @@ impl HandshakeResponse {
         if ver != consts::SOCKS5_VERSION {
             Err(Error::UnsupportedSocksVersion(ver))
         } else {
-            Ok(HandshakeResponse { chosen_method: met })
+            Ok(Self { chosen_method: met })
         }
     }
 
@@ -796,12 +796,12 @@ pub struct UdpAssociateHeader {
 
 impl UdpAssociateHeader {
     /// Creates a header
-    pub fn new(frag: u8, address: Address) -> UdpAssociateHeader {
-        UdpAssociateHeader { frag, address }
+    pub fn new(frag: u8, address: Address) -> Self {
+        Self { frag, address }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<UdpAssociateHeader, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -810,7 +810,7 @@ impl UdpAssociateHeader {
 
         let frag = buf[2];
         let address = Address::read_from(r).await?;
-        Ok(UdpAssociateHeader::new(frag, address))
+        Ok(Self::new(frag, address))
     }
 
     /// Write to a writer
@@ -825,7 +825,7 @@ impl UdpAssociateHeader {
 
     /// Write to buffer
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
-        let UdpAssociateHeader { ref frag, ref address } = *self;
+        let Self { ref frag, ref address } = *self;
         buf.put_slice(&[0x00, 0x00, *frag]);
         address.write_to_buf(buf);
     }
@@ -855,7 +855,7 @@ pub struct PasswdAuthRequest {
 
 impl PasswdAuthRequest {
     /// Create a Username/Password Authentication Request
-    pub fn new<U, P>(uname: U, passwd: P) -> PasswdAuthRequest
+    pub fn new<U, P>(uname: U, passwd: P) -> Self
     where
         U: Into<Vec<u8>>,
         P: Into<Vec<u8>>,
@@ -869,11 +869,11 @@ impl PasswdAuthRequest {
                 && passwd.len() <= u8::MAX as usize
         );
 
-        PasswdAuthRequest { uname, passwd }
+        Self { uname, passwd }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<PasswdAuthRequest, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -911,7 +911,7 @@ impl PasswdAuthRequest {
             let _ = r.read_exact(&mut passwd).await?;
         }
 
-        Ok(PasswdAuthRequest { uname, passwd })
+        Ok(Self { uname, passwd })
     }
 
     /// Write to a writer
@@ -945,12 +945,12 @@ pub struct PasswdAuthResponse {
 }
 
 impl PasswdAuthResponse {
-    pub fn new(status: u8) -> PasswdAuthResponse {
-        PasswdAuthResponse { status }
+    pub fn new(status: u8) -> Self {
+        Self { status }
     }
 
     /// Read from a reader
-    pub async fn read_from<R>(r: &mut R) -> Result<PasswdAuthResponse, Error>
+    pub async fn read_from<R>(r: &mut R) -> Result<Self, Error>
     where
         R: AsyncRead + Unpin,
     {
@@ -961,7 +961,7 @@ impl PasswdAuthResponse {
             return Err(Error::UnsupportedPasswdAuthVersion(buf[0]));
         }
 
-        Ok(PasswdAuthResponse { status: buf[1] })
+        Ok(Self { status: buf[1] })
     }
 
     /// Write to a writer

--- a/crates/shadowsocks/src/relay/tcprelay/aead.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/aead.rs
@@ -74,10 +74,10 @@ pub enum ProtocolError {
 pub type ProtocolResult<T> = Result<T, ProtocolError>;
 
 impl From<ProtocolError> for io::Error {
-    fn from(e: ProtocolError) -> io::Error {
+    fn from(e: ProtocolError) -> Self {
         match e {
             ProtocolError::IoError(err) => err,
-            _ => io::Error::other(e),
+            _ => Self::other(e),
         }
     }
 }
@@ -101,9 +101,9 @@ pub struct DecryptedReader {
 }
 
 impl DecryptedReader {
-    pub fn new(method: CipherKind, key: &[u8]) -> DecryptedReader {
+    pub fn new(method: CipherKind, key: &[u8]) -> Self {
         if method.salt_len() > 0 {
-            DecryptedReader {
+            Self {
                 state: DecryptReadState::WaitSalt {
                     key: Bytes::copy_from_slice(key),
                 },
@@ -114,7 +114,7 @@ impl DecryptedReader {
                 has_handshaked: false,
             }
         } else {
-            DecryptedReader {
+            Self {
                 state: DecryptReadState::ReadLength,
                 cipher: Some(Cipher::new(method, key, &[])),
                 buffer: BytesMut::with_capacity(2 + method.tag_len()),
@@ -226,7 +226,7 @@ impl DecryptedReader {
         let cipher = self.cipher.as_mut().expect("cipher is None");
 
         let m = &mut self.buffer[..length_len];
-        let length = DecryptedReader::decrypt_length(cipher, m)?;
+        let length = Self::decrypt_length(cipher, m)?;
 
         Ok(Some(length)).into()
     }
@@ -339,12 +339,12 @@ pub struct EncryptedWriter {
 
 impl EncryptedWriter {
     /// Creates a new EncryptedWriter
-    pub fn new(method: CipherKind, key: &[u8], nonce: &[u8]) -> EncryptedWriter {
+    pub fn new(method: CipherKind, key: &[u8], nonce: &[u8]) -> Self {
         // nonce should be sent with the first packet
         let mut buffer = BytesMut::with_capacity(nonce.len());
         buffer.put(nonce);
 
-        EncryptedWriter {
+        Self {
             cipher: Cipher::new(method, key, nonce),
             buffer,
             state: EncryptWriteState::AssemblePacket,

--- a/crates/shadowsocks/src/relay/tcprelay/aead_2022.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/aead_2022.rs
@@ -110,10 +110,10 @@ pub enum ProtocolError {
 pub type ProtocolResult<T> = Result<T, ProtocolError>;
 
 impl From<ProtocolError> for io::Error {
-    fn from(e: ProtocolError) -> io::Error {
+    fn from(e: ProtocolError) -> Self {
         match e {
             ProtocolError::IoError(err) => err,
-            _ => io::Error::other(e),
+            _ => Self::other(e),
         }
     }
 }
@@ -141,8 +141,8 @@ pub struct DecryptedReader {
 }
 
 impl DecryptedReader {
-    pub fn new(stream_ty: StreamType, method: CipherKind, key: &[u8]) -> DecryptedReader {
-        DecryptedReader::with_user_manager(stream_ty, method, key, None)
+    pub fn new(stream_ty: StreamType, method: CipherKind, key: &[u8]) -> Self {
+        Self::with_user_manager(stream_ty, method, key, None)
     }
 
     pub fn with_user_manager(
@@ -150,9 +150,9 @@ impl DecryptedReader {
         method: CipherKind,
         key: &[u8],
         user_manager: Option<Arc<ServerUserManager>>,
-    ) -> DecryptedReader {
+    ) -> Self {
         if method.salt_len() > 0 {
-            DecryptedReader {
+            Self {
                 stream_ty,
                 state: DecryptReadState::ReadHeader {
                     key: Bytes::copy_from_slice(key),
@@ -168,7 +168,7 @@ impl DecryptedReader {
                 has_handshaked: false,
             }
         } else {
-            DecryptedReader {
+            Self {
                 stream_ty,
                 state: DecryptReadState::ReadHeader {
                     key: Bytes::new(), // EMPTY SALT, no allocation
@@ -419,7 +419,7 @@ impl DecryptedReader {
         let cipher = self.cipher.as_mut().expect("cipher is None");
 
         let m = &mut self.buffer[..length_len];
-        let length = DecryptedReader::decrypt_length(cipher, m)?;
+        let length = Self::decrypt_length(cipher, m)?;
 
         Ok(Some(length)).into()
     }
@@ -531,9 +531,9 @@ pub struct EncryptedWriter {
 
 impl EncryptedWriter {
     /// Creates a new EncryptedWriter
-    pub fn new(stream_ty: StreamType, method: CipherKind, key: &[u8], nonce: &[u8]) -> EncryptedWriter {
+    pub fn new(stream_ty: StreamType, method: CipherKind, key: &[u8], nonce: &[u8]) -> Self {
         const EMPTY_IDENTITY: [Bytes; 0] = [];
-        EncryptedWriter::with_identity(stream_ty, method, key, nonce, &EMPTY_IDENTITY)
+        Self::with_identity(stream_ty, method, key, nonce, &EMPTY_IDENTITY)
     }
 
     /// Creates a new EncryptedWriter with identities
@@ -543,7 +543,7 @@ impl EncryptedWriter {
         key: &[u8],
         nonce: &[u8],
         identity_keys: &[Bytes],
-    ) -> EncryptedWriter {
+    ) -> Self {
         // nonce should be sent with the first packet
         let mut buffer = BytesMut::with_capacity(nonce.len() + identity_keys.len() * 16);
         buffer.put(nonce);
@@ -607,7 +607,7 @@ impl EncryptedWriter {
             }
         }
 
-        EncryptedWriter {
+        Self {
             stream_ty,
             cipher: TcpCipher::new(method, key, nonce),
             method,

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_listener.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_listener.rs
@@ -33,8 +33,8 @@ static DEFAULT_ACCEPT_OPTS: LazyLock<AcceptOpts> = LazyLock::new(Default::defaul
 
 impl ProxyListener {
     /// Create a `ProxyListener` binding to a specific address
-    pub async fn bind(context: SharedContext, svr_cfg: &ServerConfig) -> io::Result<ProxyListener> {
-        ProxyListener::bind_with_opts(context, svr_cfg, DEFAULT_ACCEPT_OPTS.clone()).await
+    pub async fn bind(context: SharedContext, svr_cfg: &ServerConfig) -> io::Result<Self> {
+        Self::bind_with_opts(context, svr_cfg, DEFAULT_ACCEPT_OPTS.clone()).await
     }
 
     /// Create a `ProxyListener` binding to a specific address with opts
@@ -42,7 +42,7 @@ impl ProxyListener {
         context: SharedContext,
         svr_cfg: &ServerConfig,
         accept_opts: AcceptOpts,
-    ) -> io::Result<ProxyListener> {
+    ) -> io::Result<Self> {
         let listener = match svr_cfg.tcp_external_addr() {
             ServerAddr::SocketAddr(sa) => TcpListener::bind_with_opts(sa, accept_opts).await?,
             ServerAddr::DomainName(domain, port) => {
@@ -52,12 +52,12 @@ impl ProxyListener {
                 .1
             }
         };
-        Ok(ProxyListener::from_listener(context, listener, svr_cfg))
+        Ok(Self::from_listener(context, listener, svr_cfg))
     }
 
     /// Create a `ProxyListener` from a `TcpListener`
-    pub fn from_listener(context: SharedContext, listener: TcpListener, svr_cfg: &ServerConfig) -> ProxyListener {
-        ProxyListener {
+    pub fn from_listener(context: SharedContext, listener: TcpListener, svr_cfg: &ServerConfig) -> Self {
+        Self {
             listener,
             method: svr_cfg.method(),
             key: svr_cfg.key().to_vec().into_boxed_slice(),

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/client.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/client.rs
@@ -63,11 +63,11 @@ impl ProxyClientStream<OutboundTcpStream> {
         context: SharedContext,
         svr_cfg: &ServerConfig,
         addr: A,
-    ) -> io::Result<ProxyClientStream<OutboundTcpStream>>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
-        ProxyClientStream::connect_with_opts(context, svr_cfg, addr, &DEFAULT_CONNECT_OPTS).await
+        Self::connect_with_opts(context, svr_cfg, addr, &DEFAULT_CONNECT_OPTS).await
     }
 
     /// Connect to target `addr` via shadowsocks' server configured by `svr_cfg`
@@ -76,11 +76,11 @@ impl ProxyClientStream<OutboundTcpStream> {
         svr_cfg: &ServerConfig,
         addr: A,
         opts: &ConnectOpts,
-    ) -> io::Result<ProxyClientStream<OutboundTcpStream>>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
     {
-        ProxyClientStream::connect_with_opts_map(context, svr_cfg, addr, opts, |s| s).await
+        Self::connect_with_opts_map(context, svr_cfg, addr, opts, |s| s).await
     }
 }
 
@@ -94,12 +94,12 @@ where
         svr_cfg: &ServerConfig,
         addr: A,
         map_fn: F,
-    ) -> io::Result<ProxyClientStream<S>>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
         F: FnOnce(OutboundTcpStream) -> S,
     {
-        ProxyClientStream::connect_with_opts_map(context, svr_cfg, addr, &DEFAULT_CONNECT_OPTS, map_fn).await
+        Self::connect_with_opts_map(context, svr_cfg, addr, &DEFAULT_CONNECT_OPTS, map_fn).await
     }
 
     /// Connect to target `addr` via shadowsocks' server configured by `svr_cfg`, maps `TcpStream` to customized stream with `map_fn`
@@ -109,7 +109,7 @@ where
         addr: A,
         opts: &ConnectOpts,
         map_fn: F,
-    ) -> io::Result<ProxyClientStream<S>>
+    ) -> io::Result<Self>
     where
         A: Into<Address>,
         F: FnOnce(OutboundTcpStream) -> S,
@@ -142,13 +142,13 @@ where
             opts
         );
 
-        Ok(ProxyClientStream::from_stream(context, map_fn(stream), svr_cfg, addr))
+        Ok(Self::from_stream(context, map_fn(stream), svr_cfg, addr))
     }
 
     /// Create a `ProxyClientStream` with a connected `stream` to a shadowsocks' server
     ///
     /// NOTE: `stream` must be connected to the server with the same configuration as `svr_cfg`, otherwise strange errors would occurs
-    pub fn from_stream<A>(context: SharedContext, stream: S, svr_cfg: &ServerConfig, addr: A) -> ProxyClientStream<S>
+    pub fn from_stream<A>(context: SharedContext, stream: S, svr_cfg: &ServerConfig, addr: A) -> Self
     where
         A: Into<Address>,
     {
@@ -174,7 +174,7 @@ where
             ProxyClientStreamReadState::Established
         };
 
-        ProxyClientStream {
+        Self {
             stream,
             writer_state: ProxyClientStreamWriteState::Connect(addr),
             reader_state,

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/mod.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/mod.rs
@@ -26,21 +26,21 @@ pub enum TcpRequestHeader {
 }
 
 impl TcpRequestHeader {
-    pub async fn read_from<R: AsyncRead + Unpin>(method: CipherKind, reader: &mut R) -> io::Result<TcpRequestHeader> {
+    pub async fn read_from<R: AsyncRead + Unpin>(method: CipherKind, reader: &mut R) -> io::Result<Self> {
         match method.category() {
-            CipherCategory::None => Ok(TcpRequestHeader::Stream(
+            CipherCategory::None => Ok(Self::Stream(
                 StreamTcpRequestHeader::read_from(reader).await?,
             )),
             #[cfg(feature = "aead-cipher")]
-            CipherCategory::Aead => Ok(TcpRequestHeader::Stream(
+            CipherCategory::Aead => Ok(Self::Stream(
                 StreamTcpRequestHeader::read_from(reader).await?,
             )),
             #[cfg(feature = "stream-cipher")]
-            CipherCategory::Stream => Ok(TcpRequestHeader::Stream(
+            CipherCategory::Stream => Ok(Self::Stream(
                 StreamTcpRequestHeader::read_from(reader).await?,
             )),
             #[cfg(feature = "aead-cipher-2022")]
-            CipherCategory::Aead2022 => Ok(TcpRequestHeader::Aead2022(
+            CipherCategory::Aead2022 => Ok(Self::Aead2022(
                 Aead2022TcpRequestHeader::read_from(reader).await?,
             )),
         }
@@ -48,33 +48,33 @@ impl TcpRequestHeader {
 
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
         match *self {
-            TcpRequestHeader::Stream(ref h) => h.write_to_buf(buf),
+            Self::Stream(ref h) => h.write_to_buf(buf),
             #[cfg(feature = "aead-cipher-2022")]
-            TcpRequestHeader::Aead2022(ref h) => h.write_to_buf(buf),
+            Self::Aead2022(ref h) => h.write_to_buf(buf),
         }
     }
 
     pub fn addr(self) -> Address {
         match self {
-            TcpRequestHeader::Stream(h) => h.addr,
+            Self::Stream(h) => h.addr,
             #[cfg(feature = "aead-cipher-2022")]
-            TcpRequestHeader::Aead2022(h) => h.addr,
+            Self::Aead2022(h) => h.addr,
         }
     }
 
     pub fn addr_ref(&self) -> &Address {
         match *self {
-            TcpRequestHeader::Stream(ref h) => &h.addr,
+            Self::Stream(ref h) => &h.addr,
             #[cfg(feature = "aead-cipher-2022")]
-            TcpRequestHeader::Aead2022(ref h) => &h.addr,
+            Self::Aead2022(ref h) => &h.addr,
         }
     }
 
     pub fn serialized_len(&self) -> usize {
         match *self {
-            TcpRequestHeader::Stream(ref h) => h.serialized_len(),
+            Self::Stream(ref h) => h.serialized_len(),
             #[cfg(feature = "aead-cipher-2022")]
-            TcpRequestHeader::Aead2022(ref h) => h.serialized_len(),
+            Self::Aead2022(ref h) => h.serialized_len(),
         }
     }
 }

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v1.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v1.rs
@@ -13,8 +13,8 @@ pub struct StreamTcpRequestHeader {
 }
 
 impl StreamTcpRequestHeader {
-    pub async fn read_from<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<StreamTcpRequestHeader> {
-        Ok(StreamTcpRequestHeader {
+    pub async fn read_from<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Self> {
+        Ok(Self {
             addr: Address::read_from(reader).await?,
         })
     }

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v2.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/protocol/v2.rs
@@ -27,7 +27,7 @@ pub struct Aead2022TcpRequestHeader {
 }
 
 impl Aead2022TcpRequestHeader {
-    pub async fn read_from<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Aead2022TcpRequestHeader> {
+    pub async fn read_from<R: AsyncRead + Unpin>(reader: &mut R) -> io::Result<Self> {
         let addr = Address::read_from(reader).await?;
 
         let mut padding_size_buffer = [0u8; 2];
@@ -46,7 +46,7 @@ impl Aead2022TcpRequestHeader {
             }
         }
 
-        Ok(Aead2022TcpRequestHeader { addr, padding_size })
+        Ok(Self { addr, padding_size })
     }
 
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/server.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/server.rs
@@ -45,8 +45,8 @@ pub struct ProxyServerStream<S> {
 
 impl<S> ProxyServerStream<S> {
     /// Create a `ProxyServerStream` from a connection stream
-    pub fn from_stream(context: SharedContext, stream: S, method: CipherKind, key: &[u8]) -> ProxyServerStream<S> {
-        ProxyServerStream::from_stream_with_user_manager(context, stream, method, key, None)
+    pub fn from_stream(context: SharedContext, stream: S, method: CipherKind, key: &[u8]) -> Self {
+        Self::from_stream_with_user_manager(context, stream, method, key, None)
     }
 
     /// Create a `ProxyServerStream` from a connection stream
@@ -58,7 +58,7 @@ impl<S> ProxyServerStream<S> {
         method: CipherKind,
         key: &[u8],
         user_manager: Option<Arc<ServerUserManager>>,
-    ) -> ProxyServerStream<S> {
+    ) -> Self {
         #[cfg(feature = "aead-cipher-2022")]
         let writer_state = if method.is_aead_2022() {
             ProxyServerStreamWriteState::PrepareHeader(None)
@@ -70,7 +70,7 @@ impl<S> ProxyServerStream<S> {
         let writer_state = ProxyServerStreamWriteState::Established;
 
         const EMPTY_IDENTITY: [Bytes; 0] = [];
-        ProxyServerStream {
+        Self {
             stream: CryptoStream::from_stream_with_identity(
                 &context,
                 stream,

--- a/crates/shadowsocks/src/relay/tcprelay/stream.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/stream.rs
@@ -31,10 +31,10 @@ pub enum ProtocolError {
 pub type ProtocolResult<T> = Result<T, ProtocolError>;
 
 impl From<ProtocolError> for io::Error {
-    fn from(e: ProtocolError) -> io::Error {
+    fn from(e: ProtocolError) -> Self {
         match e {
             ProtocolError::IoError(err) => err,
-            _ => io::Error::other(e),
+            _ => Self::other(e),
         }
     }
 }
@@ -55,9 +55,9 @@ pub struct DecryptedReader {
 }
 
 impl DecryptedReader {
-    pub fn new(method: CipherKind, key: &[u8]) -> DecryptedReader {
+    pub fn new(method: CipherKind, key: &[u8]) -> Self {
         if method.iv_len() > 0 {
-            DecryptedReader {
+            Self {
                 state: DecryptReadState::WaitIv {
                     key: Bytes::copy_from_slice(key),
                 },
@@ -68,7 +68,7 @@ impl DecryptedReader {
                 has_handshaked: false,
             }
         } else {
-            DecryptedReader {
+            Self {
                 state: DecryptReadState::Read,
                 cipher: Some(Cipher::new(method, key, &[])),
                 buffer: BytesMut::new(),
@@ -209,12 +209,12 @@ pub struct EncryptedWriter {
 
 impl EncryptedWriter {
     /// Creates a new EncryptedWriter
-    pub fn new(method: CipherKind, key: &[u8], nonce: &[u8]) -> EncryptedWriter {
+    pub fn new(method: CipherKind, key: &[u8], nonce: &[u8]) -> Self {
         // nonce should be sent with the first packet
         let mut buffer = BytesMut::with_capacity(nonce.len());
         buffer.put(nonce);
 
-        EncryptedWriter {
+        Self {
             cipher: Cipher::new(method, key, nonce),
             buffer,
             state: EncryptWriteState::AssemblePacket,

--- a/crates/shadowsocks/src/relay/udprelay/aead_2022.rs
+++ b/crates/shadowsocks/src/relay/udprelay/aead_2022.rs
@@ -116,13 +116,13 @@ struct CipherKey {
 }
 
 impl PartialOrd for CipherKey {
-    fn partial_cmp(&self, other: &CipherKey) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for CipherKey {
-    fn cmp(&self, other: &CipherKey) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         let hash1 = {
             let mut hasher = DefaultHasher::new();
             self.hash(&mut hasher);

--- a/crates/shadowsocks/src/relay/udprelay/compat.rs
+++ b/crates/shadowsocks/src/relay/udprelay/compat.rs
@@ -47,11 +47,11 @@ impl DatagramSocket for UdpSocket {
 
 impl DatagramReceive for UdpSocket {
     fn poll_recv(&self, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
-        UdpSocket::poll_recv(self, cx, buf)
+        Self::poll_recv(self, cx, buf)
     }
 
     fn poll_recv_from(&self, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<SocketAddr>> {
-        UdpSocket::poll_recv_from(self, cx, buf)
+        Self::poll_recv_from(self, cx, buf)
     }
 
     fn poll_recv_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -61,11 +61,11 @@ impl DatagramReceive for UdpSocket {
 
 impl DatagramSend for UdpSocket {
     fn poll_send(&self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
-        UdpSocket::poll_send(self, cx, buf)
+        Self::poll_send(self, cx, buf)
     }
 
     fn poll_send_to(&self, cx: &mut Context<'_>, buf: &[u8], target: SocketAddr) -> Poll<io::Result<usize>> {
-        UdpSocket::poll_send_to(self, cx, buf, target)
+        Self::poll_send_to(self, cx, buf, target)
     }
 
     fn poll_send_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/crates/shadowsocks/src/relay/udprelay/proxy_socket.rs
+++ b/crates/shadowsocks/src/relay/udprelay/proxy_socket.rs
@@ -60,10 +60,10 @@ pub enum ProxySocketError {
 }
 
 impl From<ProxySocketError> for io::Error {
-    fn from(e: ProxySocketError) -> io::Error {
+    fn from(e: ProxySocketError) -> Self {
         match e {
             ProxySocketError::IoError(e) => e,
-            _ => io::Error::other(e),
+            _ => Self::other(e),
         }
     }
 }
@@ -90,8 +90,8 @@ impl ProxySocket<ShadowUdpSocket> {
     pub async fn connect(
         context: SharedContext,
         svr_cfg: &ServerConfig,
-    ) -> ProxySocketResult<ProxySocket<ShadowUdpSocket>> {
-        ProxySocket::connect_with_opts(context, svr_cfg, &DEFAULT_CONNECT_OPTS).await
+    ) -> ProxySocketResult<Self> {
+        Self::connect_with_opts(context, svr_cfg, &DEFAULT_CONNECT_OPTS).await
     }
 
     /// Create a client to communicate with Shadowsocks' UDP server (outbound)
@@ -99,7 +99,7 @@ impl ProxySocket<ShadowUdpSocket> {
         context: SharedContext,
         svr_cfg: &ServerConfig,
         opts: &ConnectOpts,
-    ) -> ProxySocketResult<ProxySocket<ShadowUdpSocket>> {
+    ) -> ProxySocketResult<Self> {
         // Note: Plugins doesn't support UDP relay
 
         let socket = ShadowUdpSocket::connect_server_with_opts(&context, svr_cfg.udp_external_addr(), opts).await?;
@@ -111,7 +111,7 @@ impl ProxySocket<ShadowUdpSocket> {
             opts
         );
 
-        Ok(ProxySocket::from_socket(
+        Ok(Self::from_socket(
             UdpSocketType::Client,
             context,
             svr_cfg,
@@ -123,8 +123,8 @@ impl ProxySocket<ShadowUdpSocket> {
     pub async fn bind(
         context: SharedContext,
         svr_cfg: &ServerConfig,
-    ) -> ProxySocketResult<ProxySocket<ShadowUdpSocket>> {
-        ProxySocket::bind_with_opts(context, svr_cfg, AcceptOpts::default()).await
+    ) -> ProxySocketResult<Self> {
+        Self::bind_with_opts(context, svr_cfg, AcceptOpts::default()).await
     }
 
     /// Create a `ProxySocket` binding to a specific address (inbound)
@@ -132,7 +132,7 @@ impl ProxySocket<ShadowUdpSocket> {
         context: SharedContext,
         svr_cfg: &ServerConfig,
         opts: AcceptOpts,
-    ) -> ProxySocketResult<ProxySocket<ShadowUdpSocket>> {
+    ) -> ProxySocketResult<Self> {
         // Plugins doesn't support UDP
         let socket = match svr_cfg.udp_external_addr() {
             ServerAddr::SocketAddr(sa) => ShadowUdpSocket::listen_with_opts(sa, opts).await?,
@@ -143,7 +143,7 @@ impl ProxySocket<ShadowUdpSocket> {
                 .1
             }
         };
-        Ok(ProxySocket::from_socket(
+        Ok(Self::from_socket(
             UdpSocketType::Server,
             context,
             svr_cfg,
@@ -159,12 +159,12 @@ impl<S> ProxySocket<S> {
         context: SharedContext,
         svr_cfg: &ServerConfig,
         socket: S,
-    ) -> ProxySocket<S> {
+    ) -> Self {
         let key = svr_cfg.key().to_vec().into_boxed_slice();
         let method = svr_cfg.method();
 
         // NOTE: svr_cfg.timeout() is not for this socket, but for associations.
-        ProxySocket {
+        Self {
             socket_type,
             io: socket,
             method,

--- a/crates/shadowsocks/src/security/replay/mod.rs
+++ b/crates/shadowsocks/src/security/replay/mod.rs
@@ -40,8 +40,8 @@ impl fmt::Debug for ReplayProtector {
 impl ReplayProtector {
     /// Create a new ReplayProtector
     #[allow(unused_variables)]
-    pub fn new(config_type: ServerType) -> ReplayProtector {
-        ReplayProtector {
+    pub fn new(config_type: ServerType) -> Self {
+        Self {
             #[cfg(feature = "security-replay-attack-detect")]
             nonce_ppbloom: spin::Mutex::new(PingPongBloom::new(config_type)),
             #[cfg(feature = "aead-cipher-2022")]

--- a/crates/shadowsocks/src/security/replay/ppbloom.rs
+++ b/crates/shadowsocks/src/security/replay/ppbloom.rs
@@ -36,7 +36,7 @@ pub struct PingPongBloom {
 }
 
 impl PingPongBloom {
-    pub fn new(ty: ServerType) -> PingPongBloom {
+    pub fn new(ty: ServerType) -> Self {
         let (mut item_count, fp_p) = if ty.is_local() {
             (BF_NUM_ENTRIES_FOR_CLIENT, BF_ERROR_RATE_FOR_CLIENT)
         } else {
@@ -45,7 +45,7 @@ impl PingPongBloom {
 
         item_count /= 2;
 
-        PingPongBloom {
+        Self {
             blooms: [
                 Bloom::new_for_fp_rate(item_count, fp_p).expect("BloomFilter1"),
                 Bloom::new_for_fp_rate(item_count, fp_p).expect("BloomFilter2"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,24 +108,24 @@ pub struct Config {
 
 impl Config {
     /// Load `Config` from file
-    pub fn load_from_file<P: AsRef<Path>>(filename: &P) -> Result<Config, ConfigError> {
+    pub fn load_from_file<P: AsRef<Path>>(filename: &P) -> Result<Self, ConfigError> {
         let filename = filename.as_ref();
 
         let mut reader = OpenOptions::new().read(true).open(filename)?;
         let mut content = String::new();
         reader.read_to_string(&mut content)?;
 
-        Config::load_from_str(&content)
+        Self::load_from_str(&content)
     }
 
     /// Load `Config` from string
-    pub fn load_from_str(s: &str) -> Result<Config, ConfigError> {
+    pub fn load_from_str(s: &str) -> Result<Self, ConfigError> {
         let ssconfig = json5::from_str(s)?;
-        Config::load_from_ssconfig(ssconfig)
+        Self::load_from_ssconfig(ssconfig)
     }
 
-    fn load_from_ssconfig(ssconfig: SSConfig) -> Result<Config, ConfigError> {
-        let mut config = Config::default();
+    fn load_from_ssconfig(ssconfig: SSConfig) -> Result<Self, ConfigError> {
+        let mut config = Self::default();
 
         #[cfg(feature = "logging")]
         if let Some(log) = ssconfig.log {
@@ -240,11 +240,11 @@ pub struct RuntimeModeError;
 impl FromStr for RuntimeMode {
     type Err = RuntimeModeError;
 
-    fn from_str(s: &str) -> Result<RuntimeMode, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "single_thread" => Ok(RuntimeMode::SingleThread),
+            "single_thread" => Ok(Self::SingleThread),
             #[cfg(feature = "multi-threaded")]
-            "multi_thread" => Ok(RuntimeMode::MultiThread),
+            "multi_thread" => Ok(Self::MultiThread),
             _ => Err(RuntimeModeError),
         }
     }

--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -59,19 +59,19 @@ mod local_value_parser {
     impl FromStr for RemoteDnsAddress {
         type Err = AddressError;
 
-        fn from_str(a: &str) -> Result<RemoteDnsAddress, Self::Err> {
+        fn from_str(a: &str) -> Result<Self, Self::Err> {
             if let Ok(ip) = a.parse::<IpAddr>() {
-                return Ok(RemoteDnsAddress(Address::SocketAddress(SocketAddr::new(ip, 53))));
+                return Ok(Self(Address::SocketAddress(SocketAddr::new(ip, 53))));
             }
 
             if let Ok(saddr) = a.parse::<SocketAddr>() {
-                return Ok(RemoteDnsAddress(Address::SocketAddress(saddr)));
+                return Ok(Self(Address::SocketAddress(saddr)));
             }
 
             if a.find(':').is_some() {
                 a.parse::<Address>().map(RemoteDnsAddress)
             } else {
-                Ok(RemoteDnsAddress(Address::DomainNameAddress(a.to_owned(), 53)))
+                Ok(Self(Address::DomainNameAddress(a.to_owned(), 53)))
             }
         }
     }

--- a/tests/socks4.rs
+++ b/tests/socks4.rs
@@ -27,7 +27,7 @@ pub struct Socks4TestServer {
 }
 
 impl Socks4TestServer {
-    pub fn new<S, L>(svr_addr: S, local_addr: L, pwd: &str, method: CipherKind) -> Socks4TestServer
+    pub fn new<S, L>(svr_addr: S, local_addr: L, pwd: &str, method: CipherKind) -> Self
     where
         S: ToSocketAddrs,
         L: ToSocketAddrs,
@@ -35,7 +35,7 @@ impl Socks4TestServer {
         let svr_addr = svr_addr.to_socket_addrs().unwrap().next().unwrap();
         let local_addr = local_addr.to_socket_addrs().unwrap().next().unwrap();
 
-        Socks4TestServer {
+        Self {
             local_addr,
             svr_config: {
                 let mut cfg = Config::new(ConfigType::Server);

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -28,7 +28,7 @@ pub struct Socks5TestServer {
 }
 
 impl Socks5TestServer {
-    pub fn new<S, L>(svr_addr: S, local_addr: L, pwd: &str, method: CipherKind, enable_udp: bool) -> Socks5TestServer
+    pub fn new<S, L>(svr_addr: S, local_addr: L, pwd: &str, method: CipherKind, enable_udp: bool) -> Self
     where
         S: ToSocketAddrs,
         L: ToSocketAddrs,
@@ -36,7 +36,7 @@ impl Socks5TestServer {
         let svr_addr = svr_addr.to_socket_addrs().unwrap().next().unwrap();
         let local_addr = local_addr.to_socket_addrs().unwrap().next().unwrap();
 
-        Socks5TestServer {
+        Self {
             local_addr,
             svr_config: {
                 let mut cfg = Config::new(ConfigType::Server);


### PR DESCRIPTION
This PR applies the clippy::use_self lint across the codebase using:
```
cargo clippy --features "full-extra local-flow-stat utility-url-outline" --allow-dirty --all --fix -- -W clippy::use_self
```
### Motivation:
* Improves readability and maintainability by reducing redundancy in impl blocks.
* Makes the codebase more idiomatic, aligning with common Rust practices.
* Helps future-proof refactoring (e.g. type renaming).