### PR TITLE
chore: allow clippy::uninlined_format_args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,7 +3422,6 @@ dependencies = [
  "log",
  "log4rs",
  "mimalloc",
- "mime",
  "qrcode",
  "rand 0.9.1",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ local-fake-dns = ["local", "shadowsocks-service/local-fake-dns", "ipnet"]
 # https://shadowsocks.org/doc/sip008.html
 local-online-config = [
     "local",
-    "mime",
     "shadowsocks-service/local-online-config",
 ]
 
@@ -218,7 +217,6 @@ serde = { version = "1.0", features = ["derive"] }
 json5 = "0.4"
 thiserror = "2.0"
 base64 = "0.22"
-mime = { version = "0.3", optional = true }
 
 clap = { version = "4.5", features = ["wrap_help", "suggestions"] }
 cfg-if = "1"
@@ -267,3 +265,6 @@ byteorder = "1.5"
 env_logger = "0.11"
 byte_string = "1.0"
 tokio = { version = "1", features = ["net", "time", "macros", "io-util"] }
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -219,3 +219,6 @@ features = [
     "dns-over-tls",
     "dns-over-https",
 ]
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/crates/shadowsocks/Cargo.toml
+++ b/crates/shadowsocks/Cargo.toml
@@ -111,3 +111,6 @@ sendfd = { version = "0.4", features = ["tokio"] }
 
 [dev-dependencies]
 env_logger = "0.11"
+
+[lints.clippy]
+uninlined_format_args = "allow"


### PR DESCRIPTION
* Disable stylistic lint enabled by default in Rust v1.88.
* Remove `mime` crate from `shadowsocks-rust` as it's only used in `shadowsocks-service`.