### PR TITLE
Support Shadowsocks outbound proxy hops

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,12 @@ Start local client with configuration file
 sslocal -c /path/to/shadowsocks.json
 ```
 
-`sslocal` also supports routing its outbound TCP connection to the Shadowsocks server through a proxy or proxy chain with the `outbound_proxy` config key. Supported hop types are `socks5://`, `http://`, `https://`, and SIP002 `ss://` URLs. Plain proxy hops accept optional `user:pass@` credentials. The first `ss://` hop may include a SIP003 plugin; plugins on later hops are rejected. A chain containing an `ss://` hop is TCP-only, and UDP traffic is rejected instead of bypassing the chain. This option is currently available through the configuration file for `sslocal`; `ssserver` supports both the config file and repeated `--outbound-proxy` command line flags.
+`sslocal` supports appending TCP proxy hops after its configured Shadowsocks server with the `outbound_proxy`
+config key. The normal `server` is always the physical first hop; `outbound_proxy` entries follow it in array order,
+and the last entry connects to the requested destination. Supported trailing hop types are `socks5://`, `http://`,
+`https://`, and SIP002 `ss://` URLs. Plain proxy hops accept optional `user:pass@` credentials. A SIP003 plugin
+belongs on the main `server`; plugins on later `ss://` hops are rejected. `sslocal` chains are currently TCP-only,
+so UDP traffic is rejected instead of bypassing the chain.
 
 ```jsonc
 {
@@ -383,6 +388,7 @@ sslocal -c /path/to/shadowsocks.json
     "local_address": "127.0.0.1",
     "local_port": 1080,
     "outbound_proxy": [
+        // Path: server.example.com -> SOCKS5 -> HTTPS -> HTTP -> destination
         "socks5://user:pass@127.0.0.1:1080",
         "https://proxy.example.com:443",
         "http://127.0.0.1:1081"
@@ -390,8 +396,8 @@ sslocal -c /path/to/shadowsocks.json
 }
 ```
 
-`ss://` outbound hops support TCP only. See [`examples/chain-ss.json5`](examples/chain-ss.json5) for a complete
-TCP-only edge-to-landing configuration.
+See [`examples/chain-ss.json5`](examples/chain-ss.json5) for a complete TCP-only configuration with an obfuscated
+main/edge server followed by a Shadowsocks landing server.
 
 ### Socks5 Local client
 
@@ -468,9 +474,9 @@ For TCP+UDP, LAN gateway, IPv6, or ipset-based routing, adapt the examples in
 [`configs/iptables_mixed.sh`](configs/iptables_mixed.sh) or [`configs/iptables_tproxy.sh`](configs/iptables_tproxy.sh)
 and run `sslocal` with `--tcp-redir "tproxy" --udp-redir "tproxy"`.
 
-If the Shadowsocks server itself must be reached through an HTTP or SOCKS proxy, combine redir mode with the
-`outbound_proxy` configuration option. This routes `sslocal`'s outbound TCP connection through that proxy; UDP traffic
-is not proxied by `outbound_proxy`.
+To append an HTTP, SOCKS, or Shadowsocks landing hop after the main server, combine redir mode with the
+`outbound_proxy` configuration option. The main Shadowsocks server remains the physical first hop; UDP traffic is
+rejected when a trailing chain is configured.
 
 ### Tun interface client
 
@@ -553,8 +559,9 @@ ssserver -s "[::]:8388" -m "aes-256-gcm" -k "hello-kitty" \
 
 Repeat `--outbound-proxy` in hop order. A single occurrence keeps the previous single-hop behavior.
 Supported hop types are `socks5://`, `http://`, `https://`, and `ss://`. The first `ss://` hop may include a SIP003
-plugin; later-hop plugins are not supported. The same `outbound_proxy` setting can also be used in configuration files
-for both `sslocal` and `ssserver`, but `ss://` hops are TCP-only and UDP traffic is rejected instead of being sent directly.
+plugin; later-hop plugins are not supported. For `ssserver`, these entries form the outbound path from the server to
+the requested destination. This differs from `sslocal`, where the configured main Shadowsocks server precedes every
+`outbound_proxy` entry. Chains containing `ss://` hops are TCP-only and reject UDP instead of sending it directly.
 
 ### Server Manager
 
@@ -847,10 +854,10 @@ Example configuration:
             "outbound_bind_addr": "11.22.33.44",
             // Outbound UDP socket allows IP fragmentation (default false)
             "outbound_udp_allow_fragmentation": false,
-            // Route outbound TCP connections through a proxy or proxy chain
-            // (TCP only; a chain containing ss:// causes UDP traffic to be rejected)
-            // Works for both sslocal and ssserver
-            // sslocal: configure in JSON; ssserver: JSON or repeated --outbound-proxy
+            // Add TCP proxy hops in array order.
+            // sslocal: hops follow this main server; any chain rejects UDP.
+            // ssserver: hops precede the requested target; ss:// rejects UDP.
+            // sslocal uses JSON; ssserver also supports repeated --outbound-proxy.
             // Single hop:
             "outbound_proxy": "socks5://127.0.0.1:1080",
             // Single hop with username/password:
@@ -925,10 +932,10 @@ Example configuration:
     "outbound_bind_addr": "11.22.33.44",
     // Outbound UDP socket allows IP fragmentation (default false)
     "outbound_udp_allow_fragmentation": false,
-    // Route outbound TCP connections through a proxy or proxy chain
-    // (TCP only; a chain containing ss:// causes UDP traffic to be rejected)
-    // Works for both sslocal and ssserver
-    // sslocal: configure in JSON; ssserver: JSON or repeated --outbound-proxy
+    // Add TCP proxy hops in array order.
+    // sslocal: hops follow the configured main server; any chain rejects UDP.
+    // ssserver: hops precede the requested target; ss:// rejects UDP.
+    // sslocal uses JSON; ssserver also supports repeated --outbound-proxy.
     // Single hop:
     "outbound_proxy": "socks5://127.0.0.1:1080",
     // Single hop with username/password:

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Start local client with configuration file
 sslocal -c /path/to/shadowsocks.json
 ```
 
-`sslocal` also supports routing its outbound TCP connection to the Shadowsocks server through a proxy or proxy chain with the `outbound_proxy` config key. Supported hop types are `socks5://`, `http://`, and `https://`, with optional `user:pass@` credentials. This option is currently available through the configuration file for `sslocal`; `ssserver` supports both the config file and repeated `--outbound-proxy` command line flags.
+`sslocal` also supports routing its outbound TCP connection to the Shadowsocks server through a proxy or proxy chain with the `outbound_proxy` config key. Supported hop types are `socks5://`, `http://`, `https://`, and SIP002 `ss://` URLs. Plain proxy hops accept optional `user:pass@` credentials. The first `ss://` hop may include a SIP003 plugin; plugins on later hops are rejected. A chain containing an `ss://` hop is TCP-only, and UDP traffic is rejected instead of bypassing the chain. This option is currently available through the configuration file for `sslocal`; `ssserver` supports both the config file and repeated `--outbound-proxy` command line flags.
 
 ```jsonc
 {
@@ -389,6 +389,9 @@ sslocal -c /path/to/shadowsocks.json
     ]
 }
 ```
+
+`ss://` outbound hops support TCP only. See [`examples/chain-ss.json5`](examples/chain-ss.json5) for a complete
+TCP-only edge-to-landing configuration.
 
 ### Socks5 Local client
 
@@ -549,7 +552,9 @@ ssserver -s "[::]:8388" -m "aes-256-gcm" -k "hello-kitty" \
 ```
 
 Repeat `--outbound-proxy` in hop order. A single occurrence keeps the previous single-hop behavior.
-Supported hop types are `socks5://`, `http://`, and `https://`. The same `outbound_proxy` setting can also be used in configuration files for both `sslocal` and `ssserver`, but UDP traffic is not proxied.
+Supported hop types are `socks5://`, `http://`, `https://`, and `ss://`. The first `ss://` hop may include a SIP003
+plugin; later-hop plugins are not supported. The same `outbound_proxy` setting can also be used in configuration files
+for both `sslocal` and `ssserver`, but `ss://` hops are TCP-only and UDP traffic is rejected instead of being sent directly.
 
 ### Server Manager
 
@@ -843,7 +848,7 @@ Example configuration:
             // Outbound UDP socket allows IP fragmentation (default false)
             "outbound_udp_allow_fragmentation": false,
             // Route outbound TCP connections through a proxy or proxy chain
-            // (TCP only; UDP is not proxied)
+            // (TCP only; a chain containing ss:// causes UDP traffic to be rejected)
             // Works for both sslocal and ssserver
             // sslocal: configure in JSON; ssserver: JSON or repeated --outbound-proxy
             // Single hop:
@@ -921,7 +926,7 @@ Example configuration:
     // Outbound UDP socket allows IP fragmentation (default false)
     "outbound_udp_allow_fragmentation": false,
     // Route outbound TCP connections through a proxy or proxy chain
-    // (TCP only; UDP is not proxied)
+    // (TCP only; a chain containing ss:// causes UDP traffic to be rejected)
     // Works for both sslocal and ssserver
     // sslocal: configure in JSON; ssserver: JSON or repeated --outbound-proxy
     // Single hop:

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -1501,7 +1501,7 @@ pub struct ServerInstanceConfig {
     pub outbound_bind_addr: Option<IpAddr>,
     pub outbound_bind_interface: Option<String>,
     pub outbound_udp_allow_fragmentation: Option<bool>,
-    /// Outbound SOCKS5 proxy chain for this server instance (empty = no proxy)
+    /// Configured outbound proxy hops for this server instance (empty = no proxy)
     pub outbound_proxy: Vec<OutboundProxy>,
 }
 
@@ -1610,7 +1610,11 @@ pub struct Config {
     /// Path to protect callback unix address, only for Android
     #[cfg(target_os = "android")]
     pub outbound_vpn_protect_path: Option<PathBuf>,
-    /// Outbound SOCKS5 proxy chain for ssserver (global, can be overridden per server; empty = no proxy)
+    /// Global outbound proxy hops.
+    ///
+    /// For `sslocal`, these follow the configured main Shadowsocks server.
+    /// For `ssserver`, these precede the requested target and can be
+    /// overridden per server instance.
     pub outbound_proxy: Vec<OutboundProxy>,
 
     /// Set `SO_SNDBUF` for inbound sockets
@@ -3566,7 +3570,17 @@ mod tests {
     fn shadowsocks_outbound_proxy_example_is_valid() {
         let config = Config::load_from_str(include_str!("../../../examples/chain-ss.json5"), ConfigType::Local)
             .expect("chain-ss example");
+        assert_eq!(config.server.len(), 1);
+        assert_eq!(config.server[0].config.addr().to_string(), "edge.example.com:443");
+        assert_eq!(
+            config.server[0].config.plugin().map(|plugin| plugin.plugin.as_str()),
+            Some("obfs-local")
+        );
         assert_eq!(config.outbound_proxy.len(), 1);
-        assert!(matches!(config.outbound_proxy[0], OutboundProxy::Ss(..)));
+        let OutboundProxy::Ss(landing) = &config.outbound_proxy[0] else {
+            panic!("expected shadowsocks landing hop");
+        };
+        assert_eq!(landing.svr_cfg.addr().to_string(), "landing.example.com:8388");
+        assert!(landing.svr_cfg.plugin().is_none());
     }
 }

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -102,6 +102,7 @@ pub enum OutboundProxyProtocol {
     Socks5,
     Http,
     Https,
+    Ss,
 }
 
 impl OutboundProxyProtocol {
@@ -110,8 +111,9 @@ impl OutboundProxyProtocol {
             "socks5" => Ok(Self::Socks5),
             "http" => Ok(Self::Http),
             "https" => Ok(Self::Https),
+            "ss" => Ok(Self::Ss),
             _ => Err(format!(
-                "unsupported proxy scheme, only socks5://, http:// and https:// are supported: {scheme}://"
+                "unsupported proxy scheme, only socks5://, http://, https:// and ss:// are supported: {scheme}://"
             )),
         }
     }
@@ -121,6 +123,7 @@ impl OutboundProxyProtocol {
             Self::Socks5 => "socks5",
             Self::Http => "http",
             Self::Https => "https",
+            Self::Ss => "ss",
         }
     }
 }
@@ -129,32 +132,62 @@ impl OutboundProxyProtocol {
 ///
 /// `ssserver` will route its outbound TCP connections through this proxy.
 /// Config file format accepts either a single string like `"socks5://host:port"`
-/// or a chain like `["socks5://host:port", "http://host:port", "https://host:port"]`.
-#[derive(Clone, Eq, PartialEq)]
-pub struct OutboundProxy {
+/// or a chain like `["ss://...", "socks5://host:port", "https://host:port"]`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OutboundProxy {
+    Plain(PlainProxy),
+    Ss(Box<ShadowsocksHop>),
+}
+
+/// Configuration for a SOCKS5, HTTP, or HTTPS outbound proxy hop.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlainProxy {
     pub protocol: OutboundProxyProtocol,
     pub host: String,
     pub port: u16,
     pub auth: Option<OutboundProxyAuth>,
 }
 
-impl Debug for OutboundProxy {
+/// Configuration for a Shadowsocks outbound proxy hop.
+#[derive(Clone)]
+pub struct ShadowsocksHop {
+    pub svr_cfg: ServerConfig,
+    pub tag: Option<String>,
+}
+
+impl Debug for ShadowsocksHop {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OutboundProxy")
-            .field("protocol", &self.protocol)
-            .field("host", &self.host)
-            .field("port", &self.port)
-            .field("auth", &self.auth)
+        f.debug_struct("ShadowsocksHop")
+            .field("addr", self.svr_cfg.addr())
+            .field("method", &self.svr_cfg.method())
+            .field("password", &"<redacted>")
+            .field("plugin", &self.svr_cfg.plugin().map(|p| p.plugin.as_str()))
+            .field("tag", &self.tag)
             .finish()
     }
 }
 
+impl PartialEq for ShadowsocksHop {
+    fn eq(&self, other: &Self) -> bool {
+        self.svr_cfg.to_url() == other.svr_cfg.to_url() && self.tag == other.tag
+    }
+}
+
+impl Eq for ShadowsocksHop {}
+
 impl OutboundProxy {
     /// Parse from a URL string like `socks5://127.0.0.1:1080`,
-    /// `http://user:pass@127.0.0.1:3128` or `https://[::1]:443`
+    /// `http://user:pass@127.0.0.1:3128`, `https://[::1]:443`, or a SIP002 `ss://` URL.
     pub fn from_url(url: &str) -> Result<Self, String> {
         let parsed = Url::parse(url).map_err(|e| format!("invalid proxy url {url}: {e}"))?;
         let protocol = OutboundProxyProtocol::from_scheme(parsed.scheme())?;
+
+        if protocol == OutboundProxyProtocol::Ss {
+            let svr_cfg =
+                ServerConfig::from_url(url).map_err(|e| format!("invalid shadowsocks outbound proxy URL: {e}"))?;
+            let tag = svr_cfg.remarks().map(ToOwned::to_owned);
+            return Ok(Self::Ss(Box::new(ShadowsocksHop { svr_cfg, tag })));
+        }
 
         let host = parsed
             .host_str()
@@ -189,39 +222,60 @@ impl OutboundProxy {
             Some(OutboundProxyAuth { username, password })
         };
 
-        Ok(OutboundProxy {
+        Ok(Self::Plain(PlainProxy {
             protocol,
             host,
             port,
             auth,
-        })
+        }))
     }
 
     pub fn address(&self) -> Address {
-        match self.host.parse::<IpAddr>() {
-            Ok(ip) => Address::SocketAddress(SocketAddr::new(ip, self.port)),
-            Err(..) => Address::DomainNameAddress(self.host.clone(), self.port),
+        match self {
+            Self::Plain(proxy) => match proxy.host.parse::<IpAddr>() {
+                Ok(ip) => Address::SocketAddress(SocketAddr::new(ip, proxy.port)),
+                Err(..) => Address::DomainNameAddress(proxy.host.clone(), proxy.port),
+            },
+            Self::Ss(hop) => hop.svr_cfg.addr().into(),
+        }
+    }
+
+    /// Whether this hop can participate in the existing SOCKS5 UDP relay chain.
+    pub(crate) fn supports_udp(&self) -> bool {
+        matches!(self, Self::Plain(proxy) if proxy.protocol == OutboundProxyProtocol::Socks5)
+    }
+
+    /// Server address for an `ss://` hop, used for cycle diagnostics.
+    pub(crate) fn shadowsocks_server_addr(&self) -> Option<&ServerAddr> {
+        match self {
+            Self::Ss(hop) => Some(hop.svr_cfg.addr()),
+            Self::Plain(..) => None,
         }
     }
 
     /// Serialize back to URL form, with brackets for IPv6 hosts
     pub fn to_url(&self) -> String {
-        let host = if self.host.contains(':') {
-            format!("[{}]", self.host)
-        } else {
-            self.host.clone()
-        };
+        match self {
+            Self::Ss(hop) => hop.svr_cfg.to_url(),
+            Self::Plain(proxy) => {
+                let host = if proxy.host.contains(':') {
+                    format!("[{}]", proxy.host)
+                } else {
+                    proxy.host.clone()
+                };
 
-        match self.auth {
-            Some(ref auth) => format!(
-                "{}://{}:{}@{}:{}",
-                self.protocol.as_scheme(),
-                auth.username,
-                auth.password,
-                host,
-                self.port
-            ),
-            None => format!("{}://{}:{}", self.protocol.as_scheme(), host, self.port),
+                match proxy.auth {
+                    Some(ref auth) => format!(
+                        "{}://{}:{}@{}:{}",
+                        proxy.protocol.as_scheme(),
+                        auth.username,
+                        auth.password,
+                        host,
+                        proxy.port
+                    ),
+                    None => format!("{}://{}:{}", proxy.protocol.as_scheme(), host, proxy.port),
+                }
+            }
         }
     }
 }
@@ -3447,23 +3501,72 @@ pub fn read_variable_field_value(value: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::OutboundProxy;
+    #[cfg(feature = "local")]
+    use super::{Config, ConfigType};
 
     #[test]
     fn outbound_proxy_url_without_auth() {
         let proxy = OutboundProxy::from_url("socks5://127.0.0.1:1080").expect("proxy");
-        assert_eq!(proxy.host, "127.0.0.1");
-        assert_eq!(proxy.port, 1080);
-        assert!(proxy.auth.is_none());
+        let OutboundProxy::Plain(plain) = &proxy else {
+            panic!("expected plain proxy");
+        };
+        assert_eq!(plain.host, "127.0.0.1");
+        assert_eq!(plain.port, 1080);
+        assert!(plain.auth.is_none());
         assert_eq!(proxy.to_url(), "socks5://127.0.0.1:1080");
     }
 
     #[test]
     fn outbound_proxy_url_with_auth() {
         let proxy = OutboundProxy::from_url("socks5://user:pass@[::1]:1080").expect("proxy");
-        assert_eq!(proxy.host, "::1");
-        assert_eq!(proxy.port, 1080);
-        let auth = proxy.auth.expect("auth");
+        let OutboundProxy::Plain(plain) = proxy else {
+            panic!("expected plain proxy");
+        };
+        assert_eq!(plain.host, "::1");
+        assert_eq!(plain.port, 1080);
+        let auth = plain.auth.expect("auth");
         assert_eq!(auth.username, "user");
         assert_eq!(auth.password, "pass");
+    }
+
+    #[cfg(feature = "aead-cipher")]
+    #[test]
+    fn shadowsocks_outbound_proxy_url_round_trip() {
+        let url = "ss://YWVzLTEyOC1nY206cGFzc3dvcmQ@127.0.0.1:8388#edge";
+        let proxy = OutboundProxy::from_url(url).expect("ss proxy");
+        let OutboundProxy::Ss(hop) = &proxy else {
+            panic!("expected shadowsocks proxy");
+        };
+        assert_eq!(hop.svr_cfg.addr().to_string(), "127.0.0.1:8388");
+        assert_eq!(hop.svr_cfg.password(), "password");
+        assert_eq!(hop.tag.as_deref(), Some("edge"));
+
+        let reparsed = OutboundProxy::from_url(&proxy.to_url()).expect("round-trip ss proxy");
+        assert_eq!(reparsed, proxy);
+    }
+
+    #[cfg(feature = "aead-cipher")]
+    #[test]
+    fn shadowsocks_outbound_proxy_url_with_plugin() {
+        let url = concat!(
+            "ss://YWVzLTEyOC1nY206cGFzc3dvcmQ@127.0.0.1:8388/",
+            "?plugin=obfs-local%3Bobfs%3Dhttp%3Bobfs-host%3Dexample.com"
+        );
+        let proxy = OutboundProxy::from_url(url).expect("ss proxy with plugin");
+        let OutboundProxy::Ss(hop) = proxy else {
+            panic!("expected shadowsocks proxy");
+        };
+        let plugin = hop.svr_cfg.plugin().expect("plugin");
+        assert_eq!(plugin.plugin, "obfs-local");
+        assert_eq!(plugin.plugin_opts.as_deref(), Some("obfs=http;obfs-host=example.com"));
+    }
+
+    #[cfg(all(feature = "local", feature = "aead-cipher"))]
+    #[test]
+    fn shadowsocks_outbound_proxy_example_is_valid() {
+        let config = Config::load_from_str(include_str!("../../../examples/chain-ss.json5"), ConfigType::Local)
+            .expect("chain-ss example");
+        assert_eq!(config.outbound_proxy.len(), 1);
+        assert!(matches!(config.outbound_proxy[0], OutboundProxy::Ss(..)));
     }
 }

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -102,7 +102,7 @@ pub enum OutboundProxyProtocol {
     Socks5,
     Http,
     Https,
-    Ss,
+    Shadowsocks,
 }
 
 impl OutboundProxyProtocol {
@@ -111,7 +111,7 @@ impl OutboundProxyProtocol {
             "socks5" => Ok(Self::Socks5),
             "http" => Ok(Self::Http),
             "https" => Ok(Self::Https),
-            "ss" => Ok(Self::Ss),
+            "ss" => Ok(Self::Shadowsocks),
             _ => Err(format!(
                 "unsupported proxy scheme, only socks5://, http://, https:// and ss:// are supported: {scheme}://"
             )),
@@ -123,7 +123,7 @@ impl OutboundProxyProtocol {
             Self::Socks5 => "socks5",
             Self::Http => "http",
             Self::Https => "https",
-            Self::Ss => "ss",
+            Self::Shadowsocks => "ss",
         }
     }
 }
@@ -136,7 +136,7 @@ impl OutboundProxyProtocol {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OutboundProxy {
     Plain(PlainProxy),
-    Ss(Box<ShadowsocksHop>),
+    Shadowsocks(Box<ShadowsocksHop>),
 }
 
 /// Configuration for a SOCKS5, HTTP, or HTTPS outbound proxy hop.
@@ -182,11 +182,11 @@ impl OutboundProxy {
         let parsed = Url::parse(url).map_err(|e| format!("invalid proxy url {url}: {e}"))?;
         let protocol = OutboundProxyProtocol::from_scheme(parsed.scheme())?;
 
-        if protocol == OutboundProxyProtocol::Ss {
+        if protocol == OutboundProxyProtocol::Shadowsocks {
             let svr_cfg =
                 ServerConfig::from_url(url).map_err(|e| format!("invalid shadowsocks outbound proxy URL: {e}"))?;
             let tag = svr_cfg.remarks().map(ToOwned::to_owned);
-            return Ok(Self::Ss(Box::new(ShadowsocksHop { svr_cfg, tag })));
+            return Ok(Self::Shadowsocks(Box::new(ShadowsocksHop { svr_cfg, tag })));
         }
 
         let host = parsed
@@ -236,7 +236,7 @@ impl OutboundProxy {
                 Ok(ip) => Address::SocketAddress(SocketAddr::new(ip, proxy.port)),
                 Err(..) => Address::DomainNameAddress(proxy.host.clone(), proxy.port),
             },
-            Self::Ss(hop) => hop.svr_cfg.addr().into(),
+            Self::Shadowsocks(hop) => hop.svr_cfg.addr().into(),
         }
     }
 
@@ -248,7 +248,7 @@ impl OutboundProxy {
     /// Server address for an `ss://` hop, used for cycle diagnostics.
     pub(crate) fn shadowsocks_server_addr(&self) -> Option<&ServerAddr> {
         match self {
-            Self::Ss(hop) => Some(hop.svr_cfg.addr()),
+            Self::Shadowsocks(hop) => Some(hop.svr_cfg.addr()),
             Self::Plain(..) => None,
         }
     }
@@ -256,7 +256,7 @@ impl OutboundProxy {
     /// Serialize back to URL form, with brackets for IPv6 hosts
     pub fn to_url(&self) -> String {
         match self {
-            Self::Ss(hop) => hop.svr_cfg.to_url(),
+            Self::Shadowsocks(hop) => hop.svr_cfg.to_url(),
             Self::Plain(proxy) => {
                 let host = if proxy.host.contains(':') {
                     format!("[{}]", proxy.host)
@@ -3559,7 +3559,7 @@ mod tests {
     fn shadowsocks_outbound_proxy_url_round_trip() {
         let url = "ss://YWVzLTEyOC1nY206cGFzc3dvcmQ@127.0.0.1:8388#edge";
         let proxy = OutboundProxy::from_url(url).expect("ss proxy");
-        let OutboundProxy::Ss(hop) = &proxy else {
+        let OutboundProxy::Shadowsocks(hop) = &proxy else {
             panic!("expected shadowsocks proxy");
         };
         assert_eq!(hop.svr_cfg.addr().to_string(), "127.0.0.1:8388");
@@ -3578,7 +3578,7 @@ mod tests {
             "?plugin=obfs-local%3Bobfs%3Dhttp%3Bobfs-host%3Dexample.com"
         );
         let proxy = OutboundProxy::from_url(url).expect("ss proxy with plugin");
-        let OutboundProxy::Ss(hop) = proxy else {
+        let OutboundProxy::Shadowsocks(hop) = proxy else {
             panic!("expected shadowsocks proxy");
         };
         let plugin = hop.svr_cfg.plugin().expect("plugin");
@@ -3598,7 +3598,7 @@ mod tests {
             Some("obfs-local")
         );
         assert_eq!(config.outbound_proxy.len(), 1);
-        let OutboundProxy::Ss(landing) = &config.outbound_proxy[0] else {
+        let OutboundProxy::Shadowsocks(landing) = &config.outbound_proxy[0] else {
             panic!("expected shadowsocks landing hop");
         };
         assert_eq!(landing.svr_cfg.addr().to_string(), "landing.example.com:8388");

--- a/crates/shadowsocks-service/src/local/context.rs
+++ b/crates/shadowsocks-service/src/local/context.rs
@@ -1,6 +1,6 @@
 //! Shadowsocks Local Server Context
 
-use std::sync::Arc;
+use std::{io, sync::Arc};
 #[cfg(feature = "local-dns")]
 use std::{net::IpAddr, time::Duration};
 
@@ -118,12 +118,13 @@ impl ServiceContext {
     }
 
     /// Set outbound proxy chain (connection to SS server routes through these proxies)
-    pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) {
+    pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) -> io::Result<()> {
         self.outbound_client = if proxies.is_empty() {
             None
         } else {
-            Some(Arc::new(OutboundProxyClient::from_config(&proxies)))
+            Some(Arc::new(OutboundProxyClient::try_from_config(&proxies)?))
         };
+        Ok(())
     }
 
     /// Get the outbound proxy client (if a chain is configured).

--- a/crates/shadowsocks-service/src/local/context.rs
+++ b/crates/shadowsocks-service/src/local/context.rs
@@ -40,7 +40,7 @@ pub struct ServiceContext {
     // Flow statistic report
     flow_stat: Arc<FlowStat>,
 
-    // Outbound proxy chain (sslocal -> ss-server connection routes through these proxies)
+    // Trailing proxy chain (sslocal main server -> these proxies -> target)
     outbound_client: Option<Arc<OutboundProxyClient>>,
 
     // For DNS relay's ACL domain name reverse lookup -- whether the IP shall be forwarded
@@ -117,12 +117,14 @@ impl ServiceContext {
         self.acl.as_deref()
     }
 
-    /// Set outbound proxy chain (connection to SS server routes through these proxies)
+    /// Set the proxy hops that follow sslocal's configured main SS server.
     pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) -> io::Result<()> {
         self.outbound_client = if proxies.is_empty() {
             None
         } else {
-            Some(Arc::new(OutboundProxyClient::try_from_config(&proxies)?))
+            Some(Arc::new(OutboundProxyClient::try_from_config_after_main_server(
+                &proxies,
+            )?))
         };
         Ok(())
     }

--- a/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
+++ b/crates/shadowsocks-service/src/local/loadbalancing/ping_balancer.rs
@@ -23,7 +23,6 @@ use shadowsocks::{
     plugin::{Plugin, PluginMode},
     relay::{
         socks5::Address,
-        tcprelay::proxy_stream::ProxyClientStream,
         udprelay::{MAXIMUM_UDP_PAYLOAD_SIZE, options::UdpSocketControlData, proxy_socket::ProxySocket},
     },
 };
@@ -36,6 +35,8 @@ use tokio::{
 };
 
 use crate::{config::ServerInstanceConfig, local::context::ServiceContext};
+
+use crate::local::net::tcp::auto_proxy_stream::AutoProxyClientStream;
 
 use super::{
     server_data::ServerIdent,
@@ -851,9 +852,9 @@ impl PingChecker {
 
         let addr = Address::DomainNameAddress("clients3.google.com".to_owned(), 80);
 
-        let mut stream = ProxyClientStream::connect_with_opts(
-            self.context.context(),
-            self.server.server_config(),
+        let mut stream = AutoProxyClientStream::connect_proxied_with_opts(
+            self.context.clone(),
+            &self.server,
             &addr,
             self.server.connect_opts_ref(),
         )
@@ -890,9 +891,9 @@ impl PingChecker {
 
         let addr = Address::DomainNameAddress("detectportal.firefox.com".to_owned(), 80);
 
-        let mut stream = ProxyClientStream::connect_with_opts(
-            self.context.context(),
-            self.server.server_config(),
+        let mut stream = AutoProxyClientStream::connect_proxied_with_opts(
+            self.context.clone(),
+            &self.server,
             &addr,
             self.server.connect_opts_ref(),
         )
@@ -921,6 +922,13 @@ impl PingChecker {
     }
 
     async fn check_request_udp(&self) -> io::Result<()> {
+        if self.context.outbound_client().is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "UDP health checks are unavailable with an sslocal outbound chain",
+            ));
+        }
+
         // TransactionID: 0x1234
         // Flags: 0x0100 RD
         // Questions: 0x0001

--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -181,17 +181,29 @@ impl Server {
         context.set_security_config(&config.security);
 
         if !config.outbound_proxy.is_empty() {
-            let has_udp = config.local.iter().any(|local| local.config.mode.enable_udp());
-            if has_udp {
-                let preview = crate::net::OutboundProxyClient::from_config(&config.outbound_proxy);
-                if !preview.supports_udp() {
+            for proxy in &config.outbound_proxy {
+                if let Some(proxy_addr) = proxy.shadowsocks_server_addr()
+                    && config.server.iter().any(|server| server.config.addr() == proxy_addr)
+                {
                     log::warn!(
-                        "outbound proxy chain contains non-SOCKS5 hop(s); UDP traffic will bypass the chain. \
-                         Configure a SOCKS5-only chain to enable UDP relay."
+                        "ss outbound proxy hop {} is also configured as a main server; verify that the chain is not recursive",
+                        proxy_addr
                     );
                 }
             }
-            context.set_outbound_proxies(config.outbound_proxy);
+
+            let has_udp = config.local.iter().any(|local| local.config.mode.enable_udp());
+            if has_udp
+                && crate::net::OutboundProxyClient::config_contains_shadowsocks_hop(&config.outbound_proxy)
+            {
+                log::warn!("UDP traffic will be rejected because the outbound proxy chain contains an ss hop");
+            } else if has_udp && !crate::net::OutboundProxyClient::config_supports_udp(&config.outbound_proxy) {
+                log::warn!(
+                    "outbound proxy chain contains non-SOCKS5 hop(s); UDP traffic will bypass the chain. \
+                     Configure a SOCKS5-only chain to enable UDP relay."
+                );
+            }
+            context.set_outbound_proxies(config.outbound_proxy)?;
         }
 
         assert!(!config.local.is_empty(), "no valid local server configuration");

--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -193,14 +193,9 @@ impl Server {
             }
 
             let has_udp = config.local.iter().any(|local| local.config.mode.enable_udp());
-            if has_udp
-                && crate::net::OutboundProxyClient::config_contains_shadowsocks_hop(&config.outbound_proxy)
-            {
-                log::warn!("UDP traffic will be rejected because the outbound proxy chain contains an ss hop");
-            } else if has_udp && !crate::net::OutboundProxyClient::config_supports_udp(&config.outbound_proxy) {
+            if has_udp {
                 log::warn!(
-                    "outbound proxy chain contains non-SOCKS5 hop(s); UDP traffic will bypass the chain. \
-                     Configure a SOCKS5-only chain to enable UDP relay."
+                    "UDP traffic will be rejected because sslocal outbound chains start with the main ss server"
                 );
             }
             context.set_outbound_proxies(config.outbound_proxy)?;

--- a/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
+++ b/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
@@ -23,28 +23,27 @@ use crate::{
 
 use super::auto_proxy_io::AutoProxyIo;
 
-/// Outbound transport used by [`AutoProxyClientStream`]: either a direct
-/// TCP connection or a tunnel through the configured outbound proxy chain.
+/// Fully established proxied transport used by [`AutoProxyClientStream`].
 #[allow(clippy::large_enum_variant)]
 #[pin_project(project = OutboundTransportProj)]
 pub enum OutboundTransport {
-    /// Direct TCP, no outbound chain configured.
-    Direct(#[pin] TcpStream),
-    /// Tunnel produced by `OutboundProxyClient::connect_tcp`.
-    Chained(#[pin] OutboundProxyStream),
+    /// A normal one-hop Shadowsocks connection with no trailing chain.
+    Direct(#[pin] ProxyClientStream<MonProxyStream<TcpStream>>),
+    /// A complete main-server-first chain produced by `OutboundProxyClient`.
+    Chained(#[pin] MonProxyStream<OutboundProxyStream>),
 }
 
 impl OutboundTransport {
     fn local_addr(&self) -> io::Result<SocketAddr> {
         match self {
-            Self::Direct(s) => s.local_addr(),
-            Self::Chained(s) => s.local_addr(),
+            Self::Direct(s) => s.get_ref().get_ref().local_addr(),
+            Self::Chained(s) => s.get_ref().local_addr(),
         }
     }
 
     fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         match self {
-            Self::Direct(s) => s.set_nodelay(nodelay),
+            Self::Direct(s) => s.get_ref().get_ref().set_nodelay(nodelay),
             // For tunnels we can only forward the request to the underlying
             // TCP socket if it is exposed; the unified enum has no such
             // accessor today, so the call is a no-op.
@@ -120,9 +119,9 @@ impl<'a> TcpDialer for DirectTcpDialer<'a> {
 #[allow(clippy::large_enum_variant)]
 #[pin_project(project = AutoProxyClientStreamProj)]
 pub enum AutoProxyClientStream {
-    /// Tunnel through the shadowsocks server (optionally over the outbound
-    /// proxy chain).
-    Proxied(#[pin] ProxyClientStream<MonProxyStream<OutboundTransport>>),
+    /// Tunnel through the main Shadowsocks server and any configured
+    /// trailing outbound proxy hops.
+    Proxied(#[pin] OutboundTransport),
     /// Direct TCP, bypassing the shadowsocks server.
     Bypassed(#[pin] TcpStream),
 }
@@ -238,21 +237,38 @@ impl AutoProxyClientStream {
     {
         let flow_stat = context.flow_stat();
         let target_addr: Address = addr.into();
-        let ss_addr: Address = server.server_config().tcp_external_addr().into();
 
         let dial_result = match context.outbound_client() {
-            None => TcpStream::connect_remote_with_opts(context.context_ref(), &ss_addr, connect_opts)
-                .await
-                .map(OutboundTransport::Direct),
+            None => {
+                let ss_addr: Address = server.server_config().tcp_external_addr().into();
+                match TcpStream::connect_remote_with_opts(context.context_ref(), &ss_addr, connect_opts).await {
+                    Ok(transport) => {
+                        let transport = MonProxyStream::from_stream(transport, flow_stat.clone());
+                        let stream = ProxyClientStream::from_stream(
+                            context.context(),
+                            transport,
+                            server.server_config(),
+                            target_addr.clone(),
+                        );
+                        Ok(OutboundTransport::Direct(stream))
+                    }
+                    Err(err) => Err(err),
+                }
+            }
             Some(client) => {
                 let dialer = DirectTcpDialer {
                     context: context.as_ref(),
                     opts: connect_opts,
                 };
                 client
-                    .connect_tcp(context.context(), &dialer, &ss_addr)
+                    .connect_tcp_with_initial_shadowsocks(
+                        context.context(),
+                        &dialer,
+                        server.server_config(),
+                        &target_addr,
+                    )
                     .await
-                    .map(OutboundTransport::Chained)
+                    .map(|stream| OutboundTransport::Chained(MonProxyStream::from_stream(stream, flow_stat.clone())))
             }
         };
 
@@ -264,21 +280,19 @@ impl AutoProxyClientStream {
             }
         };
 
-        let mon = MonProxyStream::from_stream(transport, flow_stat);
-        let stream = ProxyClientStream::from_stream(context.context(), mon, server.server_config(), target_addr);
-        Ok(Self::Proxied(stream))
+        Ok(Self::Proxied(transport))
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match *self {
-            Self::Proxied(ref s) => s.get_ref().get_ref().local_addr(),
+            Self::Proxied(ref s) => s.local_addr(),
             Self::Bypassed(ref s) => s.local_addr(),
         }
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         match *self {
-            Self::Proxied(ref s) => s.get_ref().get_ref().set_nodelay(nodelay),
+            Self::Proxied(ref s) => s.set_nodelay(nodelay),
             Self::Bypassed(ref s) => s.set_nodelay(nodelay),
         }
     }

--- a/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
+++ b/crates/shadowsocks-service/src/local/net/tcp/auto_proxy_stream.rs
@@ -250,7 +250,7 @@ impl AutoProxyClientStream {
                     opts: connect_opts,
                 };
                 client
-                    .connect_tcp(&dialer, &ss_addr)
+                    .connect_tcp(context.context(), &dialer, &ss_addr)
                     .await
                     .map(OutboundTransport::Chained)
             }

--- a/crates/shadowsocks-service/src/local/net/udp/association.rs
+++ b/crates/shadowsocks-service/src/local/net/udp/association.rs
@@ -19,108 +19,59 @@ use tokio::{sync::mpsc, task::JoinHandle, time};
 use shadowsocks::{
     config::ServerConfig,
     lookup_then,
-    net::{AddrFamily, ConnectOpts, TcpStream as ShadowTcpStream, UdpSocket as ShadowUdpSocket},
+    net::{AddrFamily, ConnectOpts, UdpSocket as ShadowUdpSocket},
     relay::{
         Address,
-        udprelay::{
-            MAXIMUM_UDP_PAYLOAD_SIZE, ProxySocket,
-            options::UdpSocketControlData,
-            proxy_socket::UdpSocketType,
-        },
+        udprelay::{MAXIMUM_UDP_PAYLOAD_SIZE, ProxySocket, options::UdpSocketControlData},
     },
 };
 
 use crate::{
     local::{context::ServiceContext, loadbalancing::PingBalancer},
     net::{
-        MonProxySocket, OutboundProxyDatagram, TcpDialer,
-        UDP_ASSOCIATION_KEEP_ALIVE_CHANNEL_SIZE, UDP_ASSOCIATION_SEND_CHANNEL_SIZE,
+        MonProxySocket, UDP_ASSOCIATION_KEEP_ALIVE_CHANNEL_SIZE, UDP_ASSOCIATION_SEND_CHANNEL_SIZE,
         packet_window::PacketWindowFilter,
     },
 };
 
-/// Build the proxied socket appropriate for `svr_cfg`, going through a
-/// fully-SOCKS5 outbound chain, rejecting chains with a Shadowsocks hop,
-/// and preserving the legacy direct fallback for other unsupported hops.
+/// Build the proxied socket appropriate for `svr_cfg`.
+///
+/// `sslocal` TCP chains start with the configured main Shadowsocks server.
+/// The UDP relay cannot reproduce that nested ordering, so any configured
+/// trailing chain is rejected instead of bypassed.
 async fn create_proxied_socket(
     context: &ServiceContext,
     svr_cfg: &ServerConfig,
     connect_opts: &ConnectOpts,
 ) -> io::Result<ProxiedSocket> {
-    if let Some(client) = context.outbound_client() {
-        if client.contains_shadowsocks_hop() {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "UDP traffic is rejected because the outbound proxy chain contains an ss hop",
-            ));
-        }
-
-        if !client.supports_udp() {
-            let socket = ProxySocket::connect_with_opts(context.context(), svr_cfg, connect_opts).await?;
-            let mon = MonProxySocket::from_socket(socket, context.flow_stat());
-            return Ok(ProxiedSocket::Direct(mon));
-        }
-
-        let client = client.clone();
-        let dialer = LocalTcpDialer {
-            context: Arc::new(context.clone()),
-            opts: connect_opts.clone(),
-        };
-        let target: Address = svr_cfg.udp_external_addr().into();
-        let datagram = client
-            .associate_udp(&context.context(), &dialer, connect_opts, target)
-            .await?;
-        let proxy_socket =
-            ProxySocket::from_socket(UdpSocketType::Client, context.context(), svr_cfg, datagram);
-        let mon = MonProxySocket::from_socket(proxy_socket, context.flow_stat());
-        Ok(ProxiedSocket::Chained(mon))
-    } else {
-        let socket = ProxySocket::connect_with_opts(context.context(), svr_cfg, connect_opts).await?;
-        let mon = MonProxySocket::from_socket(socket, context.flow_stat());
-        Ok(ProxiedSocket::Direct(mon))
+    if context.outbound_client().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "UDP traffic is rejected because sslocal outbound chains start with the main ss server",
+        ));
     }
+
+    let socket = ProxySocket::connect_with_opts(context.context(), svr_cfg, connect_opts).await?;
+    let mon = MonProxySocket::from_socket(socket, context.flow_stat());
+    Ok(ProxiedSocket::Direct(mon))
 }
 
-/// `TcpDialer` adapter that uses the local service context's connect options.
-struct LocalTcpDialer {
-    context: Arc<ServiceContext>,
-    opts: ConnectOpts,
-}
-
-impl TcpDialer for LocalTcpDialer {
-    async fn dial(&self, addr: &Address) -> io::Result<ShadowTcpStream> {
-        ShadowTcpStream::connect_remote_with_opts(self.context.context_ref(), addr, &self.opts).await
-    }
-}
-
-/// Proxied UDP socket, either direct (single hop to ss-server) or routed
-/// through a SOCKS5-only outbound proxy chain.
+/// Proxied UDP socket connected directly to the configured SS server.
 #[allow(clippy::large_enum_variant)]
 enum ProxiedSocket {
     Direct(MonProxySocket<ShadowUdpSocket>),
-    Chained(MonProxySocket<OutboundProxyDatagram>),
 }
 
 impl ProxiedSocket {
-    async fn send_with_ctrl(
-        &self,
-        addr: &Address,
-        control: &UdpSocketControlData,
-        data: &[u8],
-    ) -> io::Result<()> {
+    async fn send_with_ctrl(&self, addr: &Address, control: &UdpSocketControlData, data: &[u8]) -> io::Result<()> {
         match self {
             Self::Direct(s) => s.send_with_ctrl(addr, control, data).await,
-            Self::Chained(s) => s.send_with_ctrl(addr, control, data).await,
         }
     }
 
-    async fn recv_with_ctrl(
-        &self,
-        buf: &mut [u8],
-    ) -> io::Result<(usize, Address, Option<UdpSocketControlData>)> {
+    async fn recv_with_ctrl(&self, buf: &mut [u8]) -> io::Result<(usize, Address, Option<UdpSocketControlData>)> {
         match self {
             Self::Direct(s) => s.recv_with_ctrl(buf).await,
-            Self::Chained(s) => s.recv_with_ctrl(buf).await,
         }
     }
 }
@@ -660,12 +611,7 @@ where
                 let server = self.balancer.best_udp_server();
                 let svr_cfg = server.server_config();
 
-                let proxied = create_proxied_socket(
-                    self.context.as_ref(),
-                    svr_cfg,
-                    server.connect_opts_ref(),
-                )
-                .await?;
+                let proxied = create_proxied_socket(self.context.as_ref(), svr_cfg, server.connect_opts_ref()).await?;
 
                 self.proxied_socket.insert(proxied)
             }

--- a/crates/shadowsocks-service/src/local/net/udp/association.rs
+++ b/crates/shadowsocks-service/src/local/net/udp/association.rs
@@ -39,24 +39,29 @@ use crate::{
     },
 };
 
-/// Build the proxied socket appropriate for `svr_cfg`, transparently
-/// going through the configured outbound chain when one is present and
-/// fully SOCKS5 (otherwise the chain is bypassed for UDP).
+/// Build the proxied socket appropriate for `svr_cfg`, going through a
+/// fully-SOCKS5 outbound chain, rejecting chains with a Shadowsocks hop,
+/// and preserving the legacy direct fallback for other unsupported hops.
 async fn create_proxied_socket(
     context: &ServiceContext,
     svr_cfg: &ServerConfig,
     connect_opts: &ConnectOpts,
 ) -> io::Result<ProxiedSocket> {
-    let use_chain = context
-        .outbound_client()
-        .map(|c| c.supports_udp())
-        .unwrap_or(false);
+    if let Some(client) = context.outbound_client() {
+        if client.contains_shadowsocks_hop() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "UDP traffic is rejected because the outbound proxy chain contains an ss hop",
+            ));
+        }
 
-    if use_chain {
-        let client = context
-            .outbound_client()
-            .expect("outbound_client checked above")
-            .clone();
+        if !client.supports_udp() {
+            let socket = ProxySocket::connect_with_opts(context.context(), svr_cfg, connect_opts).await?;
+            let mon = MonProxySocket::from_socket(socket, context.flow_stat());
+            return Ok(ProxiedSocket::Direct(mon));
+        }
+
+        let client = client.clone();
         let dialer = LocalTcpDialer {
             context: Arc::new(context.clone()),
             opts: connect_opts.clone(),

--- a/crates/shadowsocks-service/src/net/outbound/chain.rs
+++ b/crates/shadowsocks-service/src/net/outbound/chain.rs
@@ -4,6 +4,7 @@ use std::io;
 
 use log::trace;
 use shadowsocks::{
+    config::ServerConfig,
     context::SharedContext,
     relay::{socks5::Address, tcprelay::ProxyClientStream},
 };
@@ -35,6 +36,22 @@ impl OutboundProxyClient {
     {
         connect_chain(self.hops(), &context, dialer, target).await
     }
+
+    /// Establish an `sslocal` TCP tunnel whose configured main Shadowsocks
+    /// server is the physical first hop and whose `outbound_proxy` entries
+    /// are the subsequent hops.
+    pub async fn connect_tcp_with_initial_shadowsocks<D>(
+        &self,
+        context: SharedContext,
+        dialer: &D,
+        initial: &ServerConfig,
+        target: &Address,
+    ) -> io::Result<OutboundProxyStream>
+    where
+        D: TcpDialer + Sync,
+    {
+        connect_chain_with_initial_shadowsocks(self.hops(), &context, dialer, initial, target).await
+    }
 }
 
 pub(crate) async fn connect_chain<D>(
@@ -57,8 +74,39 @@ where
 
     trace!("dialling first outbound proxy hop {}", first_hop.addr);
     let first_tcp = dialer.dial(&first_hop.addr).await?;
-    let mut stream = OutboundProxyStream::from_tcp(first_tcp)?;
+    let stream = OutboundProxyStream::from_tcp(first_tcp)?;
 
+    negotiate_hops(hops, context, stream, target).await
+}
+
+async fn connect_chain_with_initial_shadowsocks<D>(
+    hops: &[OutboundProxyHop],
+    context: &SharedContext,
+    dialer: &D,
+    initial: &ServerConfig,
+    target: &Address,
+) -> io::Result<OutboundProxyStream>
+where
+    D: TcpDialer + Sync,
+{
+    let initial_addr: Address = initial.tcp_external_addr().into();
+    trace!("dialling initial shadowsocks hop {}", initial_addr);
+    let initial_tcp = dialer.dial(&initial_addr).await?;
+    let local_addr = initial_tcp.local_addr()?;
+    let initial_stream = OutboundProxyStream::from_tcp_with_local_addr(initial_tcp, local_addr);
+    let next_target = hops.first().map(|hop| &hop.addr).unwrap_or(target);
+    let initial_stream = ProxyClientStream::from_stream(context.clone(), initial_stream, initial, next_target.clone());
+    let stream = OutboundProxyStream::from_ss(local_addr, initial_stream);
+
+    negotiate_hops(hops, context, stream, target).await
+}
+
+async fn negotiate_hops(
+    hops: &[OutboundProxyHop],
+    context: &SharedContext,
+    mut stream: OutboundProxyStream,
+    target: &Address,
+) -> io::Result<OutboundProxyStream> {
     for (idx, hop) in hops.iter().enumerate() {
         // For HTTPS hops, wrap the wire layer with TLS *before* speaking
         // the application-level CONNECT verb.

--- a/crates/shadowsocks-service/src/net/outbound/chain.rs
+++ b/crates/shadowsocks-service/src/net/outbound/chain.rs
@@ -3,7 +3,10 @@
 use std::io;
 
 use log::trace;
-use shadowsocks::relay::socks5::Address;
+use shadowsocks::{
+    context::SharedContext,
+    relay::{socks5::Address, tcprelay::ProxyClientStream},
+};
 
 use super::{
     OutboundProxyClient, OutboundProxyHop, OutboundProxyKind, TcpDialer, socks5::Socks5Negotiator,
@@ -23,18 +26,20 @@ impl OutboundProxyClient {
     /// bypass routing, ...).
     pub async fn connect_tcp<D>(
         &self,
+        context: SharedContext,
         dialer: &D,
         target: &Address,
     ) -> io::Result<OutboundProxyStream>
     where
         D: TcpDialer + Sync,
     {
-        connect_chain(self.hops(), dialer, target).await
+        connect_chain(self.hops(), &context, dialer, target).await
     }
 }
 
 pub(crate) async fn connect_chain<D>(
     hops: &[OutboundProxyHop],
+    context: &SharedContext,
     dialer: &D,
     target: &Address,
 ) -> io::Result<OutboundProxyStream>
@@ -48,6 +53,8 @@ where
         ));
     };
 
+    first_hop.wait_plugin_started().await?;
+
     trace!("dialling first outbound proxy hop {}", first_hop.addr);
     let first_tcp = dialer.dial(&first_hop.addr).await?;
     let mut stream = OutboundProxyStream::from_tcp(first_tcp)?;
@@ -59,12 +66,9 @@ where
             stream = tls_wrap(stream, hop.tls_sni()).await?;
         }
 
-        let next_target = hops
-            .get(idx + 1)
-            .map(|h| &h.addr)
-            .unwrap_or(target);
+        let next_target = hops.get(idx + 1).map(|h| &h.addr).unwrap_or(target);
 
-        stream = negotiate_hop(stream, hop, next_target).await?;
+        stream = negotiate_hop(context, stream, hop, next_target).await?;
     }
 
     Ok(stream)
@@ -81,6 +85,7 @@ where
 pub(crate) async fn connect_chain_for_udp_associate<D>(
     hops: &[OutboundProxyHop],
     hop_index: usize,
+    context: &SharedContext,
     dialer: &D,
 ) -> io::Result<OutboundProxyStream>
 where
@@ -100,10 +105,11 @@ where
     // builder will SOCKS5-TcpConnect through prefix and leave the byte
     // stream pointed at `hops[hop_index]` ready for the caller to issue
     // its own SOCKS5 handshake / UdpAssociate command on top.
-    connect_chain(prefix, dialer, &target_hop.addr).await
+    connect_chain(prefix, context, dialer, &target_hop.addr).await
 }
 
 async fn negotiate_hop(
+    context: &SharedContext,
     mut stream: OutboundProxyStream,
     hop: &OutboundProxyHop,
     next_target: &Address,
@@ -126,6 +132,11 @@ async fn negotiate_hop(
             io::ErrorKind::Unsupported,
             "HTTP/HTTPS outbound proxy requires the `local-http` feature",
         )),
+        OutboundProxyKind::Ss { svr_cfg, .. } => {
+            let local_addr = stream.local_addr()?;
+            let stream = ProxyClientStream::from_stream(context.clone(), stream, svr_cfg, next_target.clone());
+            Ok(OutboundProxyStream::from_ss(local_addr, stream))
+        }
     }
 }
 

--- a/crates/shadowsocks-service/src/net/outbound/chain.rs
+++ b/crates/shadowsocks-service/src/net/outbound/chain.rs
@@ -96,7 +96,7 @@ where
     let initial_stream = OutboundProxyStream::from_tcp_with_local_addr(initial_tcp, local_addr);
     let next_target = hops.first().map(|hop| &hop.addr).unwrap_or(target);
     let initial_stream = ProxyClientStream::from_stream(context.clone(), initial_stream, initial, next_target.clone());
-    let stream = OutboundProxyStream::from_ss(local_addr, initial_stream);
+    let stream = OutboundProxyStream::from_shadowsocks(local_addr, initial_stream);
 
     negotiate_hops(hops, context, stream, target).await
 }
@@ -180,10 +180,10 @@ async fn negotiate_hop(
             io::ErrorKind::Unsupported,
             "HTTP/HTTPS outbound proxy requires the `local-http` feature",
         )),
-        OutboundProxyKind::Ss { svr_cfg, .. } => {
+        OutboundProxyKind::Shadowsocks { svr_cfg, .. } => {
             let local_addr = stream.local_addr()?;
             let stream = ProxyClientStream::from_stream(context.clone(), stream, svr_cfg, next_target.clone());
-            Ok(OutboundProxyStream::from_ss(local_addr, stream))
+            Ok(OutboundProxyStream::from_shadowsocks(local_addr, stream))
         }
     }
 }

--- a/crates/shadowsocks-service/src/net/outbound/mod.rs
+++ b/crates/shadowsocks-service/src/net/outbound/mod.rs
@@ -230,10 +230,25 @@ impl OutboundProxyClient {
     /// Build a client from a (possibly empty) list of `OutboundProxy`
     /// configuration entries.
     pub fn try_from_config(proxies: &[OutboundProxy]) -> io::Result<Self> {
+        Self::try_from_config_with_hop_offset(proxies, 0)
+    }
+
+    /// Build the trailing hops of an `sslocal` chain whose configured main
+    /// Shadowsocks server is hop zero.
+    ///
+    /// SIP003 plugins are only usable on the physical first hop. Starting
+    /// indices at one makes plugin-bearing entries in `outbound_proxy` fail
+    /// during configuration instead of trying to start an unreachable local
+    /// plugin for a later hop.
+    pub fn try_from_config_after_main_server(proxies: &[OutboundProxy]) -> io::Result<Self> {
+        Self::try_from_config_with_hop_offset(proxies, 1)
+    }
+
+    fn try_from_config_with_hop_offset(proxies: &[OutboundProxy], hop_offset: usize) -> io::Result<Self> {
         let hops = proxies
             .iter()
             .enumerate()
-            .map(|(idx, proxy)| hop_from_config(idx, proxy))
+            .map(|(idx, proxy)| hop_from_config(idx + hop_offset, proxy))
             .collect::<io::Result<Vec<_>>>()?;
         Ok(Self { hops: hops.into() })
     }

--- a/crates/shadowsocks-service/src/net/outbound/mod.rs
+++ b/crates/shadowsocks-service/src/net/outbound/mod.rs
@@ -1,7 +1,7 @@
 //! Outbound proxy chain support.
 //!
 //! Provides a unified [`OutboundProxyClient`] that connects through a chain
-//! of intermediate proxies (SOCKS5 / HTTP / HTTPS) before reaching the
+//! of intermediate proxies (SOCKS5 / HTTP / HTTPS / Shadowsocks) before reaching the
 //! actual target. The previous implementation lived in two parallel files
 //! (`net::outbound_proxy` for the server, `local::net::tcp::outbound_proxy`
 //! for the local side) and leaked protocol-specific types
@@ -21,15 +21,22 @@
 //!   tunnel returned by the chain builder.
 //! * [`chain`] — The chain construction algorithm itself.
 
-use std::{io, sync::Arc};
-
-use shadowsocks::{
-    context::SharedContext,
-    net::ConnectOpts,
-    relay::socks5::Address,
+use std::{
+    fmt, io,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 
-use crate::config::{OutboundProxy, OutboundProxyProtocol};
+use shadowsocks::{
+    config::ServerConfig,
+    context::SharedContext,
+    net::ConnectOpts,
+    plugin::{Plugin, PluginMode},
+    relay::socks5::Address,
+};
+use tokio::sync::Mutex;
+
+use crate::config::{OutboundProxy, OutboundProxyProtocol, PlainProxy};
 
 pub mod auth;
 pub mod chain;
@@ -59,7 +66,7 @@ pub trait TcpDialer {
 }
 
 /// One protocol-friendly hop. Built from [`OutboundProxy`] via
-/// [`OutboundProxyClient::from_config`]; keeps the protocol-specific
+/// [`OutboundProxyClient::try_from_config`]; keeps the protocol-specific
 /// authentication info pre-converted so the data path doesn't have to
 /// touch [`crate::config`] at all.
 #[derive(Debug, Clone)]
@@ -91,10 +98,88 @@ impl OutboundProxyHop {
     fn supports_udp(&self) -> bool {
         matches!(self.kind, OutboundProxyKind::Socks5 { .. })
     }
+
+    async fn wait_plugin_started(&self) -> io::Result<()> {
+        match &self.kind {
+            OutboundProxyKind::Ss {
+                plugin: Some(plugin), ..
+            } => plugin.wait_started().await,
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Keeps a first-hop SIP003 plugin alive for the lifetime of its outbound client.
+pub struct PluginHandle {
+    plugin: Plugin,
+    readiness: Mutex<PluginReadiness>,
+}
+
+enum PluginReadiness {
+    Pending,
+    Started,
+    Failed { retry_at: Instant, message: String },
+}
+
+impl PluginHandle {
+    const START_TIMEOUT: Duration = Duration::from_secs(3);
+    const RETRY_DELAY: Duration = Duration::from_secs(1);
+
+    fn new(plugin: Plugin) -> Self {
+        Self {
+            plugin,
+            readiness: Mutex::new(PluginReadiness::Pending),
+        }
+    }
+
+    async fn wait_started(&self) -> io::Result<()> {
+        // Serialize readiness probes so a busy client cannot start a new
+        // three-second wait for every concurrent connection. A failure is
+        // cached briefly, then retried so a slow plugin can still recover.
+        let mut readiness = self.readiness.lock().await;
+        match &*readiness {
+            PluginReadiness::Started => return Ok(()),
+            PluginReadiness::Failed { retry_at, message } if Instant::now() < *retry_at => {
+                return Err(io::Error::new(io::ErrorKind::TimedOut, message.clone()));
+            }
+            PluginReadiness::Pending | PluginReadiness::Failed { .. } => {}
+        }
+
+        if self.plugin.wait_started(Self::START_TIMEOUT).await {
+            *readiness = PluginReadiness::Started;
+            Ok(())
+        } else {
+            let message = format!(
+                "outbound proxy plugin on {} did not start within {} seconds",
+                self.plugin.local_addr(),
+                Self::START_TIMEOUT.as_secs()
+            );
+            *readiness = PluginReadiness::Failed {
+                retry_at: Instant::now() + Self::RETRY_DELAY,
+                message: message.clone(),
+            };
+            Err(io::Error::new(io::ErrorKind::TimedOut, message))
+        }
+    }
+}
+
+impl fmt::Debug for PluginHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = match self.readiness.try_lock().as_deref() {
+            Ok(PluginReadiness::Pending) => "pending",
+            Ok(PluginReadiness::Started) => "started",
+            Ok(PluginReadiness::Failed { .. }) => "failed",
+            Err(_) => "checking",
+        };
+        f.debug_struct("PluginHandle")
+            .field("local_addr", &self.plugin.local_addr())
+            .field("state", &state)
+            .finish()
+    }
 }
 
 /// Per-protocol settings for one [`OutboundProxyHop`].
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub enum OutboundProxyKind {
     /// SOCKS5 proxy.
@@ -107,11 +192,33 @@ pub enum OutboundProxyKind {
         /// Server name to use for TLS SNI.
         sni: String,
     },
+    /// Shadowsocks encrypted hop. The plugin is only supported on the first hop.
+    Ss {
+        svr_cfg: Arc<ServerConfig>,
+        plugin: Option<Arc<PluginHandle>>,
+    },
+}
+
+impl fmt::Debug for OutboundProxyKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Socks5 { auth } => f.debug_struct("Socks5").field("auth", auth).finish(),
+            Self::Http { auth } => f.debug_struct("Http").field("auth", auth).finish(),
+            Self::Https { auth, sni } => f.debug_struct("Https").field("auth", auth).field("sni", sni).finish(),
+            Self::Ss { svr_cfg, plugin } => f
+                .debug_struct("Ss")
+                .field("addr", &svr_cfg.addr())
+                .field("method", &svr_cfg.method())
+                .field("password", &"<redacted>")
+                .field("plugin", plugin)
+                .finish(),
+        }
+    }
 }
 
 /// Unified outbound proxy client.
 ///
-/// Construct from configuration via [`Self::from_config`]. The instance
+/// Construct from configuration via [`Self::try_from_config`]. The instance
 /// can be cached (e.g. inside `ServiceContext`) and reused across
 /// connections.
 #[derive(Debug, Clone)]
@@ -122,9 +229,23 @@ pub struct OutboundProxyClient {
 impl OutboundProxyClient {
     /// Build a client from a (possibly empty) list of `OutboundProxy`
     /// configuration entries.
-    pub fn from_config(proxies: &[OutboundProxy]) -> Self {
-        let hops: Vec<OutboundProxyHop> = proxies.iter().map(hop_from_config).collect();
-        Self { hops: hops.into() }
+    pub fn try_from_config(proxies: &[OutboundProxy]) -> io::Result<Self> {
+        let hops = proxies
+            .iter()
+            .enumerate()
+            .map(|(idx, proxy)| hop_from_config(idx, proxy))
+            .collect::<io::Result<Vec<_>>>()?;
+        Ok(Self { hops: hops.into() })
+    }
+
+    /// Whether a configuration can use the existing SOCKS5-only UDP relay path.
+    pub fn config_supports_udp(proxies: &[OutboundProxy]) -> bool {
+        !proxies.is_empty() && proxies.iter().all(OutboundProxy::supports_udp)
+    }
+
+    /// Whether a configuration contains a Shadowsocks outbound hop.
+    pub fn config_contains_shadowsocks_hop(proxies: &[OutboundProxy]) -> bool {
+        proxies.iter().any(|proxy| matches!(proxy, OutboundProxy::Ss(_)))
     }
 
     /// Underlying hops.
@@ -148,6 +269,13 @@ impl OutboundProxyClient {
         !self.hops.is_empty() && self.hops.iter().all(OutboundProxyHop::supports_udp)
     }
 
+    /// Whether this chain contains a Shadowsocks outbound hop.
+    pub fn contains_shadowsocks_hop(&self) -> bool {
+        self.hops
+            .iter()
+            .any(|hop| matches!(hop.kind, OutboundProxyKind::Ss { .. }))
+    }
+
     /// Establish a multi-hop UDP relay through the chain.
     ///
     /// Requires every hop to be SOCKS5 (see [`Self::supports_udp`]).
@@ -168,8 +296,43 @@ impl OutboundProxyClient {
     }
 }
 
-fn hop_from_config(proxy: &OutboundProxy) -> OutboundProxyHop {
-    let addr = proxy.address();
+fn hop_from_config(idx: usize, proxy: &OutboundProxy) -> io::Result<OutboundProxyHop> {
+    match proxy {
+        OutboundProxy::Plain(proxy) => plain_hop(proxy),
+        OutboundProxy::Ss(hop) => {
+            let mut svr_cfg = hop.svr_cfg.clone();
+            let plugin = match svr_cfg.plugin().cloned() {
+                Some(plugin_cfg) => {
+                    if idx != 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Unsupported,
+                            "plugin on non-first ss outbound proxy hop requires rendezvous support",
+                        ));
+                    }
+
+                    let plugin = Plugin::start(&plugin_cfg, svr_cfg.addr(), PluginMode::Client)?;
+                    svr_cfg.set_plugin_addr(plugin.local_addr().into());
+                    Some(Arc::new(PluginHandle::new(plugin)))
+                }
+                None => None,
+            };
+
+            Ok(OutboundProxyHop {
+                addr: svr_cfg.tcp_external_addr().into(),
+                kind: OutboundProxyKind::Ss {
+                    svr_cfg: Arc::new(svr_cfg),
+                    plugin,
+                },
+            })
+        }
+    }
+}
+
+fn plain_hop(proxy: &PlainProxy) -> io::Result<OutboundProxyHop> {
+    let addr = match proxy.host.parse() {
+        Ok(ip) => Address::SocketAddress(std::net::SocketAddr::new(ip, proxy.port)),
+        Err(..) => Address::DomainNameAddress(proxy.host.clone(), proxy.port),
+    };
     let kind = match proxy.protocol {
         OutboundProxyProtocol::Socks5 => {
             let auth = match proxy.auth.as_ref() {
@@ -185,12 +348,18 @@ fn hop_from_config(proxy: &OutboundProxy) -> OutboundProxyHop {
             auth: http_auth_from_config(proxy),
             sni: proxy.host.clone(),
         },
+        OutboundProxyProtocol::Ss => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "plain outbound proxy cannot use the ss scheme",
+            ));
+        }
     };
 
-    OutboundProxyHop { addr, kind }
+    Ok(OutboundProxyHop { addr, kind })
 }
 
-fn http_auth_from_config(proxy: &OutboundProxy) -> HttpProxyAuth {
+fn http_auth_from_config(proxy: &PlainProxy) -> HttpProxyAuth {
     match proxy.auth.as_ref() {
         Some(a) => HttpProxyAuth::basic(a.username.clone(), a.password.clone()),
         None => HttpProxyAuth::None,

--- a/crates/shadowsocks-service/src/net/outbound/mod.rs
+++ b/crates/shadowsocks-service/src/net/outbound/mod.rs
@@ -101,7 +101,7 @@ impl OutboundProxyHop {
 
     async fn wait_plugin_started(&self) -> io::Result<()> {
         match &self.kind {
-            OutboundProxyKind::Ss {
+            OutboundProxyKind::Shadowsocks {
                 plugin: Some(plugin), ..
             } => plugin.wait_started().await,
             _ => Ok(()),
@@ -193,7 +193,7 @@ pub enum OutboundProxyKind {
         sni: String,
     },
     /// Shadowsocks encrypted hop. The plugin is only supported on the first hop.
-    Ss {
+    Shadowsocks {
         svr_cfg: Arc<ServerConfig>,
         plugin: Option<Arc<PluginHandle>>,
     },
@@ -205,8 +205,8 @@ impl fmt::Debug for OutboundProxyKind {
             Self::Socks5 { auth } => f.debug_struct("Socks5").field("auth", auth).finish(),
             Self::Http { auth } => f.debug_struct("Http").field("auth", auth).finish(),
             Self::Https { auth, sni } => f.debug_struct("Https").field("auth", auth).field("sni", sni).finish(),
-            Self::Ss { svr_cfg, plugin } => f
-                .debug_struct("Ss")
+            Self::Shadowsocks { svr_cfg, plugin } => f
+                .debug_struct("Shadowsocks")
                 .field("addr", &svr_cfg.addr())
                 .field("method", &svr_cfg.method())
                 .field("password", &"<redacted>")
@@ -260,7 +260,7 @@ impl OutboundProxyClient {
 
     /// Whether a configuration contains a Shadowsocks outbound hop.
     pub fn config_contains_shadowsocks_hop(proxies: &[OutboundProxy]) -> bool {
-        proxies.iter().any(|proxy| matches!(proxy, OutboundProxy::Ss(_)))
+        proxies.iter().any(|proxy| matches!(proxy, OutboundProxy::Shadowsocks(_)))
     }
 
     /// Underlying hops.
@@ -288,7 +288,7 @@ impl OutboundProxyClient {
     pub fn contains_shadowsocks_hop(&self) -> bool {
         self.hops
             .iter()
-            .any(|hop| matches!(hop.kind, OutboundProxyKind::Ss { .. }))
+            .any(|hop| matches!(hop.kind, OutboundProxyKind::Shadowsocks { .. }))
     }
 
     /// Establish a multi-hop UDP relay through the chain.
@@ -314,7 +314,7 @@ impl OutboundProxyClient {
 fn hop_from_config(idx: usize, proxy: &OutboundProxy) -> io::Result<OutboundProxyHop> {
     match proxy {
         OutboundProxy::Plain(proxy) => plain_hop(proxy),
-        OutboundProxy::Ss(hop) => {
+        OutboundProxy::Shadowsocks(hop) => {
             let mut svr_cfg = hop.svr_cfg.clone();
             let plugin = match svr_cfg.plugin().cloned() {
                 Some(plugin_cfg) => {
@@ -334,7 +334,7 @@ fn hop_from_config(idx: usize, proxy: &OutboundProxy) -> io::Result<OutboundProx
 
             Ok(OutboundProxyHop {
                 addr: svr_cfg.tcp_external_addr().into(),
-                kind: OutboundProxyKind::Ss {
+                kind: OutboundProxyKind::Shadowsocks {
                     svr_cfg: Arc::new(svr_cfg),
                     plugin,
                 },
@@ -363,7 +363,7 @@ fn plain_hop(proxy: &PlainProxy) -> io::Result<OutboundProxyHop> {
             auth: http_auth_from_config(proxy),
             sni: proxy.host.clone(),
         },
-        OutboundProxyProtocol::Ss => {
+        OutboundProxyProtocol::Shadowsocks => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "plain outbound proxy cannot use the ss scheme",

--- a/crates/shadowsocks-service/src/net/outbound/stream.rs
+++ b/crates/shadowsocks-service/src/net/outbound/stream.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use pin_project::pin_project;
-use shadowsocks::net::TcpStream;
+use shadowsocks::{net::TcpStream, relay::tcprelay::ProxyClientStream};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 #[cfg(feature = "local-http")]
@@ -52,6 +52,9 @@ enum OutboundProxyStreamInner {
     /// Tunnel obtained from a successful HTTP CONNECT upgrade.
     #[cfg(feature = "local-http")]
     Http(#[pin] HttpConnectTunnel),
+
+    /// Shadowsocks encryption layered on an inner outbound stream.
+    Ss(#[pin] Box<ProxyClientStream<OutboundProxyStream>>),
 }
 
 impl OutboundProxyStream {
@@ -118,6 +121,14 @@ impl OutboundProxyStream {
         }
     }
 
+    /// Wrap an established transport with a Shadowsocks client stream.
+    pub(super) fn from_ss(local_addr: SocketAddr, stream: ProxyClientStream<OutboundProxyStream>) -> Self {
+        Self {
+            local_addr,
+            inner: OutboundProxyStreamInner::Ss(Box::new(stream)),
+        }
+    }
+
     /// Project the pinned `inner` enum.
     fn project_inner(self: Pin<&mut Self>) -> OutboundProxyStreamInnerProj<'_> {
         // SAFETY: `local_addr` is `Copy` and not pin-projected; only `inner`
@@ -146,6 +157,7 @@ impl AsyncRead for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_read(cx, buf),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_read(cx, buf),
+            OutboundProxyStreamInnerProj::Ss(s) => s.poll_read(cx, buf),
         }
     }
 }
@@ -158,6 +170,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_write(cx, buf),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_write(cx, buf),
+            OutboundProxyStreamInnerProj::Ss(s) => s.poll_write(cx, buf),
         }
     }
 
@@ -168,6 +181,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_flush(cx),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_flush(cx),
+            OutboundProxyStreamInnerProj::Ss(s) => s.poll_flush(cx),
         }
     }
 
@@ -178,6 +192,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_shutdown(cx),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_shutdown(cx),
+            OutboundProxyStreamInnerProj::Ss(s) => s.poll_shutdown(cx),
         }
     }
 
@@ -192,6 +207,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_write_vectored(cx, bufs),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_write_vectored(cx, bufs),
+            OutboundProxyStreamInnerProj::Ss(s) => s.poll_write_vectored(cx, bufs),
         }
     }
 
@@ -203,6 +219,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInner::Https(_) => false,
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInner::Http(_) => false,
+            OutboundProxyStreamInner::Ss(s) => s.is_write_vectored(),
         }
     }
 }

--- a/crates/shadowsocks-service/src/net/outbound/stream.rs
+++ b/crates/shadowsocks-service/src/net/outbound/stream.rs
@@ -54,7 +54,7 @@ enum OutboundProxyStreamInner {
     Http(#[pin] HttpConnectTunnel),
 
     /// Shadowsocks encryption layered on an inner outbound stream.
-    Ss(#[pin] Box<ProxyClientStream<OutboundProxyStream>>),
+    Shadowsocks(#[pin] Box<ProxyClientStream<OutboundProxyStream>>),
 }
 
 impl OutboundProxyStream {
@@ -98,7 +98,7 @@ impl OutboundProxyStream {
             OutboundProxyStreamInner::Https(_) => Err(self),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInner::Http(_) => Err(self),
-            OutboundProxyStreamInner::Ss(_) => Err(self),
+            OutboundProxyStreamInner::Shadowsocks(_) => Err(self),
         }
     }
 
@@ -123,10 +123,10 @@ impl OutboundProxyStream {
     }
 
     /// Wrap an established transport with a Shadowsocks client stream.
-    pub(super) fn from_ss(local_addr: SocketAddr, stream: ProxyClientStream<OutboundProxyStream>) -> Self {
+    pub(super) fn from_shadowsocks(local_addr: SocketAddr, stream: ProxyClientStream<OutboundProxyStream>) -> Self {
         Self {
             local_addr,
-            inner: OutboundProxyStreamInner::Ss(Box::new(stream)),
+            inner: OutboundProxyStreamInner::Shadowsocks(Box::new(stream)),
         }
     }
 
@@ -158,7 +158,7 @@ impl AsyncRead for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_read(cx, buf),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_read(cx, buf),
-            OutboundProxyStreamInnerProj::Ss(s) => s.poll_read(cx, buf),
+            OutboundProxyStreamInnerProj::Shadowsocks(s) => s.poll_read(cx, buf),
         }
     }
 }
@@ -171,7 +171,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_write(cx, buf),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_write(cx, buf),
-            OutboundProxyStreamInnerProj::Ss(s) => s.poll_write(cx, buf),
+            OutboundProxyStreamInnerProj::Shadowsocks(s) => s.poll_write(cx, buf),
         }
     }
 
@@ -182,7 +182,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_flush(cx),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_flush(cx),
-            OutboundProxyStreamInnerProj::Ss(s) => s.poll_flush(cx),
+            OutboundProxyStreamInnerProj::Shadowsocks(s) => s.poll_flush(cx),
         }
     }
 
@@ -193,7 +193,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_shutdown(cx),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_shutdown(cx),
-            OutboundProxyStreamInnerProj::Ss(s) => s.poll_shutdown(cx),
+            OutboundProxyStreamInnerProj::Shadowsocks(s) => s.poll_shutdown(cx),
         }
     }
 
@@ -208,7 +208,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInnerProj::Https(s) => s.poll_write_vectored(cx, bufs),
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInnerProj::Http(s) => s.poll_write_vectored(cx, bufs),
-            OutboundProxyStreamInnerProj::Ss(s) => s.poll_write_vectored(cx, bufs),
+            OutboundProxyStreamInnerProj::Shadowsocks(s) => s.poll_write_vectored(cx, bufs),
         }
     }
 
@@ -220,7 +220,7 @@ impl AsyncWrite for OutboundProxyStream {
             OutboundProxyStreamInner::Https(_) => false,
             #[cfg(feature = "local-http")]
             OutboundProxyStreamInner::Http(_) => false,
-            OutboundProxyStreamInner::Ss(s) => s.is_write_vectored(),
+            OutboundProxyStreamInner::Shadowsocks(s) => s.is_write_vectored(),
         }
     }
 }

--- a/crates/shadowsocks-service/src/net/outbound/udp.rs
+++ b/crates/shadowsocks-service/src/net/outbound/udp.rs
@@ -33,8 +33,7 @@ use shadowsocks::{
 use tokio::io::ReadBuf;
 
 use super::{
-    OutboundProxyClient, OutboundProxyKind, TcpDialer, chain::connect_chain_for_udp_associate,
-    socks5::Socks5Negotiator,
+    OutboundProxyClient, OutboundProxyKind, TcpDialer, chain::connect_chain_for_udp_associate, socks5::Socks5Negotiator,
 };
 
 /// One SOCKS5 UDP relay hop. The `assoc_tcp` keep-alive connection must
@@ -107,6 +106,12 @@ impl OutboundProxyDatagram {
             ));
         }
         for hop in hops {
+            if matches!(hop.kind, OutboundProxyKind::Ss { .. }) {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "outbound UDP relay is unavailable because the chain contains an ss hop",
+                ));
+            }
             if !matches!(hop.kind, OutboundProxyKind::Socks5 { .. }) {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
@@ -133,7 +138,7 @@ impl OutboundProxyDatagram {
         for (idx, hop) in hops.iter().enumerate() {
             // Build a TCP control connection that *terminates* at `hop`
             // (i.e. previous hops are traversed via SOCKS5 TcpConnect).
-            let mut tcp = connect_chain_for_udp_associate(hops, idx, dialer).await?;
+            let mut tcp = connect_chain_for_udp_associate(hops, idx, context, dialer).await?;
 
             let auth = match &hop.kind {
                 OutboundProxyKind::Socks5 { auth } => auth,
@@ -149,9 +154,7 @@ impl OutboundProxyDatagram {
             // applied). Recover the underlying TcpStream so the relay
             // struct stays `Sync`.
             let tcp = tcp.try_into_tcp().map_err(|_| {
-                io::Error::other(
-                    "internal error: outbound UDP relay produced a non-TCP keep-alive stream",
-                )
+                io::Error::other("internal error: outbound UDP relay produced a non-TCP keep-alive stream")
             })?;
 
             let relay_addr = resp.address;
@@ -161,9 +164,7 @@ impl OutboundProxyDatagram {
                     // Resolve domain-name relay addresses via the
                     // shadowsocks shared resolver — matches what a direct
                     // ProxySocket::connect_with_opts does.
-                    let (sa, _) = lookup_then!(context, name, port, |sa| {
-                        Ok::<SocketAddr, io::Error>(sa)
-                    })?;
+                    let (sa, _) = lookup_then!(context, name, port, |sa| { Ok::<SocketAddr, io::Error>(sa) })?;
                     Some(sa)
                 }
             };

--- a/crates/shadowsocks-service/src/net/outbound/udp.rs
+++ b/crates/shadowsocks-service/src/net/outbound/udp.rs
@@ -106,7 +106,7 @@ impl OutboundProxyDatagram {
             ));
         }
         for hop in hops {
-            if matches!(hop.kind, OutboundProxyKind::Ss { .. }) {
+            if matches!(hop.kind, OutboundProxyKind::Shadowsocks { .. }) {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
                     "outbound UDP relay is unavailable because the chain contains an ss hop",

--- a/crates/shadowsocks-service/src/server/context.rs
+++ b/crates/shadowsocks-service/src/server/context.rs
@@ -1,6 +1,6 @@
 //! Shadowsocks Local Server Context
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{io, net::SocketAddr, sync::Arc};
 
 use shadowsocks::{
     config::ServerType,
@@ -72,12 +72,13 @@ impl ServiceContext {
     }
 
     /// Set outbound proxy chain
-    pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) {
+    pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) -> io::Result<()> {
         self.outbound_client = if proxies.is_empty() {
             None
         } else {
-            Some(Arc::new(OutboundProxyClient::from_config(&proxies)))
+            Some(Arc::new(OutboundProxyClient::try_from_config(&proxies)?))
         };
+        Ok(())
     }
 
     /// Get the outbound proxy client (if a chain is configured).

--- a/crates/shadowsocks-service/src/server/mod.rs
+++ b/crates/shadowsocks-service/src/server/mod.rs
@@ -111,6 +111,7 @@ pub async fn run(config: Config) -> io::Result<()> {
     for inst in config.server {
         let svr_cfg = inst.config;
         let svr_enable_udp = svr_cfg.mode().enable_udp();
+        let svr_addr = svr_cfg.addr().clone();
         let mut server_builder = ServerBuilder::new(svr_cfg);
 
         if let Some(ref r) = resolver {
@@ -150,20 +151,25 @@ pub async fn run(config: Config) -> io::Result<()> {
                 config.outbound_proxy.clone()
             };
 
-            // Warn (once per server instance) when UDP is enabled but the
-            // chain cannot relay UDP — UDP traffic will then bypass the
-            // chain and connect to the upstream directly.
-            if svr_enable_udp {
-                let preview = crate::net::OutboundProxyClient::from_config(&proxies);
-                if !preview.supports_udp() {
+            for proxy in &proxies {
+                if proxy.shadowsocks_server_addr() == Some(&svr_addr) {
                     log::warn!(
-                        "outbound proxy chain contains non-SOCKS5 hop(s); UDP traffic will bypass the chain. \
-                         Configure a SOCKS5-only chain to enable UDP relay."
+                        "ss outbound proxy hop {} is also the main server; verify that the chain is not recursive",
+                        svr_addr
                     );
                 }
             }
 
-            server_builder.set_outbound_proxies(proxies);
+            if svr_enable_udp && crate::net::OutboundProxyClient::config_contains_shadowsocks_hop(&proxies) {
+                log::warn!("UDP traffic will be rejected because the outbound proxy chain contains an ss hop");
+            } else if svr_enable_udp && !crate::net::OutboundProxyClient::config_supports_udp(&proxies) {
+                log::warn!(
+                    "outbound proxy chain contains non-SOCKS5 hop(s); UDP traffic will bypass the chain. \
+                     Configure a SOCKS5-only chain to enable UDP relay."
+                );
+            }
+
+            server_builder.set_outbound_proxies(proxies)?;
         }
 
         server_builder.set_connect_opts(connect_opts);

--- a/crates/shadowsocks-service/src/server/server.rs
+++ b/crates/shadowsocks-service/src/server/server.rs
@@ -111,8 +111,8 @@ impl ServerBuilder {
     }
 
     /// Set outbound SOCKS5 proxy chain
-    pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) {
-        self.context.set_outbound_proxies(proxies);
+    pub fn set_outbound_proxies(&mut self, proxies: Vec<OutboundProxy>) -> io::Result<()> {
+        self.context.set_outbound_proxies(proxies)
     }
 
     /// Start the server

--- a/crates/shadowsocks-service/src/server/tcprelay.rs
+++ b/crates/shadowsocks-service/src/server/tcprelay.rs
@@ -15,7 +15,10 @@ use shadowsocks::{
     ProxyListener, ServerConfig,
     crypto::CipherKind,
     net::{AcceptOpts, TcpStream as OutboundTcpStream},
-    relay::{socks5::Address, tcprelay::{ProxyServerStream, utils::copy_encrypted_bidirectional}},
+    relay::{
+        socks5::Address,
+        tcprelay::{ProxyServerStream, utils::copy_encrypted_bidirectional},
+    },
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf},
@@ -270,7 +273,7 @@ impl TcpServerClient {
                         context: self.context.as_ref(),
                     };
                     client
-                        .connect_tcp(&dialer, &target_addr)
+                        .connect_tcp(self.context.context(), &dialer, &target_addr)
                         .await
                         .map(RemoteStream::Proxied)
                 }

--- a/crates/shadowsocks-service/src/server/udprelay.rs
+++ b/crates/shadowsocks-service/src/server/udprelay.rs
@@ -650,6 +650,17 @@ impl UdpAssociationContext {
     }
 
     async fn dispatch_received_outbound_packet(&mut self, target_addr: &Address, data: &[u8]) -> io::Result<()> {
+        if self
+            .context
+            .outbound_client()
+            .is_some_and(|client| client.contains_shadowsocks_hop())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "UDP traffic is rejected because the outbound proxy chain contains an ss hop",
+            ));
+        }
+
         match *target_addr {
             Address::SocketAddress(sa) => self.send_received_outbound_packet(sa, data).await,
             Address::DomainNameAddress(ref dname, port) => {

--- a/crates/shadowsocks-service/tests/outbound_ss.rs
+++ b/crates/shadowsocks-service/tests/outbound_ss.rs
@@ -1,0 +1,366 @@
+#![cfg(feature = "aead-cipher")]
+
+use std::{io, net::SocketAddr, sync::Arc, time::Duration};
+
+use shadowsocks_service::{
+    config::{OutboundProxy, ShadowsocksHop},
+    net::{OutboundProxyClient, TcpDialer},
+    shadowsocks::{
+        ProxyListener,
+        config::{Mode, ServerConfig, ServerType},
+        context::{Context, SharedContext},
+        crypto::CipherKind,
+        net::{ConnectOpts, TcpStream as ShadowTcpStream},
+        plugin::PluginConfig,
+        relay::socks5::Address,
+    },
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+
+struct DirectDialer {
+    context: SharedContext,
+}
+
+impl TcpDialer for DirectDialer {
+    async fn dial(&self, addr: &Address) -> io::Result<ShadowTcpStream> {
+        ShadowTcpStream::connect_remote_with_opts(&self.context, addr, &ConnectOpts::default()).await
+    }
+}
+
+async fn make_ss_listener(password: &str) -> (ProxyListener, ServerConfig) {
+    let bind_config = ServerConfig::new(
+        "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        password,
+        CipherKind::AES_128_GCM,
+    )
+    .unwrap();
+    let listener = ProxyListener::bind(Context::new_shared(ServerType::Server), &bind_config)
+        .await
+        .unwrap();
+    let client_config = ServerConfig::new(listener.local_addr().unwrap(), password, CipherKind::AES_128_GCM).unwrap();
+    (listener, client_config)
+}
+
+fn spawn_ss_relay(listener: ProxyListener) {
+    tokio::spawn(async move {
+        while let Ok((mut inbound, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let Ok(target) = inbound.handshake().await else {
+                    return;
+                };
+                let mut outbound = match target {
+                    Address::SocketAddress(addr) => TcpStream::connect(addr).await.unwrap(),
+                    Address::DomainNameAddress(host, port) => TcpStream::connect((host, port)).await.unwrap(),
+                };
+                tokio::io::copy_bidirectional(&mut inbound, &mut outbound)
+                    .await
+                    .unwrap();
+            });
+        }
+    });
+}
+
+#[tokio::test]
+async fn tcp_echo_through_two_shadowsocks_outbound_hops() {
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = echo_listener.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            stream.write_all(&buf[..n]).await.unwrap();
+        }
+    });
+
+    let (first_listener, first_config) = make_ss_listener("first-hop-password").await;
+    let (second_listener, second_config) = make_ss_listener("second-hop-password").await;
+    spawn_ss_relay(first_listener);
+    spawn_ss_relay(second_listener);
+
+    let proxies = [first_config, second_config]
+        .into_iter()
+        .map(|config| OutboundProxy::from_url(&config.to_url()).unwrap())
+        .collect::<Vec<_>>();
+    let client = OutboundProxyClient::try_from_config(&proxies).unwrap();
+    assert!(!client.supports_udp());
+
+    let context = Context::new_shared(ServerType::Local);
+    let dialer = DirectDialer {
+        context: context.clone(),
+    };
+    let mut stream = client
+        .connect_tcp(context, &dialer, &Address::from(echo_addr))
+        .await
+        .unwrap();
+
+    const MESSAGE: &[u8] = b"two encrypted outbound hops";
+    stream.write_all(MESSAGE).await.unwrap();
+    let mut echoed = vec![0u8; MESSAGE.len()];
+    stream.read_exact(&mut echoed).await.unwrap();
+    assert_eq!(echoed, MESSAGE);
+}
+
+#[tokio::test]
+async fn tcp_echo_through_first_shadowsocks_hop_plugin() {
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = echo_listener.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            stream.write_all(&buf[..n]).await.unwrap();
+        }
+    });
+
+    let (listener, mut config) = make_ss_listener("plugin-hop-password").await;
+    spawn_ss_relay(listener);
+    config.set_plugin(PluginConfig {
+        plugin: std::env::current_exe().unwrap().to_string_lossy().into_owned(),
+        plugin_opts: Some("mock-options".to_owned()),
+        plugin_args: vec![
+            "--ignored".to_owned(),
+            "--exact".to_owned(),
+            "mock_sip003_plugin_process".to_owned(),
+            "--nocapture".to_owned(),
+        ],
+        plugin_mode: Mode::TcpOnly,
+    });
+
+    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+        svr_cfg: config,
+        tag: Some("mock-plugin".to_owned()),
+    }))])
+    .unwrap();
+    let context = Context::new_shared(ServerType::Local);
+    let dialer = DirectDialer {
+        context: context.clone(),
+    };
+    let mut stream = client
+        .connect_tcp(context, &dialer, &Address::from(echo_addr))
+        .await
+        .unwrap();
+
+    const MESSAGE: &[u8] = b"first hop plugin";
+    stream.write_all(MESSAGE).await.unwrap();
+    let mut echoed = vec![0u8; MESSAGE.len()];
+    stream.read_exact(&mut echoed).await.unwrap();
+    assert_eq!(echoed, MESSAGE);
+}
+
+#[tokio::test]
+async fn first_hop_plugin_start_failure_is_throttled_and_retried() {
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = echo_listener.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            stream.write_all(&buf[..n]).await.unwrap();
+        }
+    });
+
+    let (listener, mut config) = make_ss_listener("late-plugin-password").await;
+    spawn_ss_relay(listener);
+    config.set_plugin(PluginConfig {
+        plugin: std::env::current_exe().unwrap().to_string_lossy().into_owned(),
+        plugin_opts: Some("mock-options".to_owned()),
+        plugin_args: vec![
+            "--ignored".to_owned(),
+            "--exact".to_owned(),
+            "mock_sip003_plugin_starts_late".to_owned(),
+            "--nocapture".to_owned(),
+        ],
+        plugin_mode: Mode::TcpOnly,
+    });
+
+    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+        svr_cfg: config,
+        tag: Some("mock-plugin-failure".to_owned()),
+    }))])
+    .unwrap();
+    assert!(client.contains_shadowsocks_hop());
+    let context = Context::new_shared(ServerType::Local);
+    let dialer = DirectDialer {
+        context: context.clone(),
+    };
+    let target = Address::from(echo_addr);
+
+    let first = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.connect_tcp(context.clone(), &dialer, &target),
+    )
+    .await
+    .expect("initial plugin readiness check exceeded its timeout");
+    let first_error = match first {
+        Ok(_) => panic!("plugin unexpectedly accepted a connection before its delayed start"),
+        Err(err) => err,
+    };
+    assert_eq!(first_error.kind(), io::ErrorKind::TimedOut);
+
+    let second = tokio::time::timeout(
+        Duration::from_millis(500),
+        client.connect_tcp(context.clone(), &dialer, &target),
+    )
+    .await
+    .expect("throttled plugin startup failure did not fail fast");
+    let second_error = match second {
+        Ok(_) => panic!("plugin unexpectedly accepted a connection before its delayed start"),
+        Err(err) => err,
+    };
+    assert_eq!(second_error.kind(), io::ErrorKind::TimedOut);
+    assert_eq!(second_error.to_string(), first_error.to_string());
+
+    tokio::time::sleep(Duration::from_millis(1_200)).await;
+    let mut stream = tokio::time::timeout(Duration::from_secs(2), client.connect_tcp(context, &dialer, &target))
+        .await
+        .expect("plugin readiness retry timed out")
+        .expect("late-starting plugin did not recover");
+
+    const MESSAGE: &[u8] = b"late plugin recovery";
+    stream.write_all(MESSAGE).await.unwrap();
+    let mut echoed = vec![0u8; MESSAGE.len()];
+    stream.read_exact(&mut echoed).await.unwrap();
+    assert_eq!(echoed, MESSAGE);
+}
+
+#[test]
+fn plugin_on_non_first_shadowsocks_hop_is_rejected() {
+    let first = ServerConfig::new(
+        "127.0.0.1:10001".parse::<SocketAddr>().unwrap(),
+        "first",
+        CipherKind::AES_128_GCM,
+    )
+    .unwrap();
+    let mut second = ServerConfig::new(
+        "127.0.0.1:10002".parse::<SocketAddr>().unwrap(),
+        "second",
+        CipherKind::AES_128_GCM,
+    )
+    .unwrap();
+    second.set_plugin(PluginConfig {
+        plugin: "mock-plugin".to_owned(),
+        plugin_opts: None,
+        plugin_args: Vec::new(),
+        plugin_mode: Mode::TcpOnly,
+    });
+
+    let proxies = vec![
+        OutboundProxy::Ss(Box::new(ShadowsocksHop {
+            svr_cfg: first,
+            tag: None,
+        })),
+        OutboundProxy::Ss(Box::new(ShadowsocksHop {
+            svr_cfg: second,
+            tag: None,
+        })),
+    ];
+    let err = OutboundProxyClient::try_from_config(&proxies).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert!(err.to_string().contains("non-first ss outbound proxy hop"));
+}
+
+#[tokio::test]
+async fn udp_rejects_chain_containing_shadowsocks_hop() {
+    let config = ServerConfig::new(
+        "127.0.0.1:10003".parse::<SocketAddr>().unwrap(),
+        "udp",
+        CipherKind::AES_128_GCM,
+    )
+    .unwrap();
+    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+        svr_cfg: config,
+        tag: None,
+    }))])
+    .unwrap();
+    let context = Context::new_shared(ServerType::Local);
+    let dialer = DirectDialer {
+        context: context.clone(),
+    };
+
+    let result = client
+        .associate_udp(
+            &context,
+            &dialer,
+            &ConnectOpts::default(),
+            Address::from("127.0.0.1:53".parse::<std::net::SocketAddr>().unwrap()),
+        )
+        .await;
+    let err = match result {
+        Err(err) => err,
+        Ok(..) => panic!("ss outbound hop unexpectedly supported UDP"),
+    };
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert!(err.to_string().contains("chain contains an ss hop"));
+}
+
+// Keep `Arc` referenced so this integration test also verifies `OutboundProxyClient`
+// remains shareable in the service contexts that cache it.
+#[test]
+fn outbound_client_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Arc<OutboundProxyClient>>();
+}
+
+fn run_mock_sip003_plugin(start_delay: Duration) {
+    use std::{
+        env,
+        io::copy,
+        net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream},
+        thread,
+    };
+
+    thread::sleep(start_delay);
+
+    let local_host = env::var("SS_LOCAL_HOST").unwrap();
+    let local_port = env::var("SS_LOCAL_PORT").unwrap();
+    let remote_host = env::var("SS_REMOTE_HOST").unwrap();
+    let remote_port = env::var("SS_REMOTE_PORT").unwrap();
+    assert_eq!(env::var("SS_PLUGIN_OPTIONS").as_deref(), Ok("mock-options"));
+
+    let listener = StdTcpListener::bind(format!("{local_host}:{local_port}")).unwrap();
+    for local in listener.incoming() {
+        let local = local.unwrap();
+        let remote = StdTcpStream::connect(format!("{remote_host}:{remote_port}")).unwrap();
+        thread::spawn(move || {
+            let mut local_reader = local.try_clone().unwrap();
+            let mut remote_writer = remote.try_clone().unwrap();
+            let forward = thread::spawn(move || copy(&mut local_reader, &mut remote_writer));
+
+            let mut remote_reader = remote;
+            let mut local_writer = local;
+            let _ = copy(&mut remote_reader, &mut local_writer);
+            let _ = forward.join();
+        });
+    }
+}
+
+/// Re-entered by `tcp_echo_through_first_shadowsocks_hop_plugin` as a SIP003
+/// subprocess. Keeping it ignored prevents the normal test runner from blocking.
+#[test]
+#[ignore]
+fn mock_sip003_plugin_process() {
+    run_mock_sip003_plugin(Duration::ZERO);
+}
+
+/// Re-entered by `first_hop_plugin_start_failure_is_throttled_and_retried`
+/// to emulate a plugin that starts shortly after the initial readiness timeout.
+#[test]
+#[ignore]
+fn mock_sip003_plugin_starts_late() {
+    run_mock_sip003_plugin(Duration::from_millis(3_250));
+}

--- a/crates/shadowsocks-service/tests/outbound_ss.rs
+++ b/crates/shadowsocks-service/tests/outbound_ss.rs
@@ -18,6 +18,7 @@ use shadowsocks_service::{
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
+    sync::mpsc,
 };
 
 struct DirectDialer {
@@ -61,6 +62,71 @@ fn spawn_ss_relay(listener: ProxyListener) {
             });
         }
     });
+}
+
+fn spawn_ss_relay_reporting_targets(listener: ProxyListener, targets: mpsc::UnboundedSender<Address>) {
+    tokio::spawn(async move {
+        while let Ok((mut inbound, _)) = listener.accept().await {
+            let targets = targets.clone();
+            tokio::spawn(async move {
+                let Ok(target) = inbound.handshake().await else {
+                    return;
+                };
+                let _ = targets.send(target.clone());
+                let mut outbound = match target {
+                    Address::SocketAddress(addr) => TcpStream::connect(addr).await.unwrap(),
+                    Address::DomainNameAddress(host, port) => TcpStream::connect((host, port)).await.unwrap(),
+                };
+                tokio::io::copy_bidirectional(&mut inbound, &mut outbound)
+                    .await
+                    .unwrap();
+            });
+        }
+    });
+}
+
+#[tokio::test]
+async fn sslocal_main_server_is_first_hop_and_outbound_proxy_is_landing() {
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = echo_listener.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            stream.write_all(&buf[..n]).await.unwrap();
+        }
+    });
+
+    let (main_listener, main_config) = make_ss_listener("main-first-hop-password").await;
+    let (landing_listener, landing_config) = make_ss_listener("landing-password").await;
+    let landing_addr = landing_listener.local_addr().unwrap();
+    let (main_targets_tx, mut main_targets_rx) = mpsc::unbounded_channel();
+    let (landing_targets_tx, mut landing_targets_rx) = mpsc::unbounded_channel();
+    spawn_ss_relay_reporting_targets(main_listener, main_targets_tx);
+    spawn_ss_relay_reporting_targets(landing_listener, landing_targets_tx);
+
+    let landing_proxy = OutboundProxy::from_url(&landing_config.to_url()).unwrap();
+    let client = OutboundProxyClient::try_from_config_after_main_server(&[landing_proxy]).unwrap();
+    let context = Context::new_shared(ServerType::Local);
+    let dialer = DirectDialer {
+        context: context.clone(),
+    };
+    let mut stream = client
+        .connect_tcp_with_initial_shadowsocks(context, &dialer, &main_config, &Address::from(echo_addr))
+        .await
+        .unwrap();
+
+    const MESSAGE: &[u8] = b"main first, outbound landing";
+    stream.write_all(MESSAGE).await.unwrap();
+    assert_eq!(main_targets_rx.recv().await, Some(Address::from(landing_addr)));
+    assert_eq!(landing_targets_rx.recv().await, Some(Address::from(echo_addr)));
+    let mut echoed = vec![0u8; MESSAGE.len()];
+    stream.read_exact(&mut echoed).await.unwrap();
+    assert_eq!(echoed, MESSAGE);
 }
 
 #[tokio::test]
@@ -270,6 +336,30 @@ fn plugin_on_non_first_shadowsocks_hop_is_rejected() {
         })),
     ];
     let err = OutboundProxyClient::try_from_config(&proxies).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert!(err.to_string().contains("non-first ss outbound proxy hop"));
+}
+
+#[test]
+fn sslocal_outbound_proxy_plugin_is_rejected_as_non_first_hop() {
+    let mut landing = ServerConfig::new(
+        "127.0.0.1:10004".parse::<SocketAddr>().unwrap(),
+        "landing",
+        CipherKind::AES_128_GCM,
+    )
+    .unwrap();
+    landing.set_plugin(PluginConfig {
+        plugin: "mock-plugin".to_owned(),
+        plugin_opts: None,
+        plugin_args: Vec::new(),
+        plugin_mode: Mode::TcpOnly,
+    });
+
+    let err = OutboundProxyClient::try_from_config_after_main_server(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+        svr_cfg: landing,
+        tag: None,
+    }))])
+    .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     assert!(err.to_string().contains("non-first ss outbound proxy hop"));
 }

--- a/crates/shadowsocks-service/tests/outbound_ss.rs
+++ b/crates/shadowsocks-service/tests/outbound_ss.rs
@@ -203,7 +203,7 @@ async fn tcp_echo_through_first_shadowsocks_hop_plugin() {
         plugin_mode: Mode::TcpOnly,
     });
 
-    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Shadowsocks(Box::new(ShadowsocksHop {
         svr_cfg: config,
         tag: Some("mock-plugin".to_owned()),
     }))])
@@ -254,7 +254,7 @@ async fn first_hop_plugin_start_failure_is_throttled_and_retried() {
         plugin_mode: Mode::TcpOnly,
     });
 
-    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Shadowsocks(Box::new(ShadowsocksHop {
         svr_cfg: config,
         tag: Some("mock-plugin-failure".to_owned()),
     }))])
@@ -326,11 +326,11 @@ fn plugin_on_non_first_shadowsocks_hop_is_rejected() {
     });
 
     let proxies = vec![
-        OutboundProxy::Ss(Box::new(ShadowsocksHop {
+        OutboundProxy::Shadowsocks(Box::new(ShadowsocksHop {
             svr_cfg: first,
             tag: None,
         })),
-        OutboundProxy::Ss(Box::new(ShadowsocksHop {
+        OutboundProxy::Shadowsocks(Box::new(ShadowsocksHop {
             svr_cfg: second,
             tag: None,
         })),
@@ -355,7 +355,7 @@ fn sslocal_outbound_proxy_plugin_is_rejected_as_non_first_hop() {
         plugin_mode: Mode::TcpOnly,
     });
 
-    let err = OutboundProxyClient::try_from_config_after_main_server(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+    let err = OutboundProxyClient::try_from_config_after_main_server(&[OutboundProxy::Shadowsocks(Box::new(ShadowsocksHop {
         svr_cfg: landing,
         tag: None,
     }))])
@@ -372,7 +372,7 @@ async fn udp_rejects_chain_containing_shadowsocks_hop() {
         CipherKind::AES_128_GCM,
     )
     .unwrap();
-    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Ss(Box::new(ShadowsocksHop {
+    let client = OutboundProxyClient::try_from_config(&[OutboundProxy::Shadowsocks(Box::new(ShadowsocksHop {
         svr_cfg: config,
         tag: None,
     }))])

--- a/examples/chain-ss.json5
+++ b/examples/chain-ss.json5
@@ -1,0 +1,18 @@
+{
+    // The normal sslocal upstream is the landing server. Its address is sent
+    // through the encrypted edge hop below instead of dialled directly.
+    "server": "landing.example.com",
+    "server_port": 8388,
+    "method": "aes-256-gcm",
+    "password": "replace-with-landing-password",
+
+    "local_address": "127.0.0.1",
+    "local_port": 1080,
+    "mode": "tcp_only",
+
+    // SIP002 URL for the edge hop. Only the first ss:// hop may have a SIP003
+    // plugin. ss:// outbound hops are TCP-only, so keep this example in TCP mode.
+    "outbound_proxy": [
+        "ss://YWVzLTEyOC1nY206ZWRnZS1wYXNzd29yZA@edge.example.com:443/?plugin=obfs-local%3Bobfs%3Dhttp%3Bobfs-host%3Dcdn.example.com"
+    ]
+}

--- a/examples/chain-ss.json5
+++ b/examples/chain-ss.json5
@@ -1,18 +1,20 @@
 {
-    // The normal sslocal upstream is the landing server. Its address is sent
-    // through the encrypted edge hop below instead of dialled directly.
-    "server": "landing.example.com",
-    "server_port": 8388,
-    "method": "aes-256-gcm",
-    "password": "replace-with-landing-password",
+    // sslocal's normal server is the physical first hop.
+    "server": "edge.example.com",
+    "server_port": 443,
+    "method": "aes-128-gcm",
+    "password": "edge-password",
+    "plugin": "obfs-local",
+    "plugin_opts": "obfs=http;obfs-host=cdn.example.com",
 
     "local_address": "127.0.0.1",
     "local_port": 1080,
     "mode": "tcp_only",
 
-    // SIP002 URL for the edge hop. Only the first ss:// hop may have a SIP003
-    // plugin. ss:// outbound hops are TCP-only, so keep this example in TCP mode.
+    // outbound_proxy entries follow the main server in array order. This SS
+    // hop is therefore the landing server and carries the final destination.
+    // Later hops cannot use SIP003 plugins, and sslocal chains are TCP-only.
     "outbound_proxy": [
-        "ss://YWVzLTEyOC1nY206ZWRnZS1wYXNzd29yZA@edge.example.com:443/?plugin=obfs-local%3Bobfs%3Dhttp%3Bobfs-host%3Dcdn.example.com"
+        "ss://YWVzLTI1Ni1nY206bGFuZGluZy1wYXNzd29yZA@landing.example.com:8388#landing"
     ]
 }


### PR DESCRIPTION
## Summary

This PR adds TCP-only Shadowsocks (`ss://`) hops to the existing `outbound_proxy` chain used by `sslocal` and `ssserver`.

It allows an outbound connection to traverse an encrypted Shadowsocks edge hop before reaching the normal Shadowsocks server or another supported proxy hop. Existing SOCKS5, HTTP, and HTTPS outbound-proxy configurations continue to use the same configuration forms and connection paths.

## Motivation

The existing outbound chain can hide the final Shadowsocks server behind SOCKS5/HTTP CONNECT proxies, but it cannot use a Shadowsocks server itself as an encrypted intermediate hop. This is useful for deployments where:

- the first reachable edge must use Shadowsocks encryption or a SIP003 transport plugin;
- the final landing server should not be dialled directly from the client;
- the entire route should remain in one `sslocal` or `ssserver` process instead of requiring an additional local forwarding process.

## What changed

### Configuration and URL compatibility

- `OutboundProxy` is now an enum with separate plain-proxy and Shadowsocks-hop variants.
- SOCKS5, HTTP, and HTTPS retain their existing host, port, and optional authentication representation.
- SIP002 `ss://` URLs are parsed through `ServerConfig`, so cipher, password, remarks, and SIP003 plugin parameters use the existing Shadowsocks parser.
- `to_url()` supports round-tripping Shadowsocks hops.
- Debug output redacts Shadowsocks passwords.
- Existing single-string and string-array `outbound_proxy` configuration formats remain supported.
- A sanitized end-to-end example is provided in `examples/chain-ss.json5`.

### TCP chain composition

- `OutboundProxyKind` gains an `Ss` variant backed by an `Arc<ServerConfig>`.
- The chain builder receives the shared Shadowsocks context and wraps the already-established transport in `ProxyClientStream` for an `ss://` hop.
- `OutboundProxyStream` gains a boxed Shadowsocks variant. Boxing breaks the recursive stream type while preserving static async I/O dispatch.
- The same outbound client is used by both local and server TCP relay paths.
- SOCKS5, HTTP, HTTPS, and Shadowsocks layers can compose without changing the existing first-hop dialer abstraction.

### SIP003 plugin lifecycle

- A SIP003 plugin is supported on the first Shadowsocks outbound hop.
- The plugin is started once in client mode, and its loopback listener becomes the first physical address dialled by the chain.
- The plugin handle is retained by the outbound client, so the child process follows the client's lifetime and is terminated through the existing `Plugin` drop behavior.
- Plugin readiness probes are serialized to prevent concurrent connections from creating repeated three-second waits.
- A failed readiness probe is cached for one second and then retried. This avoids a retry storm while still allowing a slow-starting plugin to recover.
- Plugins on non-first Shadowsocks hops return `Unsupported`; supporting those requires per-connection rendezvous plumbing and is intentionally outside this PR.

### UDP behavior

Shadowsocks outbound hops are TCP-only in this PR.

- A chain containing an `ss://` hop reports that it does not support UDP.
- Direct `OutboundProxyDatagram` association returns `io::ErrorKind::Unsupported` with a specific diagnostic.
- Local and server UDP relay paths reject traffic when the configured chain contains a Shadowsocks hop.
- UDP therefore fails closed instead of silently bypassing the chain and exposing a destination or upstream address through a direct datagram path.
- The legacy behavior for other non-SOCKS5 hop types is unchanged.

### Diagnostics and documentation

- Startup warnings identify potentially recursive Shadowsocks-hop/server configurations.
- Startup warnings explain that UDP is rejected for chains containing a Shadowsocks hop.
- README configuration and CLI documentation now list `ss://`, first-hop plugin support, TCP-only behavior, and the new example.

## Compatibility and limitations

- Existing SOCKS5/HTTP/HTTPS outbound proxy URLs and JSON configuration remain compatible.
- No new dependencies are introduced.
- Shadowsocks outbound hops support TCP only.
- Only the first Shadowsocks hop may contain a SIP003 plugin.
- UDP chaining through Shadowsocks is not implemented; it requires a separate datagram design with per-hop encapsulation and NAT state.
- Static cycle detection is diagnostic only and cannot detect every DNS-based or dynamically resolved loop.

## Tests

The new integration suite covers:

- TCP echo through two encrypted Shadowsocks outbound hops;
- a real mock SIP003 child process on the first hop;
- throttled plugin-start failure followed by recovery after a delayed plugin start;
- rejection of a plugin on a non-first Shadowsocks hop;
- rejection of UDP association through a chain containing a Shadowsocks hop;
- `Send + Sync` compatibility of the cached outbound client;
- SIP002 URL round-tripping, plugin parameters, and example configuration parsing.

Local validation completed successfully:

- `cargo test -p shadowsocks-service --test outbound_ss --no-default-features --features aead-cipher -- --nocapture` (`6 passed`, `2 ignored` helper entry points)
- `cargo check --features full-extra`
- `cargo build --features full` on Windows with NASM 3.01
- `cargo clippy --features "full-extra local-flow-stat utility-url-outline" -- -A clippy::absurd_extreme_comparisons`
- `git diff --check`

GitHub Actions completed successfully on the pushed branch:

- Build & Test, including Linux, macOS, and Windows matrices
- Build MSRV
- Clippy Check
- Cargo Deny Check

## Security considerations

- Example credentials and endpoints are placeholders.
- Shadowsocks passwords are redacted from debug formatting.
- Unsupported UDP traffic fails closed for `ss://` chains instead of bypassing the configured route.
