### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/shadowsocks-service/src/local/http/http_client.rs
+++ b/crates/shadowsocks-service/src/local/http/http_client.rs
@@ -53,6 +53,7 @@ pub enum HttpClientError {
     InvalidHeaderValue(#[from] InvalidHeaderValue),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 enum SendRequestError<B> {
     #[error("{0}")]


### PR DESCRIPTION
```
warning: large size difference between variants
  --> crates/shadowsocks-service/src/local/http/http_client.rs:57:1
   |
57 | / enum SendRequestError<B> {
58 | |     #[error("{0}")]
59 | |     Http(#[from] http::Error),
   | |     ------------------------- the second-largest variant contains at least 2 bytes
...  |
62 | |     TrySend(#[from] TrySendError<Request<B>>),
   | |     ----------------------------------------- the largest variant contains at least 232 bytes
63 | | }
   | |_^ the entire enum is at least 232 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#large_enum_variant
   = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   |
62 -     TrySend(#[from] TrySendError<Request<B>>),
62 +     TrySend(#[from] Box<TrySendError<Request<B>>>),
   |
```