### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/shadowsocks-service/src/local/online_config/content_encoding.rs
+++ b/crates/shadowsocks-service/src/local/online_config/content_encoding.rs
@@ -46,7 +46,7 @@ pub async fn read_body<B>(encoding: ContentEncoding, body: &mut B) -> io::Result
 where
     B: Body + Sized + Unpin + 'static,
     B::Data: AsRef<[u8]>,
-    B::Error: Into<Box<(dyn ::std::error::Error + Send + Sync + 'static)>>,
+    B::Error: Into<Box<dyn ::std::error::Error + Send + Sync + 'static>>,
 {
     let mut raw_body = Vec::new();
 

--- a/deny.toml
+++ b/deny.toml
@@ -74,9 +74,6 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-
-    # https://github.com/estk/log4rs/pull/351
-    { id = "RUSTSEC-2024-0388", reason = "log4rs PRs are not merged yet" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/src/daemonize/mod.rs
+++ b/src/daemonize/mod.rs
@@ -6,6 +6,7 @@ cfg_if! {
     if #[cfg(unix)] {
         mod unix;
         #[allow(unsafe_op_in_unsafe_fn, unused)]
+        #[allow(clippy::module_inception)]
         mod daemonize;
         pub use self::unix::daemonize;
     } else {


### PR DESCRIPTION
* Fix clippy warnings that showed up in https://github.com/shadowsocks/shadowsocks-rust/pull/2023/files.
 * `log4rs` crate issue resolved in `v1.4.0`.