### PR TITLE
docs: fix acl documentation

### DIFF
--- a/crates/shadowsocks-service/src/acl/mod.rs
+++ b/crates/shadowsocks-service/src/acl/mod.rs
@@ -323,8 +323,8 @@ impl ParsingRules {
 ///
 /// Mode is the default ACL strategy for those addresses that are not in configuration file.
 ///
-/// - `BlackList` - Bypasses / Rejects all addresses except those in `[proxy_list]` or `[white_list]`
-/// - `WhiteList` - Proxies / Accepts all addresses except those in `[bypass_list]` or `[black_list]`
+/// - `WhiteList` - Bypasses / Rejects all addresses except those in `[proxy_list]` or `[white_list]`
+/// - `BlackList` - Proxies / Accepts all addresses except those in `[bypass_list]` or `[black_list]`
 ///
 /// ## Rules
 ///


### PR DESCRIPTION
The list runs in `BlackList` mode when `[proxy_all]` is read, not `WhiteList`