### PR TITLE
feat: expose user_key() on CryptoStream and ProxyServerStream

### DIFF
--- a/crates/shadowsocks/src/relay/tcprelay/crypto_io.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/crypto_io.rs
@@ -450,6 +450,14 @@ impl<S> CryptoStream<S> {
         self.dec.nonce()
     }
 
+    /// Get authenticated user key (AEAD2022).
+    /// Returns the key of the user that was authenticated during the handshake,
+    /// or `None` for single-user mode or non-AEAD2022 ciphers.
+    #[inline]
+    pub fn user_key(&self) -> Option<&[u8]> {
+        self.dec.user_key()
+    }
+
     /// Get sent IV (Stream) or Salt (AEAD, AEAD2022)
     #[inline]
     pub fn sent_nonce(&self) -> &[u8] {

--- a/crates/shadowsocks/src/relay/tcprelay/proxy_stream/server.rs
+++ b/crates/shadowsocks/src/relay/tcprelay/proxy_stream/server.rs
@@ -100,6 +100,12 @@ impl<S> ProxyServerStream<S> {
     pub fn into_inner(self) -> S {
         self.stream.into_inner()
     }
+
+    /// Get authenticated user key after handshake (AEAD2022 multi-user mode).
+    /// Returns `None` in single-user mode or before the handshake completes.
+    pub fn user_key(&self) -> Option<&[u8]> {
+        self.stream.user_key()
+    }
 }
 
 impl<S> ProxyServerStream<S>


### PR DESCRIPTION
After an AEAD2022 handshake with a ServerUserManager, the authenticated user's raw key is available inside DecryptedReader but not reachable from the public API.  Expose it via:

  CryptoStream::user_key()       -> Option<&[u8]>
  ProxyServerStream::user_key()  -> Option<&[u8]>

This lets callers (e.g. clash-rs) identify which multi-user identity was authenticated without having to manually peek and re-derive the identity subkey via BLAKE3 + AES-256-ECB before the handshake.