### PR TITLE
chore: refactor Docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM --platform=$BUILDPLATFORM rust:alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM rust:1.89.0-alpine3.22 AS builder
 
 ARG TARGETARCH
 
 RUN set -x \
-    && apk add --no-cache build-base cmake llvm15-dev clang15-libclang clang15 rust-bindgen
+    && apk add --no-cache musl-dev
 
 WORKDIR /root/shadowsocks-rust
 
@@ -36,7 +36,6 @@ RUN case "$TARGETARCH" in \
     && PATH="/root/$MUSL-cross/bin:$PATH" \
     && CC=/root/$MUSL-cross/bin/$MUSL-gcc \
     && echo "CC=$CC" \
-    && rustup override set stable \
     && rustup target add "$RUST_TARGET" \
     && RUSTFLAGS="-C linker=$CC" CC=$CC cargo build --target "$RUST_TARGET" --release --features "full" \
     && mv target/$RUST_TARGET/release/ss* target/release/


### PR DESCRIPTION
Improvements:
- don't install unnecessary packages
- use toolchain from base image (drop command `rustup override set stable`)

I also tried to drop dependency on musl-cross (musl.cc) by using QEMU emulation but build time increased from 30 to 70 minutes. Not great but I can make a PR if anyone interested.