### PR TITLE
chore: specify regex dependency without unicode feature

### DIFF
--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -170,7 +170,7 @@ hickory-resolver = { version = "0.25", optional = true, features = ["serde"] }
 idna = "1.0"
 ipnet = "2.10"
 iprange = "0.6"
-regex = "1.4"
+regex = { version = "1.4", default-features = false, features = ["std", "perf"] }
 
 mime = { version = "0.3", optional = true }
 flate2 = { version = "1.0", optional = true }


### PR DESCRIPTION
Since we skip ACL rules with non-ascii characters, there's no need to enable unicode feature for regex.
As a result, the compiled binary will be smaller, as Unicode tables and related logic will be omitted.