### PR TITLE
chore: clippy fix

### DIFF
--- a/crates/shadowsocks-service/src/local/redir/sys/mod.rs
+++ b/crates/shadowsocks-service/src/local/redir/sys/mod.rs
@@ -18,8 +18,7 @@ where
     S: std::os::unix::io::AsFd,
 {
     let sock = SockRef::from(socket);
-    let result = sock.set_only_v6(ipv6_only);
-    result
+    sock.set_only_v6(ipv6_only)
 }
 
 #[cfg(windows)]
@@ -29,6 +28,5 @@ where
     S: std::os::windows::io::AsSocket,
 {
     let sock = SockRef::from(socket);
-    let result = sock.set_only_v6(ipv6_only);
-    result
+    sock.set_only_v6(ipv6_only)
 }

--- a/crates/shadowsocks/src/net/sys/mod.rs
+++ b/crates/shadowsocks/src/net/sys/mod.rs
@@ -74,9 +74,7 @@ where
     S: std::os::unix::io::AsFd,
 {
     let sock = SockRef::from(socket);
-    let result = socket_bind_dual_stack_inner(&sock, addr, ipv6_only);
-
-    result
+    socket_bind_dual_stack_inner(&sock, addr, ipv6_only)
 }
 
 /// Try to call `bind()` with dual-stack enabled.
@@ -88,9 +86,7 @@ where
     S: std::os::windows::io::AsSocket,
 {
     let sock = SockRef::from(socket);
-    let result = socket_bind_dual_stack_inner(&sock, addr, ipv6_only);
-
-    result
+    socket_bind_dual_stack_inner(&sock, addr, ipv6_only)
 }
 
 fn socket_bind_dual_stack_inner(socket: &Socket, addr: &SocketAddr, ipv6_only: bool) -> io::Result<()> {

--- a/crates/shadowsocks/src/net/sys/unix/mod.rs
+++ b/crates/shadowsocks/src/net/sys/unix/mod.rs
@@ -101,8 +101,7 @@ where
     F: FnOnce(&Socket) -> io::Result<()>,
 {
     let socket = SockRef::from(stream);
-    let result = f(&socket);
-    result
+    f(&socket)
 }
 
 pub fn set_common_sockopt_after_connect<S>(stream: &S, opts: &ConnectOpts) -> io::Result<()>


### PR DESCRIPTION
Fix clippy warnings: `unnecessary-cast`, `let-and-return`, `nested-if`.