### PR TITLE
fix: native build error on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM --platform=$BUILDPLATFORM rust:1.94.0-alpine3.23 AS builder
 
 ARG TARGETARCH
+ARG BUILDARCH
 
 RUN set -x \
-    && apk add --no-cache musl-dev
+    && apk add --no-cache musl-dev gcc \
+    && echo "Building for ${TARGETARCH} on ${BUILDARCH}"
 
 WORKDIR /root/shadowsocks-rust
 
@@ -33,8 +35,15 @@ RUN case "$TARGETARCH" in \
     && wget "https://github.com/AaronChen0/musl-cc-mirror/releases/download/2021-09-23/$MUSL-cross.tgz" \
     && ( echo "$SHA512" "$MUSL-cross.tgz" | sha512sum -c ) \
     && tar -xzf "$MUSL-cross.tgz" -C /root/ \
-    && PATH="/root/$MUSL-cross/bin:$PATH" \
-    && CC=/root/$MUSL-cross/bin/$MUSL-gcc \
+    && CROSS="/root/$MUSL-cross/bin/$MUSL-gcc" \
+    && if [ -x "$CROSS" ] && "$CROSS" --version >/dev/null 2>&1; then \
+        CC="/root/$MUSL-cross/bin/$MUSL-gcc"; \
+        PATH="/root/$MUSL-cross/bin:$PATH"; \
+        echo "INFO: Using downloaded cross toolchain: $CC"; \
+    else \
+        CC="gcc"; \
+        echo "WARN: downloaded cross toolchain is not executable on this builder, fallback to native gcc"; \
+    fi \
     && echo "CC=$CC" \
     && rustup target add "$RUST_TARGET" \
     && RUSTFLAGS="-C linker=$CC" CC=$CC cargo build --target "$RUST_TARGET" --release --features "full" \


### PR DESCRIPTION
fix #2099 , After fix:

```
kane@instance:~/shadowsocks-rust$ dpkg --print-architecture
arm64
```

Build:

```
...
#11 271.9    Compiling shadowsocks-service v1.24.0 (/root/shadowsocks-rust/crates/shadowsocks-service)
#11 286.4    Compiling rpassword v7.4.0
#11 286.7    Compiling directories v6.0.0
#11 287.1    Compiling clap v4.6.0
#11 287.2    Compiling tracing-appender v0.2.4
#11 289.7    Compiling syslog-tracing v0.3.1
#11 290.2    Compiling sysexits v0.13.0
#11 290.3    Compiling qrcode v0.14.1
#11 292.0    Compiling xdg v3.0.0
#11 293.0    Compiling shadowsocks-rust v1.24.0 (/root/shadowsocks-rust)
#11 769.5     Finished `release` profile [optimized] target(s) in 12m 45s
#11 DONE 769.8s
```
