### PR TITLE
fix(shadowsocks-service): fix compilation without `aead-cipher`

### DIFF
--- a/crates/shadowsocks-service/src/manager/server.rs
+++ b/crates/shadowsocks-service/src/manager/server.rs
@@ -479,7 +479,7 @@ impl Manager {
             #[cfg(feature = "aead-cipher")]
             None => self.svr_cfg.method.unwrap_or(CipherKind::CHACHA20_POLY1305),
             #[cfg(not(feature = "aead-cipher"))]
-            None => return Ok(AddResponse("method is required")),
+            None => return Ok(AddResponse("method is required".to_string())),
         };
 
         let mut svr_cfg = match ServerConfig::new(addr, req.password.clone(), method) {


### PR DESCRIPTION
#1968 made it possible to actually disable `aead-cipher` feature for `shadowsocks-service`.
That exposed previously unreachable code path which does not compile.

Closes #1982.
