### PR TITLE
fix(net): make udp batch cfgs match the bsd module routing for tvos/watchos

### DIFF
--- a/crates/shadowsocks/src/net/udp.rs
+++ b/crates/shadowsocks/src/net/udp.rs
@@ -5,6 +5,8 @@
     target_os = "android",
     target_os = "macos",
     target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
     target_os = "freebsd"
 ))]
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
@@ -20,6 +22,8 @@ use std::{
     target_os = "android",
     target_os = "macos",
     target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
     target_os = "freebsd"
 ))]
 use futures::future;
@@ -30,6 +34,8 @@ use futures::ready;
     target_os = "android",
     target_os = "macos",
     target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
     target_os = "freebsd"
 ))]
 use tokio::io::Interest;
@@ -48,6 +54,8 @@ use super::{
     target_os = "android",
     target_os = "macos",
     target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
     target_os = "freebsd"
 ))]
 pub struct BatchSendMessage<'a> {
@@ -65,6 +73,8 @@ pub struct BatchSendMessage<'a> {
     target_os = "android",
     target_os = "macos",
     target_os = "ios",
+    target_os = "watchos",
+    target_os = "tvos",
     target_os = "freebsd"
 ))]
 pub struct BatchRecvMessage<'a> {
@@ -298,6 +308,8 @@ impl UdpSocket {
         target_os = "android",
         target_os = "macos",
         target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
         target_os = "freebsd"
     ))]
     pub fn poll_batch_send(
@@ -327,6 +339,8 @@ impl UdpSocket {
         target_os = "android",
         target_os = "macos",
         target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
         target_os = "freebsd"
     ))]
     pub async fn batch_send(&self, msgs: &mut [BatchSendMessage<'_>]) -> io::Result<usize> {
@@ -339,6 +353,8 @@ impl UdpSocket {
         target_os = "android",
         target_os = "ios",
         target_os = "macos",
+        target_os = "watchos",
+        target_os = "tvos",
         target_os = "freebsd"
     ))]
     pub fn poll_batch_recv(
@@ -368,6 +384,8 @@ impl UdpSocket {
         target_os = "android",
         target_os = "macos",
         target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
         target_os = "freebsd"
     ))]
     pub async fn batch_recv(&self, msgs: &mut [BatchRecvMessage<'_>]) -> io::Result<usize> {


### PR DESCRIPTION
## Problem

`crates/shadowsocks/src/net/sys/unix/bsd/mod.rs` routes four Apple platforms to `bsd/macos.rs`:

```rust
} else if #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos", target_os = "tvos"))] {
    mod macos;
```

and `bsd/macos.rs` unconditionally imports:

```rust
use crate::net::{..., udp::{BatchRecvMessage, BatchSendMessage}};
```

But the nine cfg gates in `crates/shadowsocks/src/net/udp.rs` list only `macos` and `ios` among the Apple platforms. So on `watchos` and `tvos` the items are configured out while the module that imports them is still compiled. The crate does not build:

```
error[E0432]: unresolved imports `crate::net::udp::BatchRecvMessage`, `crate::net::udp::BatchSendMessage`
  --> crates/shadowsocks/src/net/sys/unix/bsd/macos.rs:27:11
   |
27 |     udp::{BatchRecvMessage, BatchSendMessage},
   |           ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ no `BatchSendMessage` in `net::udp`
   |
note: found an item that was configured out
  --> crates/shadowsocks/src/net/udp.rs:70:12
```

This is an internal inconsistency between two cfg lists rather than a missing feature — one half of the crate already considers tvOS and watchOS to be macOS-family BSDs.

## Fix

Add `target_os = "watchos"` and `target_os = "tvos"` to the nine gates in `net/udp.rs`, so the two lists agree. 18 added lines, nothing else.

## Does the Apple batch path actually work there?

`bsd/macos.rs` calls Apple's `recvmsg_x` / `sendmsg_x`, declared `unsafe extern "C"` — so this has to resolve at link time, not just compile. I checked rather than assumed. On an Xcode 26.5 runner, linking a TU that takes the address of both symbols:

| SDK | link | binding |
|---|---|---|
| `appletvos` (`arm64-apple-tvos17.0`) | ok | `(undefined) external _recvmsg_x (from libSystem)` |
| `appletvsimulator` (`arm64-apple-tvos17.0-simulator`) | ok | same |
| `watchos` (`arm64_32-apple-watchos10.0`) | ok | same |
| `iphoneos` (`arm64-apple-ios17.0`) | ok | same |

Both symbols are exported from `usr/lib/libSystem.B.tbd` in the AppleTVOS, AppleTVSimulator and WatchOS SDKs, same as iPhoneOS. And the existing `ENOSYS` runtime fallback to plain `recvmsg`/`sendmsg` in `batch_recvmsg`/`batch_sendmsg` already covers the case where a kernel doesn't implement them.

## Reproducing

`aarch64-apple-tvos` is a Tier 2 target with prebuilt std, so this reproduces on any host — no macOS or Xcode needed:

```
rustup target add aarch64-apple-tvos
cargo check -p shadowsocks --no-default-features --target aarch64-apple-tvos
```

(`--no-default-features` only to keep `blake3` from wanting `xcrun` for its NEON path when you're checking from Linux; on macOS you can drop it.)

Before: `error[E0432]` above. After: clean, on both `aarch64-apple-tvos` and `aarch64-apple-tvos-sim`.

No regression on existing platforms — `cargo check -p shadowsocks` and `--all-features` still pass on Linux.

`watchos` I fixed by inspection rather than by compiling: the Apple watch targets are Tier 3 with no prebuilt std, so `cargo check` can't reach them without `-Z build-std`. It's the same import from the same module through the same cfg list, and the link probe above covers the symbol question.

## Motivation

tvOS 17 made `NEPacketTunnelProvider` available, so shadowsocks-rust can be embedded in an Apple TV network extension. This is the first thing that stops it.
