### PR TITLE
fix: make hickory-dns truly optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ jemallocator = { version = "0.5", optional = true }
 snmalloc-rs = { version = "0.3", optional = true }
 rpmalloc = { version = "0.2", optional = true }
 
-shadowsocks-service = { version = "1.23.4", path = "./crates/shadowsocks-service" }
+shadowsocks-service = { version = "1.23.4", path = "./crates/shadowsocks-service", default-features = false, features = ["aead-cipher"] }
 
 windows-service = { version = "0.8", optional = true }
 


### PR DESCRIPTION
`hickory-dns` is enabled by default even using `--no-default-features`, though it is specified as optional in README.