### PR TITLE
fix(deps): fix NetBSD build by updating rust crate mio to v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",


### PR DESCRIPTION
CI failed on NetBSD after `libc` updated to `v0.2.178`.