### PR TITLE
fix(CI): freebsd/netbsd artifacts missing

### DIFF
--- a/build/build-release
+++ b/build/build-release
@@ -91,7 +91,7 @@ function build() {
     PKG_DIR="${CUR_DIR}/release"
     mkdir -p "${PKG_DIR}"
 
-    if [[ "$TARGET" == *"-linux-"* ]]; then
+    if [[ "$TARGET" == *"-linux-"* || "$TARGET" == *"-freebsd" || "$TARGET" == *"-netbsd" ]]; then
         PKG_NAME="shadowsocks-v${VERSION}.${TARGET}.tar.xz"
         PKG_PATH="${PKG_DIR}/${PKG_NAME}"
 


### PR DESCRIPTION
Saw 2 warnings in CI.

[build-nightly-cross (x86_64-unknown-freebsd, stable)](https://github.com/shadowsocks/shadowsocks-rust/actions/runs/19391386149/job/55485329966#step:8:13)
No files were found with the provided path: build/release/*. No artifacts will be uploaded.
[build-nightly-cross (x86_64-unknown-netbsd, stable)](https://github.com/shadowsocks/shadowsocks-rust/actions/runs/19391386149/job/55485330028#step:8:13)
No files were found with the provided path: build/release/*. No artifacts will be uploaded.