### PR TITLE
fix: skip TCP_FASTOPEN on MPTCP sockets

### DIFF
--- a/crates/shadowsocks/src/net/tcp.rs
+++ b/crates/shadowsocks/src/net/tcp.rs
@@ -12,6 +12,7 @@ use std::{
     task::{self, Poll},
 };
 
+use log::warn;
 use futures::{future, ready};
 use pin_project::pin_project;
 use tokio::{
@@ -159,7 +160,11 @@ impl TcpListener {
         // Enable TFO if supported
         // macos requires TCP_FASTOPEN to be set after listen(), but other platform doesn't have this constraint
         if accept_opts.tcp.fastopen {
-            set_tcp_fastopen(&inner)?;
+            if accept_opts.tcp.mptcp {
+                warn!("TCP_FASTOPEN is not compatible with MPTCP, skipping");
+            } else {
+                set_tcp_fastopen(&inner)?;
+            }
         }
 
         Ok(Self { inner, accept_opts })
@@ -170,7 +175,11 @@ impl TcpListener {
         // Enable TFO if supported
         // macos requires TCP_FASTOPEN to be set after listen(), but other platform doesn't have this constraint
         if accept_opts.tcp.fastopen {
-            set_tcp_fastopen(&listener)?;
+            if accept_opts.tcp.mptcp {
+                warn!("TCP_FASTOPEN is not compatible with MPTCP, skipping");
+            } else {
+                set_tcp_fastopen(&listener)?;
+            }
         }
 
         Ok(Self {


### PR DESCRIPTION
Enabling both `mptcp` and `fast_open` crashes the server because MPTCP sockets don't support `TCP_FASTOPEN`. Skip TFO when MPTCP is active.