### PR TITLE
chore: make syslog-tracing optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ dns-over-h3 = ["shadowsocks-service/dns-over-h3"]
 # Enable logging output
 logging = [
     "log4rs",
+    "syslog-tracing",
     "tracing",
     "tracing-subscriber",
     "time",
@@ -249,7 +250,7 @@ windows-service = { version = "0.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 xdg = "3.0"
-syslog-tracing = "0.3"
+syslog-tracing = { version = "0.3", optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 reqwest = { version = "0.12", features = [

--- a/src/logging/tracing.rs
+++ b/src/logging/tracing.rs
@@ -212,10 +212,8 @@ fn make_syslog_writer(bin_name: &str, config: &LogSyslogWriterConfig) -> Syslog 
     let options = Options::default();
     let identity = CString::new(identity).expect("syslog identity contains null-byte ('\\0')");
 
-    let syslogger = match Syslog::new(identity, options, facility) {
+    match Syslog::new(identity, options, facility) {
         Some(l) => l,
         None => panic!("syslog is already initialized"),
-    };
-
-    syslogger
+    }
 }


### PR DESCRIPTION
* `syslog-tracing` should not compile when the `logging` feature is not enabled.
* Fix a trivial `clippy::let_and_return` warning.