### PR TITLE
feat: add eih support

### DIFF
--- a/bin/ssurl.rs
+++ b/bin/ssurl.rs
@@ -47,7 +47,10 @@ fn print_qrcode(encoded: &str) {
 }
 
 fn encode(filename: &str, need_qrcode: bool) {
-    let config = Config::load_from_file(filename, ConfigType::Server).unwrap();
+    // Try loading as a server config first; fall back to local (client) config
+    let config = Config::load_from_file(filename, ConfigType::Server)
+        .or_else(|_| Config::load_from_file(filename, ConfigType::Local))
+        .unwrap();
 
     for svr in config.server {
         let encoded = svr.config.to_url();
@@ -106,7 +109,11 @@ fn main() -> ExitCode {
                 .action(ArgAction::Set)
                 .value_hint(ValueHint::FilePath)
                 .conflicts_with("DECODE_CONFIG_PATH")
-                .required_unless_present_any(["DECODE_CONFIG_PATH", "OUTLINE_CONFIG_URL"])
+                .required_unless_present_any(if cfg!(feature = "utility-url-outline") {
+                    vec!["DECODE_CONFIG_PATH", "OUTLINE_CONFIG_URL"]
+                } else {
+                    vec!["DECODE_CONFIG_PATH"]
+                })
                 .help("Encode the server configuration in the provided JSON file"),
         )
         .arg(
@@ -115,7 +122,11 @@ fn main() -> ExitCode {
                 .long("decode")
                 .action(ArgAction::Set)
                 .value_hint(ValueHint::FilePath)
-                .required_unless_present_any(["ENCODE_CONFIG_PATH", "OUTLINE_CONFIG_URL"])
+                .required_unless_present_any(if cfg!(feature = "utility-url-outline") {
+                    vec!["ENCODE_CONFIG_PATH", "OUTLINE_CONFIG_URL"]
+                } else {
+                    vec!["ENCODE_CONFIG_PATH"]
+                })
                 .help("Decode the server configuration from the provided ShadowSocks URL"),
         )
         .arg(

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -3163,7 +3163,7 @@ impl fmt::Display for Config {
                 jconf.password = if svr.method().is_none() {
                     None
                 } else {
-                    Some(svr.password().to_string())
+                    Some(svr.export_password())
                 };
                 jconf.plugin = svr.plugin().map(|p| p.plugin.to_string());
                 jconf.plugin_opts = svr.plugin().and_then(|p| p.plugin_opts.clone());
@@ -3209,7 +3209,7 @@ impl fmt::Display for Config {
                         password: if svr.method().is_none() {
                             None
                         } else {
-                            Some(svr.password().to_string())
+                            Some(svr.export_password())
                         },
                         method: svr.method().to_string(),
                         users: svr.user_manager().map(|m| {

--- a/crates/shadowsocks/src/config.rs
+++ b/crates/shadowsocks/src/config.rs
@@ -643,9 +643,24 @@ impl ServerConfig {
         self.enc_key.as_ref()
     }
 
-    /// Get password
+    /// Get password (uPSK only; does not include identity keys)
     pub fn password(&self) -> &str {
         self.password.as_str()
+    }
+
+    /// Get the full password as it should appear in a config file or URL.
+    ///
+    /// For AEAD-2022 EIH configs this reconstructs `iPSK1:...:iPSKn:uPSK`.
+    /// For all other configs this is identical to [`password()`](Self::password).
+    pub fn export_password(&self) -> String {
+        if self.identity_keys.is_empty() {
+            return self.password.clone();
+        }
+        let mut parts: Vec<String> = self.identity_keys.iter()
+            .map(|k| USER_KEY_BASE64_ENGINE.encode(k))
+            .collect();
+        parts.push(self.password.clone());
+        parts.join(":")
     }
 
     /// Get identity keys (Client)
@@ -796,7 +811,8 @@ impl ServerConfig {
                     let user_info = format!("{}:{}", self.method(), self.password());
                     URL_PASSWORD_BASE64_ENGINE.encode(user_info)
                 } else {
-                    format!("{}:{}", self.method(), percent_encoding::utf8_percent_encode(self.password(), percent_encoding::NON_ALPHANUMERIC))
+                    let pwd = self.export_password();
+                    format!("{}:{}", self.method(), percent_encoding::utf8_percent_encode(&pwd, percent_encoding::NON_ALPHANUMERIC))
                 };
             } else {
                 let mut user_info = format!("{}:{}", self.method(), self.password());
@@ -1434,5 +1450,34 @@ mod test {
     fn test_server_config_from_url() {
         let server_config = ServerConfig::from_url("ss://foo:bar@127.0.0.1:9999");
         assert!(matches!(server_config, Err(UrlParseError::InvalidMethod)));
+    }
+
+    #[cfg(feature = "aead-cipher-2022")]
+    #[test]
+    fn test_aead2022_eih_url_roundtrip() {
+        // 32-byte keys encoded in standard base64
+        let server_key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; // 32 zero bytes
+        let user_key = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE="; // 32 one-bytes
+        let password = format!("{server_key}:{user_key}");
+
+        let svr = ServerConfig::new(
+            "127.0.0.1:8388".parse::<ServerAddr>().unwrap(),
+            password.clone(),
+            CipherKind::AEAD2022_BLAKE3_AES_256_GCM,
+        )
+        .unwrap();
+
+        // identity_keys must be populated with the server key
+        assert_eq!(svr.identity_keys().len(), 1);
+
+        // to_url must round-trip: decoding the generated URL must reproduce the original password
+        let url = svr.to_url();
+        let svr2 = ServerConfig::from_url(&url).unwrap();
+
+        assert_eq!(svr2.method(), CipherKind::AEAD2022_BLAKE3_AES_256_GCM);
+        assert_eq!(svr2.addr(), svr.addr());
+        assert_eq!(svr2.identity_keys().len(), 1);
+        assert_eq!(svr2.identity_keys(), svr.identity_keys());
+        assert_eq!(svr2.key(), svr.key());
     }
 }


### PR DESCRIPTION
 What's Changed:

  - Fix: ssurl drops AEAD-2022 identity keys (EIH) on encode/decode
For EIH configs the password is SERVER-KEY:USER-KEY. ServerConfig splits these into separate fields (password / identity_keys), but neither to_url() nor the JSON serializer recombined
  them — silently dropping the server key.

  - Added ServerConfig::export_password() to reconstruct the full iPSK:uPSK string; used in to_url() and Config's Display impl.
  - ssurl -e now also accepts client config files (ConfigType::Local fallback).
  - Fixed a startup panic when built without the utility-url-outline feature.