### PR TITLE
Allow user to pass SocketProtector callback function for android

### DIFF
--- a/crates/shadowsocks/src/net/mod.rs
+++ b/crates/shadowsocks/src/net/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     udp::UdpSocket,
 };
 #[cfg(target_os = "android")]
-pub use self::option::android::SocketProtector;
+pub use self::option::android::{CloneFn, SocketProtectFn, socket_protect_fn};
 
 mod option;
 mod sys;

--- a/crates/shadowsocks/src/net/sys/unix/linux/mod.rs
+++ b/crates/shadowsocks/src/net/sys/unix/linux/mod.rs
@@ -69,8 +69,8 @@ impl TcpStream {
                 }
             }
 
-            if let Some(ref protector) = opts.vpn_socket_protector {
-                protector.protect(socket.as_raw_fd());
+            if let Some(ref protect_fn) = opts.vpn_socket_protect_fn {
+                protect_fn.call(socket.as_raw_fd());
             }
         }
 
@@ -349,8 +349,8 @@ pub async fn bind_outbound_udp_socket(bind_addr: &SocketAddr, config: &ConnectOp
             }
         }
 
-        if let Some(ref protector) = config.vpn_socket_protector {
-            protector.protect(socket.as_raw_fd());
+        if let Some(ref protect_fn) = opts.vpn_socket_protect_fn {
+            protect_fn.call(socket.as_raw_fd());
         }
     }
 


### PR DESCRIPTION
Allow user to implement the Rust interface which calls the Java VPNService protect method, and to be used to protect the socket fd right after the socket is created on Android.