### PR TITLE
chore: compile xdg only on unix

### DIFF
--- a/.github/workflows/build-msrv.yml
+++ b/.github/workflows/build-msrv.yml
@@ -55,7 +55,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
       - if: ${{ matrix.platform == 'ubuntu-latest' }}
         name: Install LLVM and Clang
-        run: sudo apt install -y clang
+        run: sudo apt update && sudo apt install -y clang
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - if: ${{ runner.os == 'Windows' }}
@@ -84,7 +84,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
       - if: ${{ matrix.platform == 'ubuntu-latest' }}
         name: Install LLVM and Clang
-        run: sudo apt install -y clang
+        run: sudo apt update && sudo apt install -y clang
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - if: ${{ runner.os == 'Windows' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,6 @@ qrcode = { version = "0.14", default-features = false, optional = true }
 sysexits = "0.9"
 build-time = "0.1"
 directories = "6.0"
-xdg = "3.0"
 rpassword = "7.3"
 libc = { version = "0.2", features = ["extra_traits"] }
 rand = "0.9"
@@ -248,6 +247,7 @@ windows-service = { version = "0.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = "0.5"
+xdg = "3.0"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 reqwest = { version = "0.12", features = [


### PR DESCRIPTION
* The crate `xdg` is only used in unix system, so only compile it for unix target.
* Update `build-msrv.yml` file for https://github.com/shadowsocks/shadowsocks-rust/commit/27202a516b972deff5c6017dc99910cd03fd0fe8 .