### PR TITLE
Remove unused imports in outbound_proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "hex",
  "indexmap",
  "js-sys",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "simdutf8",
@@ -1389,7 +1389,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "quinn",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustls",
  "serde",
@@ -1416,7 +1416,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "quinn",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "rustls",
  "serde",
@@ -2045,7 +2045,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde-value",
  "serde_json",
@@ -2597,7 +2597,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2646,9 +2646,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
@@ -3235,7 +3235,7 @@ dependencies = [
  "ghash",
  "hkdf",
  "md-5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring-compat",
  "sha1",
  "sm4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,9 +2967,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/shadowsocks-service/src/local/net/tcp/outbound_proxy.rs
+++ b/crates/shadowsocks-service/src/local/net/tcp/outbound_proxy.rs
@@ -11,20 +11,13 @@ use std::{
     task::{self, Poll},
 };
 
-use shadowsocks::{
-    net::ConnectOpts,
-    relay::socks5::{Address, Command},
-};
+use shadowsocks::{net::ConnectOpts, relay::socks5::Address};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::{
     config::{OutboundProxy, OutboundProxyProtocol},
     local::context::ServiceContext,
-    net::{
-        http_stream::ProxyHttpStream,
-        outbound_proxy::connect_via_proxy,
-        socks5_client::{socks5_command, socks5_handshake},
-    },
+    net::{http_stream::ProxyHttpStream, outbound_proxy::connect_via_proxy},
 };
 
 use super::auto_proxy_stream::AutoProxyClientStream;


### PR DESCRIPTION
Just a tiny and simple cleanup of unused imports, causing compiler warnings