### PR TITLE
feat(fakedns): support stable IP mapping

### DIFF
--- a/crates/shadowsocks-service/Cargo.toml
+++ b/crates/shadowsocks-service/Cargo.toml
@@ -83,7 +83,7 @@ local-socks4 = ["local"]
 # Enable Tun interface protocol for sslocal
 local-tun = ["local", "etherparse", "tun", "smoltcp"]
 # Enable Fake DNS
-local-fake-dns = ["local", "trust-dns", "rocksdb", "bson"]
+local-fake-dns = ["local", "trust-dns", "rocksdb", "bson", "xxhash-rust"]
 # sslocal support online URL (SIP008 Online Configuration Delivery)
 # https://shadowsocks.org/doc/sip008.html
 local-online-config = [
@@ -199,6 +199,7 @@ serde = { version = "1.0", features = ["derive"] }
 json5 = "1.3"
 serde_json = "1.0"
 bson = { version = "3.0.0", features = ["serde"], optional = true }
+xxhash-rust = { version = "0.8", features = ["xxh3"], optional = true }
 
 shadowsocks = { version = "1.24.0", path = "../shadowsocks", default-features = false }
 

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -343,6 +343,9 @@ struct SSLocalExtConfig {
     #[cfg(feature = "local-fake-dns")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fake_dns_database_path: Option<String>,
+    #[cfg(feature = "local-fake-dns")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fake_dns_stable_mapping: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     acl: Option<String>,
@@ -1061,6 +1064,9 @@ pub struct LocalConfig {
     /// Fake DNS storage database path
     #[cfg(feature = "local-fake-dns")]
     pub fake_dns_database_path: Option<PathBuf>,
+    /// Fake DNS stable mapping
+    #[cfg(feature = "local-fake-dns")]
+    pub fake_dns_stable_mapping: Option<bool>,
 }
 
 impl LocalConfig {
@@ -1130,6 +1136,8 @@ impl LocalConfig {
             fake_dns_ipv6_network: None,
             #[cfg(feature = "local-fake-dns")]
             fake_dns_database_path: None,
+            #[cfg(feature = "local-fake-dns")]
+            fake_dns_stable_mapping: None,
         }
     }
 
@@ -1877,7 +1885,10 @@ impl Config {
                                 }
                             }
                             if let Some(p) = local.fake_dns_database_path {
-                                local_config.fake_dns_database_path = Some(p.into());
+                                local_config.fake_dns_database_path = Some(PathBuf::from(p));
+                            }
+                            if let Some(stable) = local.fake_dns_stable_mapping {
+                                local_config.fake_dns_stable_mapping = Some(stable);
                             }
                         }
 
@@ -2936,6 +2947,8 @@ impl fmt::Display for Config {
                             .fake_dns_database_path
                             .as_ref()
                             .and_then(|n| n.to_str().map(ToOwned::to_owned)),
+                        #[cfg(feature = "local-fake-dns")]
+                        fake_dns_stable_mapping: local.fake_dns_stable_mapping,
 
                         acl: local_instance
                             .acl

--- a/crates/shadowsocks-service/src/local/fake_dns/proto.rs
+++ b/crates/shadowsocks-service/src/local/fake_dns/proto.rs
@@ -9,6 +9,8 @@ pub struct StorageMeta {
     pub ipv4_network: String,
     pub ipv6_network: String,
     pub version: u32,
+    #[serde(default)]
+    pub stable_mapping: bool,
 }
 
 impl StorageMeta {

--- a/crates/shadowsocks-service/src/local/fake_dns/server.rs
+++ b/crates/shadowsocks-service/src/local/fake_dns/server.rs
@@ -25,6 +25,7 @@ pub struct FakeDnsBuilder {
     ipv4_network: Ipv4Net,
     ipv6_network: Ipv6Net,
     expire_duration: Duration,
+    stable_mapping: bool,
 }
 
 impl FakeDnsBuilder {
@@ -44,6 +45,7 @@ impl FakeDnsBuilder {
             ipv4_network: Ipv4Net::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap(),
             ipv6_network: Ipv6Net::new(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0), 7).unwrap(),
             expire_duration: Duration::from_secs(10),
+            stable_mapping: false,
         }
     }
 
@@ -67,6 +69,11 @@ impl FakeDnsBuilder {
         self.database_path = database_path.as_ref().to_path_buf();
     }
 
+    /// Set stable mapping
+    pub fn set_stable_mapping(&mut self, stable: bool) {
+        self.stable_mapping = stable;
+    }
+
     /// Build Fake DNS server
     pub async fn build(self) -> io::Result<FakeDns> {
         let manager = FakeDnsManager::open(
@@ -74,6 +81,7 @@ impl FakeDnsBuilder {
             self.ipv4_network,
             self.ipv6_network,
             self.expire_duration,
+            self.stable_mapping,
         )?;
         let manager = Arc::new(manager);
 

--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -516,6 +516,9 @@ impl Server {
                     if let Some(p) = local_config.fake_dns_database_path {
                         builder.set_database_path(p);
                     }
+                    if let Some(stable) = local_config.fake_dns_stable_mapping {
+                        builder.set_stable_mapping(stable);
+                    }
                     let server = builder.build().await?;
                     #[cfg(feature = "local-fake-dns")]
                     context.add_fake_dns_manager(server.clone_manager()).await;


### PR DESCRIPTION
https://github.com/shadowsocks/shadowsocks-rust/issues/1906
1. Add `fake_dns_stable_mapping` option to configuration.
2. Implement stable mapping allocation strategy:
   - Use `xxh3_64` to hash domain names to initial IP offsets.
   - Use linear probing to find free slots if collisions occur.
   - Reuse existing stable mappings from the database.
   - Support expiration and refreshing of stable mappings.
3. Add `xxhash-rust` dependency for fast and high-quality hashing.