### PR TITLE
fix(docker): replace musl.cc

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   build-docker-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$TARGETARCH" in \
         exit 1 \
     ;; \
     esac \
-    && wget -qO- "https://musl.cc/$MUSL-cross.tgz" | tar -xzC /root/ \
+    && wget -qO- "https://github.com/AaronChen0/musl-cc-mirror/releases/download/2021-09-23/$MUSL-cross.tgz" | tar -xzC /root/ \
     && PATH="/root/$MUSL-cross/bin:$PATH" \
     && CC=/root/$MUSL-cross/bin/$MUSL-gcc \
     && echo "CC=$CC" \


### PR DESCRIPTION
Tested on https://github.com/AaronChen0/shadowsocks-rust/actions/runs/16624737890 with https://github.com/OpenListTeam/musl-compilers/releases/download/2025-06-12/$MUSL-cross.tgz.
But later I decided to make a mirror repo for my own. I will update the links if musl.cc get any updates.
