### PR TITLE
feat: file and advanced logging configuration for tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "windows-service",
  "xdg",
@@ -4010,6 +4011,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ dns-over-https = ["shadowsocks-service/dns-over-https"]
 dns-over-h3 = ["shadowsocks-service/dns-over-h3"]
 
 # Enable logging output
-logging = ["log4rs", "tracing", "tracing-subscriber", "time"]
+logging = ["log4rs", "tracing", "tracing-subscriber", "time", "tracing-appender"]
 
 # Enable DNS-relay
 local-dns = ["local", "shadowsocks-service/local-dns"]
@@ -208,6 +208,7 @@ tracing-subscriber = { version = "0.3", optional = true, features = [
     "time",
     "local-time",
 ] }
+tracing-appender = { version = "0.2.3", optional = true, default-features = false }
 time = { version = "0.3", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -871,19 +871,54 @@ Example configuration:
     // Service configurations
     // Logger configuration
     "log": {
+        // Default log level to use, if not overridden by `writers`, default is `0`
         // Equivalent to `-v` command line option
         "level": 1,
+        // Default log format to use, if not overridden by `writers`
         "format": {
-            // Euiqvalent to `--log-without-time`
+            // Euiqvalent to `--log-without-time`, default is `false`
             "without_time": false,
         },
-        // Equivalent to `--log-config`
-        // More detail could be found in https://crates.io/crates/log4rs
-        "config_path": "/path/to/log4rs/config.yaml"
+        // Advanced logging configuration for configuring multiple writers
+        // A stdout writer will be configured by default.
+        // Set this to empty array `[]` to disable logging completely
+        "writers": [
+            {
+                // Configure a stdout writer
+                // The inner fields are optional, if not set, it will use the default values
+                // To minimally configure a stdout writer, simply write `"stdout": {}`.
+                "stdout": {
+                    "level": 2,
+                    "format": {
+                        "without_time": false,
+                    }
+                }
+            },
+            {
+                // Configure a file writer, useful when running as a Windows Service
+                "file": {
+                    // `level` and `format` can also be set here, if not set, it will use the default values
+                    
+                    // Required. Directory to store log files
+                    "directory": "/var/log/shadowsocks-rust",
+                    // Optional. Log rotation frequency, must be one of the following:
+                    // - never (default): This will result in log file located at `directory/prefix.suffix`
+                    // - daily: A new log file in the format of `directory/prefix.yyyy-MM-dd.suffix` will be created daily
+                    // - hourly: A new log file in the format of `directory/prefix.yyyy-MM-dd-HH.suffix` will be created hourly
+                    "rotation": "never",
+                    // Optional. Prefix of log file, default is one of `sslocal`, `ssserver`, `ssmanager` depending on the service being run.
+                    "prefix": "shadowsocks-rust",
+                    // Optional. Suffix of log file, default is `log`
+                    "suffix": "log",
+                    // Optional. If set, keeps the last N log files
+                    "max_files": 5
+                }
+            }
+        ]
     },
     // Runtime configuration
     "runtime": {
-        // single_thread or multi_thread
+        // `single_thread` or `multi_thread`
         "mode": "multi_thread",
         // Worker threads that are used in multi-thread runtime
         "worker_count": 10

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -9,7 +9,7 @@ use crate::config::LogConfig;
 mod log4rs;
 mod tracing;
 
-/// Initialize logger ([log4rs](https://crates.io/crates/log4rs), [trace4rs](https://crates.io/crates/trace4rs)) from yaml configuration file
+/// Initialize [log4rs](https://crates.io/crates/log4rs) from yaml configuration file
 pub fn init_with_file<P>(path: P)
 where
     P: AsRef<Path>,
@@ -25,7 +25,6 @@ where
 
 /// Initialize logger with provided configuration
 pub fn init_with_config(bin_name: &str, config: &LogConfig) {
-    // log4rs::init_with_config(bin_name, config);
     tracing::init_with_config(bin_name, config);
 }
 

--- a/src/logging/tracing.rs
+++ b/src/logging/tracing.rs
@@ -1,51 +1,112 @@
 //! Logging facilities with tracing
 
+use std::io;
 use std::io::IsTerminal;
 
+use time::format_description::well_known::Rfc3339;
 use time::UtcOffset;
 use tracing::level_filters::LevelFilter;
-use tracing_subscriber::{EnvFilter, FmtSubscriber, fmt::time::OffsetTime};
+use tracing_appender::rolling::{InitError, RollingFileAppender};
+use tracing_subscriber::fmt::time::OffsetTime;
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{fmt, EnvFilter, Layer, Registry};
 
-use crate::config::LogConfig;
+use crate::config::{
+    LogConfig, LogConsoleWriterConfig, LogFileWriterConfig, LogFormatConfig, LogFormatConfigOverride, LogWriterConfig,
+};
 
 /// Initialize logger with provided configuration
 pub fn init_with_config(bin_name: &str, config: &LogConfig) {
-    let debug_level = config.level;
-    let without_time = config.format.without_time;
+    let layers: Vec<BoxedLayer> = config
+        .writers
+        .iter()
+        .map(|writer| writer.make_layer(bin_name, config))
+        .collect();
+    tracing_subscriber::registry().with(layers).init();
+}
 
-    let mut builder = FmtSubscriber::builder()
-        .with_level(true)
-        .with_timer(match OffsetTime::local_rfc_3339() {
-            Ok(t) => t,
-            Err(..) => {
-                // Reinit with UTC time
-                OffsetTime::new(UtcOffset::UTC, time::format_description::well_known::Rfc3339)
-            }
-        });
+type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
+
+trait MakeLayer {
+    fn make_layer(&self, bin_name: &str, global: &LogConfig) -> BoxedLayer;
+}
+
+impl MakeLayer for LogWriterConfig {
+    fn make_layer(&self, bin_name: &str, global: &LogConfig) -> BoxedLayer {
+        match self {
+            LogWriterConfig::Stdout(console_config) => console_config.make_layer(bin_name, global),
+            LogWriterConfig::File(file_config) => file_config.make_layer(bin_name, global),
+        }
+    }
+}
+
+impl MakeLayer for LogConsoleWriterConfig {
+    fn make_layer(&self, bin_name: &str, global: &LogConfig) -> BoxedLayer {
+        let level = self.level.unwrap_or(global.level);
+        let format = apply_override(&global.format, &self.format);
+        let ansi = io::stdout().is_terminal();
+        make_fmt_layer(bin_name, level, &format, ansi, io::stdout)
+    }
+}
+
+impl MakeLayer for LogFileWriterConfig {
+    fn make_layer(&self, bin_name: &str, global: &LogConfig) -> BoxedLayer {
+        let level = self.level.unwrap_or(global.level);
+        let format = apply_override(&global.format, &self.format);
+
+        let file_writer = make_file_writer(bin_name, self)
+            // don't have the room for a more graceful error handling here
+            .expect("Failed to create file writer for logging");
+        make_fmt_layer(bin_name, level, &format, false, file_writer)
+    }
+}
+
+/// Boilerplate for configuring a `fmt::Layer` with `level` and `format` for different writers.
+fn make_fmt_layer<W>(bin_name: &str, level: u32, format: &LogFormatConfig, ansi: bool, writer: W) -> BoxedLayer
+where
+    W: for<'a> MakeWriter<'a> + Send + Sync + 'static,
+{
+    let mut layer = fmt::layer().with_level(true);
 
     // NOTE: ansi is enabled by default.
     // Could be disabled by `NO_COLOR` environment variable.
     // https://no-color.org/
-    if !std::io::stdout().is_terminal() {
-        builder = builder.with_ansi(false);
+    if !ansi {
+        layer = layer.with_ansi(false);
     }
 
-    if debug_level >= 1 {
-        builder = builder.with_target(true).with_thread_ids(true).with_thread_names(true);
+    if level >= 1 {
+        layer = layer.with_target(true).with_thread_ids(true).with_thread_names(true);
 
-        if debug_level >= 3 {
-            builder = builder.with_file(true).with_line_number(true);
+        if level >= 3 {
+            layer = layer.with_file(true).with_line_number(true);
         }
     } else {
-        builder = builder
-            .with_target(false)
-            .with_thread_ids(false)
-            .with_thread_names(false);
+        layer = layer.with_target(false).with_thread_ids(false).with_thread_names(false);
     }
 
-    let filter = match EnvFilter::try_from_default_env() {
+    let layer = layer.with_writer(writer);
+
+    let boxed_layer = if format.without_time {
+        layer.without_time().boxed()
+    } else {
+        layer
+            .with_timer(OffsetTime::local_rfc_3339()
+                // Fallback to UTC. Eagerly evaluate because it is cheap to create.
+                .unwrap_or(OffsetTime::new(UtcOffset::UTC, Rfc3339)))
+            .boxed()
+    };
+
+    let filter = make_env_filter(bin_name, level);
+    boxed_layer.with_filter(filter).boxed()
+}
+
+fn make_env_filter(bin_name: &str, level: u32) -> EnvFilter {
+    match EnvFilter::try_from_default_env() {
         Ok(f) => f,
-        Err(..) => match debug_level {
+        Err(_) => match level {
             0 => EnvFilter::builder()
                 .with_regex(true)
                 .with_default_directive(LevelFilter::ERROR.into())
@@ -71,12 +132,33 @@ pub fn init_with_config(bin_name: &str, config: &LogConfig) {
                 .with_default_directive(LevelFilter::TRACE.into())
                 .parse_lossy(""),
         },
-    };
-    let builder = builder.with_env_filter(filter);
+    }
+}
 
-    if without_time {
-        builder.without_time().init();
-    } else {
-        builder.init();
+fn make_file_writer(bin_name: &str, config: &LogFileWriterConfig) -> Result<RollingFileAppender, InitError> {
+    // We provide default values here because we don't have access to the
+    // `bin_name` elsewhere.
+    let prefix = config.prefix.as_deref().unwrap_or(bin_name);
+    let suffix = config.suffix.as_deref().unwrap_or("log");
+
+    let mut builder = RollingFileAppender::builder()
+        .rotation(config.rotation.into())
+        .filename_prefix(prefix)
+        .filename_suffix(suffix);
+
+    if let Some(max_files) = config.max_files {
+        // setting `max_files` to `0` will cause panicking due to
+        // integer underflow in the `tracing_appender` crate.
+        if max_files > 0 {
+            builder = builder.max_log_files(max_files);
+        }
+    }
+
+    builder.build(&config.directory)
+}
+
+fn apply_override(global: &LogFormatConfig, override_config: &LogFormatConfigOverride) -> LogFormatConfig {
+    LogFormatConfig {
+        without_time: override_config.without_time.unwrap_or(global.without_time),
     }
 }

--- a/src/service/local.rs
+++ b/src/service/local.rs
@@ -261,6 +261,8 @@ pub fn define_command_line_options(mut app: Command) -> Command {
             .arg(
                 Arg::new("LOG_CONFIG")
                     .long("log-config")
+                    // deprecated for removal
+                    .hide(true)
                     .num_args(1)
                     .action(ArgAction::Set)
                     .value_parser(clap::value_parser!(PathBuf))

--- a/src/service/manager.rs
+++ b/src/service/manager.rs
@@ -148,6 +148,8 @@ pub fn define_command_line_options(mut app: Command) -> Command {
             .arg(
                 Arg::new("LOG_CONFIG")
                     .long("log-config")
+                    // deprecated for removal
+                    .hide(true)
                     .num_args(1)
                     .action(ArgAction::Set)
                     .value_parser(clap::value_parser!(PathBuf))
@@ -297,7 +299,7 @@ pub fn create(matches: &ArgMatches) -> ShadowsocksResult<(Runtime, impl Future<O
                 logging::init_with_file(path);
             }
             None => {
-                logging::init_with_config("sslocal", &service_config.log);
+                logging::init_with_config("ssmanager", &service_config.log);
             }
         }
 

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -178,6 +178,8 @@ pub fn define_command_line_options(mut app: Command) -> Command {
             .arg(
                 Arg::new("LOG_CONFIG")
                     .long("log-config")
+                    // deprecated for removal
+                    .hide(true)
                     .num_args(1)
                     .action(ArgAction::Set)
                     .value_parser(clap::value_parser!(PathBuf))
@@ -309,7 +311,7 @@ pub fn create(matches: &ArgMatches) -> ShadowsocksResult<(Runtime, impl Future<O
                 logging::init_with_file(path);
             }
             None => {
-                logging::init_with_config("sslocal", &service_config.log);
+                logging::init_with_config("ssserver", &service_config.log);
             }
         }
 


### PR DESCRIPTION
This is the second attempt of https://github.com/shadowsocks/shadowsocks-rust/pull/1992, as requested in https://github.com/shadowsocks/shadowsocks-rust/issues/1990#issuecomment-3122188623

Compare to the first attempt, this iteration enables more flexibility for logging configuration, supporting logging to stdout and multiple files simultaneously, which was a limitation in the previous version.

This new PR is intended as an alternative to the first iteration, feel free to close the other once decision is made.

---

I removed `SS*Config` structs as the amount of code duplication involved to deserialize the new `LogWriterConfig` enum is too much. And I don't really get the benefit of having them in the first place. I can see it makes sense for server configurations for backward compatibility reasons, but service configurations don't carry the same baggage and, in most cases, can be easily worked around by utilizing existing `serde_derive` features.

I've provided extra tests to ensure the change to the deserialization logic won't break existing configurations.