### PR TITLE
feat: support file logging with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "windows-service",
  "xdg",
@@ -4010,6 +4011,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ dns-over-https = ["shadowsocks-service/dns-over-https"]
 dns-over-h3 = ["shadowsocks-service/dns-over-h3"]
 
 # Enable logging output
-logging = ["log4rs", "tracing", "tracing-subscriber", "time"]
+logging = ["log4rs", "tracing", "tracing-subscriber", "time", "tracing-appender"]
 
 # Enable DNS-relay
 local-dns = ["local", "shadowsocks-service/local-dns"]
@@ -208,6 +208,7 @@ tracing-subscriber = { version = "0.3", optional = true, features = [
     "time",
     "local-time",
 ] }
+tracing-appender = { version = "0.2.3", optional = true, default-features = false }
 time = { version = "0.3", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -877,9 +877,23 @@ Example configuration:
             // Euiqvalent to `--log-without-time`
             "without_time": false,
         },
-        // Equivalent to `--log-config`
-        // More detail could be found in https://crates.io/crates/log4rs
-        "config_path": "/path/to/log4rs/config.yaml"
+        // File logging configuration (will disable stdout logging)
+        // This is particularly useful for running as a Windows Service
+        "file": {
+            // Directory to store log files. If not set, it will not log to file
+            "directory": "/var/log/shadowsocks-rust",
+            // Log rotation frequency, must be one of the following:
+            // - never (default): This will result in log file located at `directory/prefix.suffix`
+            // - daily: A new log file in the format of `directory/prefix.yyyy-MM-dd.suffix` will be created daily
+            // - hourly: A new log file in the format of `directory/prefix.yyyy-MM-dd-HH.suffix` will be created hourly
+            "rotation": "never",
+            // Prefix of log file, default is one of `sslocal`, `ssserver`, `ssmanager` depending on the service being run.
+            "prefix": "shadowsocks-rust",
+            // Suffix of log file, default is `log`
+            "suffix": "log",
+            // Keeps the last N log files. If not set, no limit will be applied.
+            "max_files": 5
+        }
     },
     // Runtime configuration
     "runtime": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,29 +142,29 @@ impl Config {
                 nlog.format = nformat;
             }
 
-            if let Some(file_config) = log.file
+            if let Some(file_config) = log.file {
                 // directory must be configured for file logging
-                && let Some(directory) = file_config.directory
-            {
-                let mut nfile = LogFileConfig::new(directory);
-                if let Some(rotation) = file_config.rotation {
-                    nfile.rotation = match rotation.as_str() {
-                        "never" => tracing_appender::rolling::Rotation::NEVER,
-                        "hourly" => tracing_appender::rolling::Rotation::HOURLY,
-                        "daily" => tracing_appender::rolling::Rotation::DAILY,
-                        _ => return Err(ConfigError::InvalidValue(rotation)),
-                    };
+                if let Some(directory) = file_config.directory {
+                    let mut nfile = LogFileConfig::new(directory);
+                    if let Some(rotation) = file_config.rotation {
+                        nfile.rotation = match rotation.as_str() {
+                            "never" => tracing_appender::rolling::Rotation::NEVER,
+                            "hourly" => tracing_appender::rolling::Rotation::HOURLY,
+                            "daily" => tracing_appender::rolling::Rotation::DAILY,
+                            _ => return Err(ConfigError::InvalidValue(rotation)),
+                        };
+                    }
+                    if let Some(prefix) = file_config.prefix {
+                        nfile.prefix = Some(prefix);
+                    }
+                    if let Some(suffix) = file_config.suffix {
+                        nfile.suffix = Some(suffix);
+                    }
+                    if let Some(max_files) = file_config.max_files {
+                        nfile.max_files = Some(max_files);
+                    }
+                    nlog.file = Some(nfile);
                 }
-                if let Some(prefix) = file_config.prefix {
-                    nfile.prefix = Some(prefix);
-                }
-                if let Some(suffix) = file_config.suffix {
-                    nfile.suffix = Some(suffix);
-                }
-                if let Some(max_files) = file_config.max_files {
-                    nfile.max_files = Some(max_files);
-                }
-                nlog.file = Some(nfile);
             }
 
             if let Some(config_path) = log.config_path {

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -9,7 +9,7 @@ use crate::config::LogConfig;
 mod log4rs;
 mod tracing;
 
-/// Initialize logger ([log4rs](https://crates.io/crates/log4rs), [trace4rs](https://crates.io/crates/trace4rs)) from yaml configuration file
+/// Initialize [log4rs](https://crates.io/crates/log4rs) from yaml configuration file
 pub fn init_with_file<P>(path: P)
 where
     P: AsRef<Path>,
@@ -25,7 +25,6 @@ where
 
 /// Initialize logger with provided configuration
 pub fn init_with_config(bin_name: &str, config: &LogConfig) {
-    // log4rs::init_with_config(bin_name, config);
     tracing::init_with_config(bin_name, config);
 }
 

--- a/src/logging/tracing.rs
+++ b/src/logging/tracing.rs
@@ -2,26 +2,27 @@
 
 use std::io::IsTerminal;
 
+use time::format_description::well_known::Rfc3339;
 use time::UtcOffset;
 use tracing::level_filters::LevelFilter;
-use tracing_subscriber::{EnvFilter, FmtSubscriber, fmt::time::OffsetTime};
+use tracing_appender::rolling::{InitError, RollingFileAppender};
+use tracing_subscriber::fmt::format::{DefaultFields, Format, Full};
+use tracing_subscriber::fmt::time::OffsetTime;
+use tracing_subscriber::fmt::{MakeWriter, SubscriberBuilder};
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
-use crate::config::LogConfig;
+use crate::config::{LogConfig, LogFileConfig};
 
 /// Initialize logger with provided configuration
 pub fn init_with_config(bin_name: &str, config: &LogConfig) {
     let debug_level = config.level;
     let without_time = config.format.without_time;
 
-    let mut builder = FmtSubscriber::builder()
-        .with_level(true)
-        .with_timer(match OffsetTime::local_rfc_3339() {
-            Ok(t) => t,
-            Err(..) => {
-                // Reinit with UTC time
-                OffsetTime::new(UtcOffset::UTC, time::format_description::well_known::Rfc3339)
-            }
-        });
+    let mut builder = FmtSubscriber::builder().with_level(true).with_timer(
+        OffsetTime::local_rfc_3339()
+                    // Fallback to UTC. Eagerly evaluate because it is cheap to create.
+                    .unwrap_or(OffsetTime::new(UtcOffset::UTC, Rfc3339)),
+    );
 
     // NOTE: ansi is enabled by default.
     // Could be disabled by `NO_COLOR` environment variable.
@@ -74,6 +75,43 @@ pub fn init_with_config(bin_name: &str, config: &LogConfig) {
     };
     let builder = builder.with_env_filter(filter);
 
+    if let Some(ref file_config) = config.file {
+        let file_writer = make_file_writer(bin_name, file_config)
+            // don't have the room for a more graceful error handling here
+            .expect("Failed to create file writer for logging");
+        init(builder.with_ansi(false).with_writer(file_writer), without_time);
+    } else {
+        init(builder, without_time);
+    }
+}
+
+fn make_file_writer(bin_name: &str, config: &LogFileConfig) -> Result<RollingFileAppender, InitError> {
+    let rotation = config.rotation.clone();
+    // We provide default values here because we don't have access to the
+    // `bin_name` elsewhere.
+    let prefix = config.prefix.as_deref().unwrap_or(bin_name);
+    let suffix = config.suffix.as_deref().unwrap_or("log");
+
+    let mut builder = RollingFileAppender::builder()
+        .rotation(rotation)
+        .filename_prefix(prefix)
+        .filename_suffix(suffix);
+
+    if let Some(max_files) = config.max_files {
+        builder = builder.max_log_files(max_files);
+    }
+
+    builder.build(&config.directory)
+}
+
+/// Initialize the logger with the provided builder and options.
+///
+/// This handles the `without_time` option generically for builders that
+/// are configured with different `MakeWriter` concrete types.
+fn init<W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static>(
+    builder: SubscriberBuilder<DefaultFields, Format<Full, OffsetTime<Rfc3339>>, EnvFilter, W>,
+    without_time: bool,
+) {
     if without_time {
         builder.without_time().init();
     } else {

--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -261,6 +261,8 @@ pub fn define_command_line_options(mut app: Command) -> Command {
             .arg(
                 Arg::new("LOG_CONFIG")
                     .long("log-config")
+                    // deprecated for removal
+                    .hide(true)
                     .num_args(1)
                     .action(ArgAction::Set)
                     .value_parser(clap::value_parser!(PathBuf))

--- a/src/service/manager.rs
+++ b/src/service/manager.rs
@@ -148,6 +148,8 @@ pub fn define_command_line_options(mut app: Command) -> Command {
             .arg(
                 Arg::new("LOG_CONFIG")
                     .long("log-config")
+                    // deprecated for removal
+                    .hide(true)
                     .num_args(1)
                     .action(ArgAction::Set)
                     .value_parser(clap::value_parser!(PathBuf))
@@ -297,7 +299,7 @@ pub fn create(matches: &ArgMatches) -> ShadowsocksResult<(Runtime, impl Future<O
                 logging::init_with_file(path);
             }
             None => {
-                logging::init_with_config("sslocal", &service_config.log);
+                logging::init_with_config("ssmanager", &service_config.log);
             }
         }
 

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -178,6 +178,8 @@ pub fn define_command_line_options(mut app: Command) -> Command {
             .arg(
                 Arg::new("LOG_CONFIG")
                     .long("log-config")
+                    // deprecated for removal
+                    .hide(true)
                     .num_args(1)
                     .action(ArgAction::Set)
                     .value_parser(clap::value_parser!(PathBuf))
@@ -309,7 +311,7 @@ pub fn create(matches: &ArgMatches) -> ShadowsocksResult<(Runtime, impl Future<O
                 logging::init_with_file(path);
             }
             None => {
-                logging::init_with_config("sslocal", &service_config.log);
+                logging::init_with_config("ssserver", &service_config.log);
             }
         }
 


### PR DESCRIPTION
### Summary

Enable file logging with tracing via `tracing-appender` and introduce new `log.file.*` configuration options.

As `log4rs` is scheduled for removal, this PR serves as an intermediate step toward that transition. I’ve also removed user-facing documentation pertaining to `log4rs` to reduce the impact of potential future breaking changes.

### Known Limitations

#### Console output will be suppressed if file logging is configured.

Significant additional work is required to support both.

#### Does not support rotation based on file size.

This is an inherent limitation of the `tracing-appender` library.

#### Plugin output will not be written to file

This is an existing issue that applies to `log4rs` as well.
