### PR TITLE
fix: allow fragmentation for inbound UDP replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,8 @@ Example configuration:
             "outbound_bind_addr": "11.22.33.44",
             // Outbound UDP socket allows IP fragmentation (default false)
             "outbound_udp_allow_fragmentation": false,
+            // Inbound UDP socket allows IP fragmentation (default false)
+            "inbound_udp_allow_fragmentation": false,
             // Route outbound TCP connections through a proxy or proxy chain
             // (TCP only; UDP is not proxied)
             // Works for both sslocal and ssserver

--- a/crates/shadowsocks-service/src/config.rs
+++ b/crates/shadowsocks-service/src/config.rs
@@ -392,6 +392,9 @@ struct SSConfig {
     outbound_udp_allow_fragmentation: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    inbound_udp_allow_fragmentation: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     outbound_proxy: Option<SSOutboundProxyConfig>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -592,6 +595,9 @@ struct SSServerExtConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     outbound_udp_allow_fragmentation: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inbound_udp_allow_fragmentation: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     outbound_proxy: Option<SSOutboundProxyConfig>,
@@ -1447,6 +1453,7 @@ pub struct ServerInstanceConfig {
     pub outbound_bind_addr: Option<IpAddr>,
     pub outbound_bind_interface: Option<String>,
     pub outbound_udp_allow_fragmentation: Option<bool>,
+    pub inbound_udp_allow_fragmentation: Option<bool>,
     /// Outbound SOCKS5 proxy chain for this server instance (empty = no proxy)
     pub outbound_proxy: Vec<OutboundProxy>,
 }
@@ -1464,6 +1471,7 @@ impl ServerInstanceConfig {
             outbound_bind_addr: None,
             outbound_bind_interface: None,
             outbound_udp_allow_fragmentation: None,
+            inbound_udp_allow_fragmentation: None,
             outbound_proxy: Vec::new(),
         }
     }
@@ -1553,6 +1561,8 @@ pub struct Config {
     pub outbound_bind_addr: Option<IpAddr>,
     /// Outbound UDP sockets allow IP fragmentation
     pub outbound_udp_allow_fragmentation: bool,
+    /// Inbound UDP sockets allow IP fragmentation
+    pub inbound_udp_allow_fragmentation: bool,
     /// Path to protect callback unix address, only for Android
     #[cfg(target_os = "android")]
     pub outbound_vpn_protect_path: Option<PathBuf>,
@@ -1701,6 +1711,7 @@ impl Config {
             outbound_bind_interface: None,
             outbound_bind_addr: None,
             outbound_udp_allow_fragmentation: false,
+            inbound_udp_allow_fragmentation: false,
             #[cfg(target_os = "android")]
             outbound_vpn_protect_path: None,
             outbound_proxy: Vec::new(),
@@ -2420,6 +2431,10 @@ impl Config {
                     server_instance.outbound_udp_allow_fragmentation = Some(outbound_udp_allow_fragmentation);
                 }
 
+                if let Some(inbound_udp_allow_fragmentation) = svr.inbound_udp_allow_fragmentation {
+                    server_instance.inbound_udp_allow_fragmentation = Some(inbound_udp_allow_fragmentation);
+                }
+
                 if let Some(proxy_config) = svr.outbound_proxy {
                     server_instance.outbound_proxy = proxy_config
                         .into_proxies()
@@ -2593,6 +2608,10 @@ impl Config {
 
         if let Some(b) = config.outbound_udp_allow_fragmentation {
             nconfig.outbound_udp_allow_fragmentation = b;
+        }
+
+        if let Some(b) = config.inbound_udp_allow_fragmentation {
+            nconfig.inbound_udp_allow_fragmentation = b;
         }
 
         if let Some(proxy_config) = config.outbound_proxy {
@@ -3275,6 +3294,7 @@ impl fmt::Display for Config {
                         outbound_bind_addr: inst.outbound_bind_addr,
                         outbound_bind_interface: inst.outbound_bind_interface.clone(),
                         outbound_udp_allow_fragmentation: inst.outbound_udp_allow_fragmentation,
+                        inbound_udp_allow_fragmentation: inst.inbound_udp_allow_fragmentation,
                         outbound_proxy: SSOutboundProxyConfig::from_proxies(&inst.outbound_proxy),
                     });
                 }
@@ -3381,6 +3401,7 @@ impl fmt::Display for Config {
         jconf.outbound_bind_addr = self.outbound_bind_addr.map(|i| i.to_string());
         jconf.outbound_bind_interface.clone_from(&self.outbound_bind_interface);
         jconf.outbound_udp_allow_fragmentation = Some(self.outbound_udp_allow_fragmentation);
+        jconf.inbound_udp_allow_fragmentation = Some(self.inbound_udp_allow_fragmentation);
         if jconf.outbound_proxy.is_none() {
             jconf.outbound_proxy = SSOutboundProxyConfig::from_proxies(&self.outbound_proxy);
         }

--- a/crates/shadowsocks-service/src/local/mod.rs
+++ b/crates/shadowsocks-service/src/local/mod.rs
@@ -157,6 +157,7 @@ impl Server {
         accept_opts.tcp.keepalive = config.keep_alive.or(Some(LOCAL_DEFAULT_KEEPALIVE_TIMEOUT));
         accept_opts.tcp.mptcp = config.mptcp;
         accept_opts.udp.mtu = config.udp_mtu;
+        accept_opts.udp.allow_fragmentation = config.inbound_udp_allow_fragmentation;
         context.set_accept_opts(accept_opts);
 
         if let Some(resolver) = build_dns_resolver(

--- a/crates/shadowsocks-service/src/manager/mod.rs
+++ b/crates/shadowsocks-service/src/manager/mod.rs
@@ -68,6 +68,7 @@ pub async fn run(config: Config) -> io::Result<()> {
     accept_opts.tcp.keepalive = config.keep_alive.or(Some(SERVER_DEFAULT_KEEPALIVE_TIMEOUT));
     accept_opts.tcp.mptcp = config.mptcp;
     accept_opts.udp.mtu = config.udp_mtu;
+    accept_opts.udp.allow_fragmentation = config.outbound_udp_allow_fragmentation;
 
     if let Some(resolver) =
         build_dns_resolver(config.dns, config.ipv6_first, config.dns_cache_size, &connect_opts).await

--- a/crates/shadowsocks-service/src/manager/mod.rs
+++ b/crates/shadowsocks-service/src/manager/mod.rs
@@ -68,7 +68,7 @@ pub async fn run(config: Config) -> io::Result<()> {
     accept_opts.tcp.keepalive = config.keep_alive.or(Some(SERVER_DEFAULT_KEEPALIVE_TIMEOUT));
     accept_opts.tcp.mptcp = config.mptcp;
     accept_opts.udp.mtu = config.udp_mtu;
-    accept_opts.udp.allow_fragmentation = config.outbound_udp_allow_fragmentation;
+    accept_opts.udp.allow_fragmentation = config.inbound_udp_allow_fragmentation;
 
     if let Some(resolver) =
         build_dns_resolver(config.dns, config.ipv6_first, config.dns_cache_size, &connect_opts).await

--- a/crates/shadowsocks-service/src/manager/server.rs
+++ b/crates/shadowsocks-service/src/manager/server.rs
@@ -392,6 +392,7 @@ impl Manager {
             outbound_bind_addr: None,
             outbound_bind_interface: None,
             outbound_udp_allow_fragmentation: None,
+            inbound_udp_allow_fragmentation: None,
             outbound_proxy: Vec::new(),
         };
 

--- a/crates/shadowsocks-service/src/server/mod.rs
+++ b/crates/shadowsocks-service/src/server/mod.rs
@@ -100,7 +100,7 @@ pub async fn run(config: Config) -> io::Result<()> {
     accept_opts.tcp.fastopen = config.fast_open;
     accept_opts.tcp.keepalive = config.keep_alive.or(Some(SERVER_DEFAULT_KEEPALIVE_TIMEOUT));
     accept_opts.tcp.mptcp = config.mptcp;
-    accept_opts.udp.allow_fragmentation = config.outbound_udp_allow_fragmentation;
+    accept_opts.udp.allow_fragmentation = config.inbound_udp_allow_fragmentation;
     accept_opts.udp.mtu = config.udp_mtu;
 
     let resolver = build_dns_resolver(config.dns, config.ipv6_first, config.dns_cache_size, &connect_opts)
@@ -141,6 +141,9 @@ pub async fn run(config: Config) -> io::Result<()> {
 
         if let Some(udp_allow_fragmentation) = inst.outbound_udp_allow_fragmentation {
             connect_opts.udp.allow_fragmentation = udp_allow_fragmentation;
+        }
+
+        if let Some(udp_allow_fragmentation) = inst.inbound_udp_allow_fragmentation {
             accept_opts.udp.allow_fragmentation = udp_allow_fragmentation;
         }
 

--- a/crates/shadowsocks-service/src/server/mod.rs
+++ b/crates/shadowsocks-service/src/server/mod.rs
@@ -100,6 +100,7 @@ pub async fn run(config: Config) -> io::Result<()> {
     accept_opts.tcp.fastopen = config.fast_open;
     accept_opts.tcp.keepalive = config.keep_alive.or(Some(SERVER_DEFAULT_KEEPALIVE_TIMEOUT));
     accept_opts.tcp.mptcp = config.mptcp;
+    accept_opts.udp.allow_fragmentation = config.outbound_udp_allow_fragmentation;
     accept_opts.udp.mtu = config.udp_mtu;
 
     let resolver = build_dns_resolver(config.dns, config.ipv6_first, config.dns_cache_size, &connect_opts)
@@ -118,7 +119,7 @@ pub async fn run(config: Config) -> io::Result<()> {
         }
 
         let mut connect_opts = connect_opts.clone();
-        let accept_opts = accept_opts.clone();
+        let mut accept_opts = accept_opts.clone();
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if let Some(fwmark) = inst.outbound_fwmark {
@@ -140,6 +141,7 @@ pub async fn run(config: Config) -> io::Result<()> {
 
         if let Some(udp_allow_fragmentation) = inst.outbound_udp_allow_fragmentation {
             connect_opts.udp.allow_fragmentation = udp_allow_fragmentation;
+            accept_opts.udp.allow_fragmentation = udp_allow_fragmentation;
         }
 
         let has_outbound_proxies = !inst.outbound_proxy.is_empty() || !config.outbound_proxy.is_empty();

--- a/crates/shadowsocks/src/net/option.rs
+++ b/crates/shadowsocks/src/net/option.rs
@@ -38,7 +38,7 @@ pub struct UdpSocketOpts {
     /// NOTE: MTU includes IP header, UDP header, UDP payload
     pub mtu: Option<usize>,
 
-    /// Outbound UDP socket allows IP fragmentation
+    /// UDP socket allows IP fragmentation
     pub allow_fragmentation: bool,
 }
 

--- a/crates/shadowsocks/src/net/sys/unix/mod.rs
+++ b/crates/shadowsocks/src/net/sys/unix/mod.rs
@@ -30,7 +30,11 @@ cfg_if! {
 pub mod uds;
 
 /// Create a `UdpSocket` binded to `addr`
-pub async fn create_inbound_udp_socket(addr: &SocketAddr, ipv6_only: bool) -> io::Result<UdpSocket> {
+pub async fn create_inbound_udp_socket(
+    addr: &SocketAddr,
+    ipv6_only: bool,
+    allow_fragmentation: bool,
+) -> io::Result<UdpSocket> {
     let set_dual_stack = is_dual_stack_addr(addr);
 
     let socket = if !set_dual_stack {
@@ -48,7 +52,7 @@ pub async fn create_inbound_udp_socket(addr: &SocketAddr, ipv6_only: bool) -> io
         SocketAddr::V4(..) => AddrFamily::Ipv4,
         SocketAddr::V6(..) => AddrFamily::Ipv6,
     };
-    if let Err(err) = set_disable_ip_fragmentation(addr_family, &socket) {
+    if !allow_fragmentation && let Err(err) = set_disable_ip_fragmentation(addr_family, &socket) {
         warn!("failed to disable IP fragmentation, error: {}", err);
     }
 

--- a/crates/shadowsocks/src/net/sys/windows/mod.rs
+++ b/crates/shadowsocks/src/net/sys/windows/mod.rs
@@ -431,7 +431,11 @@ pub fn set_disable_ip_fragmentation<S: AsRawSocket>(af: AddrFamily, socket: &S) 
 /// Create a `UdpSocket` binded to `addr`
 ///
 /// It also disables `WSAECONNRESET` for UDP socket
-pub async fn create_inbound_udp_socket(addr: &SocketAddr, ipv6_only: bool) -> io::Result<UdpSocket> {
+pub async fn create_inbound_udp_socket(
+    addr: &SocketAddr,
+    ipv6_only: bool,
+    allow_fragmentation: bool,
+) -> io::Result<UdpSocket> {
     let set_dual_stack = is_dual_stack_addr(addr);
 
     let socket = if !set_dual_stack {
@@ -449,7 +453,7 @@ pub async fn create_inbound_udp_socket(addr: &SocketAddr, ipv6_only: bool) -> io
         SocketAddr::V4(..) => AddrFamily::Ipv4,
         SocketAddr::V6(..) => AddrFamily::Ipv6,
     };
-    if let Err(err) = set_disable_ip_fragmentation(addr_family, &socket) {
+    if !allow_fragmentation && let Err(err) = set_disable_ip_fragmentation(addr_family, &socket) {
         warn!("failed to disable IP fragmentation, error: {}", err);
     }
     disable_connection_reset(&socket)?;

--- a/crates/shadowsocks/src/net/udp.rs
+++ b/crates/shadowsocks/src/net/udp.rs
@@ -179,7 +179,7 @@ impl UdpSocket {
 
     /// Binds to a specific address (inbound)
     pub async fn listen_with_opts(addr: &SocketAddr, opts: AcceptOpts) -> io::Result<Self> {
-        let socket = create_inbound_udp_socket(addr, opts.ipv6_only).await?;
+        let socket = create_inbound_udp_socket(addr, opts.ipv6_only, opts.udp.allow_fragmentation).await?;
         Ok(Self {
             socket,
             mtu: opts.udp.mtu,

--- a/crates/shadowsocks/tests/udp.rs
+++ b/crates/shadowsocks/tests/udp.rs
@@ -8,9 +8,12 @@ use shadowsocks::{
     config::{ServerConfig, ServerType},
     context::{Context, SharedContext},
     crypto::CipherKind,
-    net::{AcceptOpts, UdpSocket as ShadowUdpSocket},
+    net::UdpSocket as ShadowUdpSocket,
     relay::{socks5::Address, udprelay::ProxySocket},
 };
+
+#[cfg(target_os = "linux")]
+use shadowsocks::net::AcceptOpts;
 
 #[cfg(target_os = "linux")]
 fn ipv4_mtu_discovery(socket: &ShadowUdpSocket) -> i32 {

--- a/crates/shadowsocks/tests/udp.rs
+++ b/crates/shadowsocks/tests/udp.rs
@@ -8,9 +8,44 @@ use shadowsocks::{
     config::{ServerConfig, ServerType},
     context::{Context, SharedContext},
     crypto::CipherKind,
-    net::UdpSocket as ShadowUdpSocket,
+    net::{AcceptOpts, UdpSocket as ShadowUdpSocket},
     relay::{socks5::Address, udprelay::ProxySocket},
 };
+
+#[cfg(target_os = "linux")]
+fn ipv4_mtu_discovery(socket: &ShadowUdpSocket) -> i32 {
+    use std::{mem, os::fd::AsRawFd};
+
+    let mut value = 0;
+    let mut value_len = mem::size_of_val(&value) as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_MTU_DISCOVER,
+            &mut value as *mut _ as *mut libc::c_void,
+            &mut value_len,
+        )
+    };
+    assert_eq!(result, 0);
+    value
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn inbound_udp_fragmentation_option() {
+    let addr = "127.0.0.1:0".parse().unwrap();
+
+    let socket = ShadowUdpSocket::listen_with_opts(&addr, AcceptOpts::default())
+        .await
+        .unwrap();
+    assert_eq!(ipv4_mtu_discovery(&socket), libc::IP_PMTUDISC_DO);
+
+    let mut opts = AcceptOpts::default();
+    opts.udp.allow_fragmentation = true;
+    let socket = ShadowUdpSocket::listen_with_opts(&addr, opts).await.unwrap();
+    assert_ne!(ipv4_mtu_discovery(&socket), libc::IP_PMTUDISC_DO);
+}
 
 async fn handle_udp_server_client(
     peer_addr: SocketAddr,


### PR DESCRIPTION
## Summary

- honor the existing `outbound_udp_allow_fragmentation` option on inbound UDP listener sockets
- propagate global and per-server settings, including manager mode
- preserve the current default and cover Unix and Windows
- add a Linux regression test for `IP_MTU_DISCOVER`

## Problem

The UDP relay sends encrypted responses back to clients through its inbound listener socket. That socket always enabled DF, even when `outbound_udp_allow_fragmentation` was set. A near-MTU target response can grow after encryption and then fail with `EMSGSIZE` on the client-facing send path.

This change reuses the existing option instead of adding another configuration knob, making it apply to both UDP relay directions.

## Verification

- Linux: `cargo test -p shadowsocks --test udp --no-default-features --features aead-cipher-2022` (4 passed)
- Linux: `cargo check -p shadowsocks-service --no-default-features --features server,aead-cipher-2022`
- Real relay path: a 1472-byte UDP response failed before the change and passed 10/10 after it with fragmentation enabled