### PR TITLE
chore: mismatched_lifetime_syntaxes warning

### DIFF
--- a/crates/shadowsocks-service/src/acl/mod.rs
+++ b/crates/shadowsocks-service/src/acl/mod.rs
@@ -543,7 +543,7 @@ impl AccessControl {
 
     /// Returns the ASCII representation a domain name,
     /// if conversion fails returns original string
-    fn convert_to_ascii(host: &str) -> Cow<str> {
+    fn convert_to_ascii(host: &str) -> Cow<'_, str> {
         idna::domain_to_ascii(host)
             .map(From::from)
             .unwrap_or_else(|_| host.into())


### PR DESCRIPTION
https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> crates/shadowsocks-service/src/acl/mod.rs:546:31
    |
546 |     fn convert_to_ascii(host: &str) -> Cow<str> {
    |                               ^^^^     -------- the same lifetime is hidden here
    |                               |
    |                               the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
546 |     fn convert_to_ascii(host: &str) -> Cow<'_, str> {
    |                                            +++

warning: `shadowsocks-service` (lib) generated 1 warning
```